### PR TITLE
feat: rename binary from f5xc to vesctl for backwards compatibility

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,9 +1,9 @@
-# GoReleaser configuration for f5xc CLI
+# GoReleaser configuration for vesctl CLI
 # Documentation: https://goreleaser.com
 
 version: 2
 
-project_name: f5xc
+project_name: vesctl
 
 before:
   hooks:
@@ -11,8 +11,8 @@ before:
     - go generate ./...
 
 builds:
-  - id: f5xc
-    binary: f5xc
+  - id: vesctl
+    binary: vesctl
     main: .
     env:
       - CGO_ENABLED=0
@@ -87,46 +87,46 @@ release:
   prerelease: auto
   mode: replace
   header: |
-    ## F5XC CLI {{ .Version }}
+    ## vesctl {{ .Version }}
 
     ### Installation
 
     **macOS (Apple Silicon)**
     ```bash
-    curl -LO https://github.com/robinmordasiewicz/vesctl/releases/download/{{ .Tag }}/f5xc_{{ .Version }}_darwin_arm64.tar.gz
-    tar -xzf f5xc_{{ .Version }}_darwin_arm64.tar.gz
-    sudo mv f5xc /usr/local/bin/
+    curl -LO https://github.com/robinmordasiewicz/vesctl/releases/download/{{ .Tag }}/vesctl_{{ .Version }}_darwin_arm64.tar.gz
+    tar -xzf vesctl_{{ .Version }}_darwin_arm64.tar.gz
+    sudo mv vesctl /usr/local/bin/
     ```
 
     **macOS (Intel)**
     ```bash
-    curl -LO https://github.com/robinmordasiewicz/vesctl/releases/download/{{ .Tag }}/f5xc_{{ .Version }}_darwin_amd64.tar.gz
-    tar -xzf f5xc_{{ .Version }}_darwin_amd64.tar.gz
-    sudo mv f5xc /usr/local/bin/
+    curl -LO https://github.com/robinmordasiewicz/vesctl/releases/download/{{ .Tag }}/vesctl_{{ .Version }}_darwin_amd64.tar.gz
+    tar -xzf vesctl_{{ .Version }}_darwin_amd64.tar.gz
+    sudo mv vesctl /usr/local/bin/
     ```
 
     **Linux (amd64)**
     ```bash
-    curl -LO https://github.com/robinmordasiewicz/vesctl/releases/download/{{ .Tag }}/f5xc_{{ .Version }}_linux_amd64.tar.gz
-    tar -xzf f5xc_{{ .Version }}_linux_amd64.tar.gz
-    sudo mv f5xc /usr/local/bin/
+    curl -LO https://github.com/robinmordasiewicz/vesctl/releases/download/{{ .Tag }}/vesctl_{{ .Version }}_linux_amd64.tar.gz
+    tar -xzf vesctl_{{ .Version }}_linux_amd64.tar.gz
+    sudo mv vesctl /usr/local/bin/
     ```
 
     **Linux (arm64)**
     ```bash
-    curl -LO https://github.com/robinmordasiewicz/vesctl/releases/download/{{ .Tag }}/f5xc_{{ .Version }}_linux_arm64.tar.gz
-    tar -xzf f5xc_{{ .Version }}_linux_arm64.tar.gz
-    sudo mv f5xc /usr/local/bin/
+    curl -LO https://github.com/robinmordasiewicz/vesctl/releases/download/{{ .Tag }}/vesctl_{{ .Version }}_linux_arm64.tar.gz
+    tar -xzf vesctl_{{ .Version }}_linux_arm64.tar.gz
+    sudo mv vesctl /usr/local/bin/
     ```
 
     **Windows**
-    Download `f5xc_{{ .Version }}_windows_amd64.zip` and extract to your PATH.
+    Download `vesctl_{{ .Version }}_windows_amd64.zip` and extract to your PATH.
   footer: |
     **Full Changelog**: https://github.com/robinmordasiewicz/vesctl/compare/{{ .PreviousTag }}...{{ .Tag }}
 
 # Homebrew tap (optional - uncomment to enable)
 # brews:
-#   - name: f5xc
+#   - name: vesctl
 #     repository:
 #       owner: robinmordasiewicz
 #       name: homebrew-tap
@@ -134,6 +134,6 @@ release:
 #     description: F5 Distributed Cloud CLI
 #     license: Apache-2.0
 #     install: |
-#       bin.install "f5xc"
+#       bin.install "vesctl"
 #     test: |
-#       system "#{bin}/f5xc", "version"
+#       system "#{bin}/vesctl", "version"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-# F5XC CLI Makefile
+# vesctl CLI Makefile
 #
 # Usage:
-#   make build        - Build the f5xc binary for current platform
+#   make build        - Build the vesctl binary for current platform
 #   make build-all    - Build binaries for all platforms (linux/darwin/windows)
 #   make test         - Run all tests
 #   make test-unit    - Run unit tests only
