### PR TITLE
fix: Fix CI failures - Go version, lint errors, and test issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,19 +89,19 @@ jobs:
           mkdir -p dist
 
           # Linux amd64
-          GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o dist/f5xc-linux-amd64 .
+          GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o dist/vesctl-linux-amd64 .
 
           # Linux arm64
-          GOOS=linux GOARCH=arm64 go build -ldflags="-s -w" -o dist/f5xc-linux-arm64 .
+          GOOS=linux GOARCH=arm64 go build -ldflags="-s -w" -o dist/vesctl-linux-arm64 .
 
           # macOS amd64
-          GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w" -o dist/f5xc-darwin-amd64 .
+          GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w" -o dist/vesctl-darwin-amd64 .
 
           # macOS arm64
-          GOOS=darwin GOARCH=arm64 go build -ldflags="-s -w" -o dist/f5xc-darwin-arm64 .
+          GOOS=darwin GOARCH=arm64 go build -ldflags="-s -w" -o dist/vesctl-darwin-arm64 .
 
           # Windows amd64
-          GOOS=windows GOARCH=amd64 go build -ldflags="-s -w" -o dist/f5xc-windows-amd64.exe .
+          GOOS=windows GOARCH=amd64 go build -ldflags="-s -w" -o dist/vesctl-windows-amd64.exe .
 
       - name: List built binaries
         run: ls -la dist/

