### PR TITLE
fix: Match original vesctl table output format and default

### DIFF
--- a/claudedocs/compatibility/README.md
+++ b/claudedocs/compatibility/README.md
@@ -4,47 +4,107 @@ This directory contains the compatibility testing framework for comparing our ve
 
 ## Original Binary
 
-The original proprietary vesctl binary is stored locally for comparison testing:
-- **Location**: `./vesctl-0.2.47-original` (in project root)
-- **Version**: 0.2.47
-- **Source**: https://vesio.azureedge.net/releases/vesctl/0.2.47/vesctl.darwin-arm64.gz
+The original proprietary vesctl binary is stored locally for comparison testing.
 
-> **Note**: This file is gitignored (`vesctl*` pattern) and must be downloaded for testing.
+### IMPORTANT: Known Bug in Original vesctl
 
-### Download Original Binary
+**Versions 0.2.36 and later have a critical TLS bug** that causes crashes with the following error:
+
+```
+panic: runtime error: invalid memory address or nil pointer dereference
+[signal SIGSEGV: segmentation violation]
+...
+crypto/tls.(*CertificateRequestInfo).SupportsCertificate(0x0, 0x1400010e040)
+```
+
+This bug affects ALL platforms (macOS arm64, macOS amd64, Linux amd64) and occurs during any authenticated API operation.
+
+### Working Version for Testing
+
+**Use version 0.2.35 on Linux amd64** for compatibility testing:
+- **Version**: 0.2.35 (last working version)
+- **Platform**: Linux amd64 only
+- **Source**: https://vesio.azureedge.net/releases/vesctl/0.2.35/vesctl.linux-amd64.gz
+
+> **Note**: There is NO working macOS arm64 version of the original vesctl. All compatibility testing with authenticated API operations must be performed on a Linux amd64 host.
+
+### Download Original Binary (Linux amd64)
 
 ```bash
-# Using the provided script
-./claudedocs/compatibility/scripts/download-original.sh
+# Download working version 0.2.35 for Linux amd64
+curl -sL https://vesio.azureedge.net/releases/vesctl/0.2.35/vesctl.linux-amd64.gz | gunzip > vesctl-0.2.35
+chmod +x vesctl-0.2.35
 
-# Or manually
+# Verify it works
+./vesctl-0.2.35 version
+
+# Create symlink for test scripts
+ln -sf vesctl-0.2.35 vesctl-original
+```
+
+### Version Compatibility Matrix
+
+| Version | Status | Issue |
+|---------|--------|-------|
+| 0.2.35 | **WORKS** | Last working version |
+| 0.2.36+ | BROKEN | TLS CertManager nil pointer crash |
+| 0.2.47 | BROKEN | Same TLS bug as 0.2.36 |
+
+### Legacy Download (Non-functional for API tests)
+
+For non-authenticated tests only (help, completion, etc.):
+
+```bash
+# macOS arm64 (0.2.47 - has TLS bug, only for offline tests)
 curl -L https://vesio.azureedge.net/releases/vesctl/0.2.47/vesctl.darwin-arm64.gz -o /tmp/vesctl.gz
 gunzip /tmp/vesctl.gz
 chmod +x /tmp/vesctl
 mv /tmp/vesctl ./vesctl-0.2.47-original
-
-# Verify
-./vesctl-0.2.47-original version
 ```
 
 ## Running Tests
 
 ### Prerequisites
 
-1. Original binary downloaded: `./vesctl-0.2.47-original`
-2. Our binary built: `go build -o vesctl.darwin-arm64 .`
+**For authenticated API tests (Phase 3+):**
+1. Linux amd64 host (e.g., Ubuntu VM)
+2. Original binary: `vesctl-0.2.35` (download from link above)
+3. Our binary: `GOOS=linux GOARCH=amd64 go build -o vesctl-linux-amd64 .`
 
-### Quick Start
+**For offline tests (Phase 1-2):**
+1. Original binary: Any version (e.g., `./vesctl-0.2.47-original`)
+2. Our binary: `go build -o vesctl .`
+
+### Quick Start (Linux amd64)
+
+```bash
+# On your Linux test host
+cd ~/GIT/robinmordasiewicz/vesctl
+
+# Set environment variables
+export ORIGINAL_VESCTL=./vesctl-0.2.35
+export OUR_VESCTL=./vesctl-linux-amd64
+
+# Create convenience symlinks
+ln -sf vesctl-0.2.35 vesctl-original
+ln -sf vesctl-linux-amd64 vesctl-ours
+
+# Run namespace list comparison
+./vesctl-original configuration list namespace
+./vesctl-ours configuration list namespace
+```
+
+### Quick Start (Local macOS - offline tests only)
 
 ```bash
 # Set environment variables (use local paths)
 export ORIGINAL_VESCTL=./vesctl-0.2.47-original
 export OUR_VESCTL=./vesctl.darwin-arm64
 
-# Run all behavioral tests
+# Run all behavioral tests (no API calls)
 ./claudedocs/compatibility/tests/phase1-configure/test-behavior.sh
 
-# Run version/completion tests
+# Run version/completion tests (no API calls)
 ./claudedocs/compatibility/tests/phase2-simple/test-simple.sh
 ```
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -196,7 +196,7 @@ func GetOutputFormat() string {
 	if outfmt != "" {
 		return outfmt
 	}
-	return "yaml"
+	return "table" // Default to table for compatibility with original vesctl
 }
 
 // GetOutputDir returns the output directory


### PR DESCRIPTION
## Summary
- Refactor table formatter to use ASCII box format with `+`, `-`, `|` matching original vesctl
- Change default output format from yaml to table for compatibility
- Document vesctl 0.2.36+ TLS bug requiring v0.2.35 for testing

## Verification
Tested on linux-vm against original vesctl 0.2.35:
- **TABLE format**: byte-for-byte identical
- **JSON format**: semantically identical (field order differs due to Go's map iteration)
- **YAML format**: semantically identical (minor indent style difference)

## Test plan
- [x] Build and deploy to linux-vm
- [x] Compare table output with diff (IDENTICAL)
- [x] Compare JSON with `jq -S` normalization (IDENTICAL)
- [x] Compare YAML with Python yaml parser (IDENTICAL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)