@@ -12,7 +12,7 @@
 #   make install      - Install binary to GOPATH/bin
 #   make release-dry  - Test GoReleaser without publishing
 
-BINARY_NAME=f5xc
+BINARY_NAME=vesctl
 MODULE=github.com/robinmordasiewicz/f5xc
 VERSION?=$(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 GIT_COMMIT?=$(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
@@ -90,16 +90,16 @@ test-unit:
 # Run integration tests only (requires environment variables)
 test-int: build
 	@echo "Running integration tests..."
-	@if [ -z "$(F5XC_API_URL)" ]; then \
-		echo "Error: F5XC_API_URL not set"; \
+	@if [ -z "$(VES_API_URL)" ]; then \
+		echo "Error: VES_API_URL not set"; \
 		echo ""; \
 		echo "Set these environment variables:"; \
-		echo "  export F5XC_API_URL=\"https://tenant.staging.volterra.us\""; \
-		echo "  export F5XC_API_P12_FILE=\"/path/to/cert.p12\""; \
-		echo "  export F5XC_P12_PASSWORD=\"password\""; \
+		echo "  export VES_API_URL=\"https://tenant.staging.volterra.us\""; \
+		echo "  export VES_API_P12_FILE=\"/path/to/cert.p12\""; \
+		echo "  export VES_P12_PASSWORD=\"password\""; \
 		exit 1; \
 	fi
-	VES_P12_PASSWORD="$(F5XC_P12_PASSWORD)" go test -v ./tests/integration/...
+	VES_P12_PASSWORD="$(VES_P12_PASSWORD)" go test -v ./tests/integration/...
 
 # Run tests with coverage
 test-coverage: build
@@ -196,7 +196,7 @@ version:
 
 # Show help
 help:
-	@echo "F5XC CLI Makefile"
+	@echo "vesctl CLI Makefile"
 	@echo ""
 	@echo "Build Commands:"
 	@echo "  make build          - Build binary for current platform"
@@ -225,9 +225,9 @@ help:
 	@echo "  make watch          - Rebuild on file changes"
 	@echo ""
 	@echo "Environment Variables (for integration tests):"
-	@echo "  F5XC_API_URL        - API URL"
-	@echo "  F5XC_API_P12_FILE   - Path to P12 certificate bundle"
-	@echo "  F5XC_P12_PASSWORD   - Password for P12 bundle"
+	@echo "  VES_API_URL        - API URL"
+	@echo "  VES_API_P12_FILE   - Path to P12 certificate bundle"
+	@echo "  VES_P12_PASSWORD   - Password for P12 bundle"
 	@echo ""
 	@echo "Creating a Release:"
 	@echo "  1. Update version: git tag v1.0.0"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,20 +40,20 @@ var (
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "f5xc",
+	Use:   "vesctl",
 	Short: "F5 Distributed Cloud CLI",
-	Long: `F5 Distributed Cloud CLI (f5xc) is a command-line tool for managing
+	Long: `F5 Distributed Cloud CLI (vesctl) is a command-line tool for managing
 F5 Distributed Cloud (formerly Volterra) resources.
 
 Getting Started:
-  f5xc login                    Log in to F5 Distributed Cloud
-  f5xc configure                Configure CLI settings
-  f5xc --help                   Show help for any command
+  vesctl login                    Log in to F5 Distributed Cloud
+  vesctl configure                Configure CLI settings
+  vesctl --help                   Show help for any command
 
 Common Commands:
-  f5xc http-loadbalancer list   List HTTP load balancers
-  f5xc origin-pool create       Create an origin pool
-  f5xc namespace show           Show namespace details
+  vesctl http-loadbalancer list   List HTTP load balancers
+  vesctl origin-pool create       Create an origin pool
+  vesctl namespace show           Show namespace details
 
 Configuration:
   Default config file: ~/.vesconfig (YAML format)
@@ -158,7 +158,7 @@ func initConfig() {
 		viper.SetConfigName(".vesconfig")
 	}
 
-	viper.SetEnvPrefix("F5XC")
+	viper.SetEnvPrefix("VES")
 	viper.AutomaticEnv()
 
 	if err := viper.ReadInConfig(); err == nil {


### PR DESCRIPTION
## Summary
- Rename binary output from `f5xc` to `vesctl` for backwards compatibility with original F5 vesctl tool
- Change environment variable prefix from `F5XC_` to `VES_`
- Update all help text and installation instructions to use `vesctl`

## Changes
- `.goreleaser.yaml`: Update project_name, binary name, and installation docs
- `Makefile`: Update BINARY_NAME and environment variable references
- `cmd/root.go`: Update CLI Use field and environment prefix

## Test plan
- [x] Build completes successfully with `make build`
- [x] Binary is named `vesctl`
- [x] Help text shows `vesctl` command examples
- [ ] Release workflow produces correctly named archives

🤖 Generated with [Claude Code](https://claude.com/claude-code)