--- a/cmd/api_endpoint_control.go
+++ b/cmd/api_endpoint_control.go
@@ -276,10 +276,6 @@ func buildPolicyFromFlags() *ServicePolicy {
 
 	// Client selector
 	if controlFlags.srcService != "" {
-		srcNs := controlFlags.srcNamespace
-		if srcNs == "" {
-			srcNs = controlFlags.namespace
-		}
 		rule.Spec.ClientSelector = &ClientSelector{
 			Expressions: []string{
 				fmt.Sprintf("service.metadata.name in {%q}", controlFlags.srcService),

--- a/cmd/api_endpoint_discover.go
+++ b/cmd/api_endpoint_discover.go
@@ -58,7 +58,7 @@ func init() {
 	discoverCmd.Flags().StringVar(&discoverFlags.timeRange, "time-range", "24h", "Time range for discovery (e.g., 1h, 24h, 7d)")
 	discoverCmd.Flags().BoolVar(&discoverFlags.includeSystem, "include-system", false, "Include system/internal endpoints")
 	discoverCmd.Flags().StringVar(&discoverFlags.format, "format", "", "Output format: table, json, yaml")
-	discoverCmd.MarkFlagRequired("namespace")
+	_ = discoverCmd.MarkFlagRequired("namespace")
 }
 
 // DiscoveredEndpoint represents a discovered API endpoint
@@ -155,19 +155,19 @@ func parseTimeRange(rangeStr string) time.Duration {
 
 	if strings.HasSuffix(rangeStr, "d") {
 		days := 1
-		fmt.Sscanf(rangeStr, "%dd", &days)
+		_, _ = fmt.Sscanf(rangeStr, "%dd", &days)
 		return time.Duration(days) * 24 * time.Hour
 	}
 
 	if strings.HasSuffix(rangeStr, "h") {
 		hours := 24
-		fmt.Sscanf(rangeStr, "%dh", &hours)
+		_, _ = fmt.Sscanf(rangeStr, "%dh", &hours)
 		return time.Duration(hours) * time.Hour
 	}
 
 	if strings.HasSuffix(rangeStr, "m") {
 		minutes := 60
-		fmt.Sscanf(rangeStr, "%dm", &minutes)
+		_, _ = fmt.Sscanf(rangeStr, "%dm", &minutes)
 		return time.Duration(minutes) * time.Minute
 	}
 

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -51,13 +51,13 @@ PowerShell:
 	Run: func(cmd *cobra.Command, args []string) {
 		switch args[0] {
 		case "bash":
-			cmd.Root().GenBashCompletion(os.Stdout)
+			_ = cmd.Root().GenBashCompletion(os.Stdout)
 		case "zsh":
-			cmd.Root().GenZshCompletion(os.Stdout)
+			_ = cmd.Root().GenZshCompletion(os.Stdout)
 		case "fish":
-			cmd.Root().GenFishCompletion(os.Stdout, true)
+			_ = cmd.Root().GenFishCompletion(os.Stdout, true)
 		case "powershell":
-			cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+			_ = cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
 		}
 	},
 }

--- a/cmd/configuration.go
+++ b/cmd/configuration.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -821,22 +820,3 @@ func loadConfigResource(inputFile, jsonData string) (map[string]interface{}, err
 	return resource, nil
 }
 
-// getResourceTypeByName finds a resource type by its Name (underscore format)
-func getResourceTypeByName(name string) *types.ResourceType {
-	// First try exact match
-	for _, rt := range types.All() {
-		if rt.Name == name {
-			return rt
-		}
-	}
-
-	// Try with underscores converted to match
-	normalized := strings.ReplaceAll(name, "-", "_")
-	for _, rt := range types.All() {
-		if rt.Name == normalized {
-			return rt
-		}
-	}
-
-	return nil
-}

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -107,7 +107,7 @@ func runConfigure(cmd *cobra.Command, args []string) error {
 	// Load existing config if it exists
 	config := &ConfigFile{}
 	if data, err := os.ReadFile(configPath); err == nil {
-		yaml.Unmarshal(data, config)
+		_ = yaml.Unmarshal(data, config)
 	}
 
 	// Non-interactive mode
@@ -249,7 +249,7 @@ func runConfigureSet(cmd *cobra.Command, args []string) error {
 	// Load existing config
 	config := &ConfigFile{}
 	if data, err := os.ReadFile(configPath); err == nil {
-		yaml.Unmarshal(data, config)
+		_ = yaml.Unmarshal(data, config)
 	}
 
 	// Set the value

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -79,7 +79,7 @@ func runLogin(cmd *cobra.Command, args []string) error {
 	// Load existing config
 	config := &ConfigFile{}
 	if data, err := os.ReadFile(configPath); err == nil {
-		yaml.Unmarshal(data, config)
+		_ = yaml.Unmarshal(data, config)
 	}
 
 	// Update from flags
@@ -195,7 +195,7 @@ func runLogout(cmd *cobra.Command, args []string) error {
 	// Load existing config
 	config := &ConfigFile{}
 	if data, err := os.ReadFile(configPath); err == nil {
-		yaml.Unmarshal(data, config)
+		_ = yaml.Unmarshal(data, config)
 	}
 
 	// Clear credentials but keep server URL
@@ -250,7 +250,7 @@ func runWhoami(cmd *cobra.Command, args []string) error {
 	configPath := getConfigPath()
 	config := &ConfigFile{}
 	if data, err := os.ReadFile(configPath); err == nil {
-		yaml.Unmarshal(data, config)
+		_ = yaml.Unmarshal(data, config)
 	}
 
 	userInfo := map[string]interface{}{

--- a/cmd/request_cmdseq.go
+++ b/cmd/request_cmdseq.go
@@ -66,7 +66,7 @@ func init() {
 	commandSequenceCmd.Flags().StringVarP(&cmdSeqFlags.inputFile, "input-file", "i", "", "File containing command sequence data (required)")
 	commandSequenceCmd.Flags().StringVar(&cmdSeqFlags.oldFile, "old-file", "", "File containing old command sequence data (for replace operation)")
 	commandSequenceCmd.Flags().StringVar(&cmdSeqFlags.operation, "operation", "", "Operation to perform: create, delete, replace")
-	commandSequenceCmd.MarkFlagRequired("input-file")
+	_ = commandSequenceCmd.MarkFlagRequired("input-file")
 }
 
 func runCommandSequence(cmd *cobra.Command, args []string) error {

--- a/cmd/request_secrets.go
+++ b/cmd/request_secrets.go
@@ -159,8 +159,8 @@ func init() {
 	buildBlindfoldBundleCmd.Flags().StringVar(&buildBundleFlags.namespace, "namespace", "default", "Kubernetes namespace")
 	buildBlindfoldBundleCmd.Flags().StringVar(&buildBundleFlags.dataFile, "data", "", "File containing secret data to encrypt")
 	buildBlindfoldBundleCmd.Flags().StringVar(&buildBundleFlags.outfile, "outfile", "", "Output file for the bundle")
-	buildBlindfoldBundleCmd.MarkFlagRequired("name")
-	buildBlindfoldBundleCmd.MarkFlagRequired("data")
+	_ = buildBlindfoldBundleCmd.MarkFlagRequired("name")
+	_ = buildBlindfoldBundleCmd.MarkFlagRequired("data")
 	secretsCmd.AddCommand(buildBlindfoldBundleCmd)
 }
 

--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -73,7 +73,7 @@ func buildListCommand(rt *types.ResourceType) *cobra.Command {
 
 	if rt.SupportsNamespace {
 		cmd.Flags().StringVarP(&flags.namespace, "namespace", "n", "", "Namespace (required)")
-		cmd.MarkFlagRequired("namespace")
+		_ = cmd.MarkFlagRequired("namespace")
 	}
 
 	return cmd
@@ -101,7 +101,7 @@ func buildShowCommand(rt *types.ResourceType) *cobra.Command {
 
 	if rt.SupportsNamespace {
 		cmd.Flags().StringVarP(&flags.namespace, "namespace", "n", "", "Namespace (required)")
-		cmd.MarkFlagRequired("namespace")
+		_ = cmd.MarkFlagRequired("namespace")
 	}
 
 	return cmd
@@ -126,7 +126,7 @@ func buildCreateCommand(rt *types.ResourceType) *cobra.Command {
 
 	cmd.Flags().StringVarP(&flags.file, "file", "f", "", "Path to resource definition file (YAML or JSON)")
 	cmd.Flags().StringVarP(&flags.file, "input-file", "i", "", "Path to resource definition file (vesctl compatible)")
-	cmd.MarkFlagRequired("file")
+	_ = cmd.MarkFlagRequired("file")
 
 	if rt.SupportsNamespace {
 		cmd.Flags().StringVarP(&flags.namespace, "namespace", "n", "", "Namespace (overrides file)")
@@ -155,7 +155,7 @@ func buildUpdateCommand(rt *types.ResourceType) *cobra.Command {
 
 	cmd.Flags().StringVarP(&flags.file, "file", "f", "", "Path to resource definition file (YAML or JSON)")
 	cmd.Flags().StringVarP(&flags.file, "input-file", "i", "", "Path to resource definition file (vesctl compatible)")
-	cmd.MarkFlagRequired("file")
+	_ = cmd.MarkFlagRequired("file")
 
 	if rt.SupportsNamespace {
 		cmd.Flags().StringVarP(&flags.namespace, "namespace", "n", "", "Namespace (overrides file)")
@@ -186,7 +186,7 @@ func buildDeleteCommand(rt *types.ResourceType) *cobra.Command {
 
 	if rt.SupportsNamespace {
 		cmd.Flags().StringVarP(&flags.namespace, "namespace", "n", "", "Namespace (required)")
-		cmd.MarkFlagRequired("namespace")
+		_ = cmd.MarkFlagRequired("namespace")
 	}
 
 	cmd.Flags().BoolVarP(&flags.yes, "yes", "y", false, "Skip confirmation prompt")
@@ -214,7 +214,7 @@ func buildStatusCommand(rt *types.ResourceType) *cobra.Command {
 
 	if rt.SupportsNamespace {
 		cmd.Flags().StringVarP(&flags.namespace, "namespace", "n", "", "Namespace (required)")
-		cmd.MarkFlagRequired("namespace")
+		_ = cmd.MarkFlagRequired("namespace")
 	}
 
 	return cmd
@@ -398,7 +398,7 @@ func runDelete(rt *types.ResourceType, flags *resourceFlags) error {
 	if !flags.yes {
 		fmt.Printf("Are you sure you want to delete %s '%s'? [y/N]: ", rt.CLIName, flags.name)
 		var confirm string
-		fmt.Scanln(&confirm)
+		_, _ = fmt.Scanln(&confirm)
 		if confirm != "y" && confirm != "Y" && confirm != "yes" {
 			output.PrintInfo("Deletion cancelled")
 			return nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -131,13 +131,13 @@ func init() {
 	pf.BoolVar(&noWait, "no-wait", false, "Do not wait for long-running operations to finish")
 	pf.BoolVar(&insecure, "insecure", false, "Skip TLS certificate verification (use for staging/testing)")
 
-	// Bind flags to viper
-	viper.BindPFlag("server-urls", pf.Lookup("server-urls"))
-	viper.BindPFlag("cert", pf.Lookup("cert"))
-	viper.BindPFlag("key", pf.Lookup("key"))
-	viper.BindPFlag("cacert", pf.Lookup("cacert"))
-	viper.BindPFlag("p12-bundle", pf.Lookup("p12-bundle"))
-	viper.BindPFlag("output", pf.Lookup("output"))
+	// Bind flags to viper (errors are ignored as flags are guaranteed to exist)
+	_ = viper.BindPFlag("server-urls", pf.Lookup("server-urls"))
+	_ = viper.BindPFlag("cert", pf.Lookup("cert"))
+	_ = viper.BindPFlag("key", pf.Lookup("key"))
+	_ = viper.BindPFlag("cacert", pf.Lookup("cacert"))
+	_ = viper.BindPFlag("p12-bundle", pf.Lookup("p12-bundle"))
+	_ = viper.BindPFlag("output", pf.Lookup("output"))
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/site_aws_vpc.go
+++ b/cmd/site_aws_vpc.go
@@ -133,7 +133,7 @@ func init() {
 	// Delete command
 	awsVPCDeleteCmd.Flags().StringVar(&awsVPCFlags.name, "name", "", "Site name (required)")
 	awsVPCDeleteCmd.Flags().StringVarP(&awsVPCFlags.namespace, "namespace", "n", "system", "Namespace")
-	awsVPCDeleteCmd.MarkFlagRequired("name")
+	_ = awsVPCDeleteCmd.MarkFlagRequired("name")
 	awsVPCCmd.AddCommand(awsVPCDeleteCmd)
 
 	// Replace command
@@ -145,7 +145,7 @@ func init() {
 	// Get command
 	awsVPCGetCmd.Flags().StringVar(&awsVPCFlags.name, "name", "", "Site name (required)")
 	awsVPCGetCmd.Flags().StringVarP(&awsVPCFlags.namespace, "namespace", "n", "system", "Namespace")
-	awsVPCGetCmd.MarkFlagRequired("name")
+	_ = awsVPCGetCmd.MarkFlagRequired("name")
 	awsVPCCmd.AddCommand(awsVPCGetCmd)
 
 	// Run (Terraform) command
@@ -155,7 +155,7 @@ func init() {
 	awsVPCRunCmd.Flags().StringVar(&awsVPCFlags.terraformDir, "terraform-dir", "", "Directory for Terraform files (default: temp dir)")
 	awsVPCRunCmd.Flags().BoolVar(&awsVPCFlags.autoApprove, "auto-approve", false, "Auto-approve Terraform apply/destroy")
 	awsVPCRunCmd.Flags().BoolVar(&awsVPCFlags.wait, "wait", true, "Wait for operation to complete")
-	awsVPCRunCmd.MarkFlagRequired("name")
+	_ = awsVPCRunCmd.MarkFlagRequired("name")
 	awsVPCCmd.AddCommand(awsVPCRunCmd)
 }
 

--- a/cmd/site_azure_vnet.go
+++ b/cmd/site_azure_vnet.go
@@ -135,7 +135,7 @@ func init() {
 	// Delete command
 	azureVNetDeleteCmd.Flags().StringVar(&azureVNetFlags.name, "name", "", "Site name (required)")
 	azureVNetDeleteCmd.Flags().StringVarP(&azureVNetFlags.namespace, "namespace", "n", "system", "Namespace")
-	azureVNetDeleteCmd.MarkFlagRequired("name")
+	_ = azureVNetDeleteCmd.MarkFlagRequired("name")
 	azureVNetCmd.AddCommand(azureVNetDeleteCmd)
 
 	// Replace command
@@ -147,7 +147,7 @@ func init() {
 	// Get command
 	azureVNetGetCmd.Flags().StringVar(&azureVNetFlags.name, "name", "", "Site name (required)")
 	azureVNetGetCmd.Flags().StringVarP(&azureVNetFlags.namespace, "namespace", "n", "system", "Namespace")
-	azureVNetGetCmd.MarkFlagRequired("name")
+	_ = azureVNetGetCmd.MarkFlagRequired("name")
 	azureVNetCmd.AddCommand(azureVNetGetCmd)
 
 	// Run (Terraform) command
@@ -157,7 +157,7 @@ func init() {
 	azureVNetRunCmd.Flags().StringVar(&azureVNetFlags.terraformDir, "terraform-dir", "", "Directory for Terraform files (default: temp dir)")
 	azureVNetRunCmd.Flags().BoolVar(&azureVNetFlags.autoApprove, "auto-approve", false, "Auto-approve Terraform apply/destroy")
 	azureVNetRunCmd.Flags().BoolVar(&azureVNetFlags.wait, "wait", true, "Wait for operation to complete")
-	azureVNetRunCmd.MarkFlagRequired("name")
+	_ = azureVNetRunCmd.MarkFlagRequired("name")
 	azureVNetCmd.AddCommand(azureVNetRunCmd)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/robinmordasiewicz/f5xc
 
-go 1.25.3
+go 1.22
 
 require (
 	github.com/spf13/cobra v1.8.0

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -139,7 +139,7 @@ func (c *Client) Do(ctx context.Context, req *Request) (*Response, error) {
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	// Read response body
 	respBody, err := io.ReadAll(resp.Body)

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -41,7 +41,7 @@ func TestClient_Get(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 	}))
 	defer server.Close()
 
@@ -100,7 +100,7 @@ func TestClient_Post(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"metadata": map[string]string{"name": "test-resource"},
 			"spec":     map[string]string{},
 		})
@@ -141,7 +141,7 @@ func TestClient_Put(t *testing.T) {
 		}
 
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(map[string]string{"updated": "true"})
+		_ = json.NewEncoder(w).Encode(map[string]string{"updated": "true"})
 	}))
 	defer server.Close()
 
@@ -204,7 +204,7 @@ func TestClient_Patch(t *testing.T) {
 		}
 
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(map[string]string{"patched": "true"})
+		_ = json.NewEncoder(w).Encode(map[string]string{"patched": "true"})
 	}))
 	defer server.Close()
 
@@ -240,7 +240,7 @@ func TestClient_QueryParameters(t *testing.T) {
 		}
 
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode([]string{})
+		_ = json.NewEncoder(w).Encode([]string{})
 	}))
 	defer server.Close()
 
@@ -323,7 +323,7 @@ func TestClient_ErrorResponse(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(map[string]string{
+		_ = json.NewEncoder(w).Encode(map[string]string{
 			"error":   "bad_request",
 			"message": "Invalid parameter",
 		})

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,16 +10,16 @@ import (
 // Config represents the vesctl configuration file structure
 type Config struct {
 	// ServerURLs are the API server endpoints
-	ServerURLs []string `yaml:"-"`
+	ServerURLs []string `yaml:"server-urls"`
 
 	// P12Bundle is the path to the P12 certificate bundle
-	P12Bundle string `yaml:"p12-bundle"`
+	P12Bundle string `yaml:"p12-bundle,omitempty"`
 
 	// Cert is the path to the client certificate file
-	Cert string `yaml:"cert"`
+	Cert string `yaml:"cert,omitempty"`
 
 	// Key is the path to the client key file
-	Key string `yaml:"key"`
+	Key string `yaml:"key,omitempty"`
 }
 
 // rawConfig is used for flexible YAML parsing (supports both single string and array)

--- a/pkg/output/formatter.go
+++ b/pkg/output/formatter.go
@@ -103,14 +103,14 @@ func (f *Formatter) formatTable(data interface{}) error {
 	w := tabwriter.NewWriter(f.writer, 0, 0, 2, ' ', 0)
 
 	// Print headers
-	fmt.Fprintln(w, strings.Join(headers, "\t"))
+	_, _ = fmt.Fprintln(w, strings.Join(headers, "\t"))
 
 	// Print separator
 	separators := make([]string, len(headers))
 	for i, h := range headers {
 		separators[i] = strings.Repeat("-", len(h))
 	}
-	fmt.Fprintln(w, strings.Join(separators, "\t"))
+	_, _ = fmt.Fprintln(w, strings.Join(separators, "\t"))
 
 	// Print rows
 	for _, row := range rows {
@@ -120,7 +120,7 @@ func (f *Formatter) formatTable(data interface{}) error {
 				values[i] = formatValue(v)
 			}
 		}
-		fmt.Fprintln(w, strings.Join(values, "\t"))
+		_, _ = fmt.Fprintln(w, strings.Join(values, "\t"))
 	}
 
 	return w.Flush()
@@ -140,7 +140,7 @@ func (f *Formatter) formatTSV(data interface{}) error {
 				values[i] = formatValue(v)
 			}
 		}
-		fmt.Fprintln(f.writer, strings.Join(values, "\t"))
+		_, _ = fmt.Fprintln(f.writer, strings.Join(values, "\t"))
 	}
 
 	return nil

--- a/tests/integration/auth_test.go
+++ b/tests/integration/auth_test.go
@@ -26,8 +26,8 @@ func TestAuthentication_P12Bundle(t *testing.T) {
 	}
 
 	// Set password env var for client
-	os.Setenv("VES_P12_PASSWORD", p12Password)
-	defer os.Unsetenv("VES_P12_PASSWORD")
+	_ = os.Setenv("VES_P12_PASSWORD", p12Password)
+	defer func() { _ = os.Unsetenv("VES_P12_PASSWORD") }()
 
 	cfg := &client.Config{
 		ServerURLs:         []string{apiURL},
@@ -80,8 +80,8 @@ func TestAuthentication_Whoami(t *testing.T) {
 		t.Skipf("P12 file not found at %s", p12File)
 	}
 
-	os.Setenv("VES_P12_PASSWORD", p12Password)
-	defer os.Unsetenv("VES_P12_PASSWORD")
+	_ = os.Setenv("VES_P12_PASSWORD", p12Password)
+	defer func() { _ = os.Unsetenv("VES_P12_PASSWORD") }()
 
 	cfg := &client.Config{
 		ServerURLs:         []string{apiURL},
@@ -132,13 +132,13 @@ func TestAuthentication_InvalidP12(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
-	defer os.Remove(tmpFile.Name())
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
 
-	tmpFile.Write([]byte("not a valid p12 bundle"))
-	tmpFile.Close()
+	_, _ = tmpFile.Write([]byte("not a valid p12 bundle"))
+	_ = tmpFile.Close()
 
-	os.Setenv("VES_P12_PASSWORD", "dummy")
-	defer os.Unsetenv("VES_P12_PASSWORD")
+	_ = os.Setenv("VES_P12_PASSWORD", "dummy")
+	defer func() { _ = os.Unsetenv("VES_P12_PASSWORD") }()
 
 	cfg := &client.Config{
 		ServerURLs:         []string{apiURL},
@@ -167,8 +167,8 @@ func TestAuthentication_WrongPassword(t *testing.T) {
 	}
 
 	// Set wrong password
-	os.Setenv("VES_P12_PASSWORD", "wrong-password-12345")
-	defer os.Unsetenv("VES_P12_PASSWORD")
+	_ = os.Setenv("VES_P12_PASSWORD", "wrong-password-12345")
+	defer func() { _ = os.Unsetenv("VES_P12_PASSWORD") }()
 
 	cfg := &client.Config{
 		ServerURLs:         []string{apiURL},
@@ -198,7 +198,7 @@ func TestAuthentication_MissingPassword(t *testing.T) {
 	}
 
 	// Ensure password is not set
-	os.Unsetenv("VES_P12_PASSWORD")
+	_ = os.Unsetenv("VES_P12_PASSWORD")
 
 	cfg := &client.Config{
 		ServerURLs:         []string{apiURL},

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -136,7 +136,7 @@ func TestCLI_ConfigureShow(t *testing.T) {
 	cmd.Stderr = &stderr
 
 	// This may fail if no config exists, which is OK
-	cmd.Run()
+	_ = cmd.Run()
 
 	// Just verify it runs without crashing
 	t.Log("Configure show executed")

--- a/tests/integration/namespace_test.go
+++ b/tests/integration/namespace_test.go
@@ -24,7 +24,7 @@ func getTestClient(t *testing.T) *client.Client {
 		t.Skipf("P12 file not found at %s", p12File)
 	}
 
-	os.Setenv("VES_P12_PASSWORD", p12Password)
+	_ = os.Setenv("VES_P12_PASSWORD", p12Password)
 
 	cfg := &client.Config{
 		ServerURLs:         []string{apiURL},

--- a/tests/testutil/helpers.go
+++ b/tests/testutil/helpers.go
@@ -53,26 +53,26 @@ func SetupTestEnv(cfg *TestConfig) func() {
 	origPass := os.Getenv("VES_P12_PASSWORD")
 
 	// Set test values
-	os.Setenv("F5XC_API_URL", cfg.APIURL)
-	os.Setenv("F5XC_API_P12_FILE", cfg.P12File)
-	os.Setenv("VES_P12_PASSWORD", cfg.P12Password)
+	_ = os.Setenv("F5XC_API_URL", cfg.APIURL)
+	_ = os.Setenv("F5XC_API_P12_FILE", cfg.P12File)
+	_ = os.Setenv("VES_P12_PASSWORD", cfg.P12Password)
 
 	// Return cleanup function
 	return func() {
 		if origURL != "" {
-			os.Setenv("F5XC_API_URL", origURL)
+			_ = os.Setenv("F5XC_API_URL", origURL)
 		} else {
-			os.Unsetenv("F5XC_API_URL")
+			_ = os.Unsetenv("F5XC_API_URL")
 		}
 		if origP12 != "" {
-			os.Setenv("F5XC_API_P12_FILE", origP12)
+			_ = os.Setenv("F5XC_API_P12_FILE", origP12)
 		} else {
-			os.Unsetenv("F5XC_API_P12_FILE")
+			_ = os.Unsetenv("F5XC_API_P12_FILE")
 		}
 		if origPass != "" {
-			os.Setenv("VES_P12_PASSWORD", origPass)
+			_ = os.Setenv("VES_P12_PASSWORD", origPass)
 		} else {
-			os.Unsetenv("VES_P12_PASSWORD")
+			_ = os.Unsetenv("VES_P12_PASSWORD")
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Fix go.mod: Changed from non-existent Go 1.25.3 to Go 1.22
- Fix TestConfig_Save: Changed ServerURLs yaml tag from "-" to "server-urls" to enable serialization
- Fix CI workflow: Updated binary paths from f5xc to vesctl
- Fix 46+ lint errors (errcheck, ineffassign, unused):
  - Added error return value handling for MarkFlagRequired calls
  - Added error return value handling for yaml.Unmarshal calls
  - Added error return value handling for fmt.Fprintln/fmt.Scanln calls
  - Added error return value handling for os.Setenv/os.Unsetenv calls
  - Added error return value handling for json.NewEncoder().Encode calls
  - Added error return value handling for file operations in deferred calls
  - Removed unused srcNs variable in api_endpoint_control.go
  - Removed unused getResourceTypeByName function in configuration.go
  - Removed unused strings import in configuration.go

## Test plan
- [x] All tests pass locally with `go test ./...`
- [x] All lint checks pass with `golangci-lint run ./...`
- [ ] CI workflow should pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)