### PR TITLE
fix: Use VES_ prefix for environment variables and fix test expectations

### DIFF
--- a/pkg/output/formatter_test.go
+++ b/pkg/output/formatter_test.go
@@ -44,15 +44,15 @@ func TestNew_NoneFormat(t *testing.T) {
 
 func TestNew_EmptyDefault(t *testing.T) {
 	f := New("")
-	if f.format != FormatYAML {
-		t.Errorf("Expected YAML format as default, got %v", f.format)
+	if f.format != FormatTable {
+		t.Errorf("Expected Table format as default (matching original vesctl), got %v", f.format)
 	}
 }
 
 func TestNew_InvalidDefault(t *testing.T) {
 	f := New("invalid")
-	if f.format != FormatYAML {
-		t.Errorf("Expected YAML format for invalid input, got %v", f.format)
+	if f.format != FormatTable {
+		t.Errorf("Expected Table format for invalid input (matching original vesctl), got %v", f.format)
 	}
 }
 
@@ -152,8 +152,9 @@ func TestFormatter_FormatTable(t *testing.T) {
 	}
 
 	output := buf.String()
-	if !strings.Contains(output, "name") {
-		t.Errorf("Expected table header 'name', got: %s", output)
+	// Table format uses box-style headers: NAMESPACE | NAME | LABELS
+	if !strings.Contains(output, "NAME") {
+		t.Errorf("Expected table header 'NAME', got: %s", output)
 	}
 	if !strings.Contains(output, "resource1") {
 		t.Errorf("Expected row 'resource1', got: %s", output)

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -10,9 +10,9 @@
 #   ./scripts/test.sh -v           # Run with verbose output
 #
 # Environment Variables (required for integration tests):
-#   F5XC_API_URL      - API URL (e.g., https://tenant.staging.volterra.us)
-#   F5XC_API_P12_FILE - Path to P12 certificate bundle
-#   F5XC_P12_PASSWORD - Password for P12 bundle
+#   VES_API_URL      - API URL (e.g., https://tenant.staging.volterra.us)
+#   VES_API_P12_FILE - Path to P12 certificate bundle
+#   VES_P12_PASSWORD - Password for P12 bundle
 
 set -e
 
@@ -61,9 +61,9 @@ while [[ $# -gt 0 ]]; do
             echo "  --coverage    Generate coverage report"
             echo ""
             echo "Environment Variables (for integration tests):"
-            echo "  F5XC_API_URL      API URL"
-            echo "  F5XC_API_P12_FILE Path to P12 certificate bundle"
-            echo "  F5XC_P12_PASSWORD Password for P12 bundle"
+            echo "  VES_API_URL      API URL"
+            echo "  VES_API_P12_FILE Path to P12 certificate bundle"
+            echo "  VES_P12_PASSWORD Password for P12 bundle"
             exit 0
             ;;
         *)
@@ -73,7 +73,7 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-echo -e "${GREEN}F5XC CLI Test Runner${NC}"
+echo -e "${GREEN}vesctl CLI Test Runner${NC}"
 echo "================================"
 
 # Build the binary first
@@ -83,20 +83,20 @@ echo -e "${GREEN}✓ Build successful${NC}"
 
 # Check if integration test environment is configured
 check_integration_env() {
-    if [[ -z "$F5XC_API_URL" ]]; then
-        echo -e "${YELLOW}Warning: F5XC_API_URL not set${NC}"
+    if [[ -z "$VES_API_URL" ]]; then
+        echo -e "${YELLOW}Warning: VES_API_URL not set${NC}"
         return 1
     fi
-    if [[ -z "$F5XC_API_P12_FILE" ]]; then
-        echo -e "${YELLOW}Warning: F5XC_API_P12_FILE not set${NC}"
+    if [[ -z "$VES_API_P12_FILE" ]]; then
+        echo -e "${YELLOW}Warning: VES_API_P12_FILE not set${NC}"
         return 1
     fi
-    if [[ -z "$F5XC_P12_PASSWORD" ]]; then
-        echo -e "${YELLOW}Warning: F5XC_P12_PASSWORD not set${NC}"
+    if [[ -z "$VES_P12_PASSWORD" ]]; then
+        echo -e "${YELLOW}Warning: VES_P12_PASSWORD not set${NC}"
         return 1
     fi
-    if [[ ! -f "$F5XC_API_P12_FILE" ]]; then
-        echo -e "${YELLOW}Warning: P12 file not found at $F5XC_API_P12_FILE${NC}"
+    if [[ ! -f "$VES_API_P12_FILE" ]]; then
+        echo -e "${YELLOW}Warning: P12 file not found at $VES_API_P12_FILE${NC}"
         return 1
     fi
     return 0
@@ -107,10 +107,7 @@ run_unit_tests() {
     echo -e "\n${YELLOW}Running unit tests...${NC}"
     echo "--------------------------------"
 
-    # Set VES_P12_PASSWORD for tests if available
-    if [[ -n "$F5XC_P12_PASSWORD" ]]; then
-        export VES_P12_PASSWORD="$F5XC_P12_PASSWORD"
-    fi
+    # VES_P12_PASSWORD should already be set in environment
 
     go test $VERBOSE $COVERAGE ./pkg/... 2>&1 | while IFS= read -r line; do
         if [[ $line == *"PASS"* ]]; then
@@ -142,17 +139,14 @@ run_integration_tests() {
         echo -e "${YELLOW}Skipping integration tests - environment not configured${NC}"
         echo ""
         echo "To run integration tests, set these environment variables:"
-        echo "  export F5XC_API_URL=\"https://your-tenant.staging.volterra.us\""
-        echo "  export F5XC_API_P12_FILE=\"/path/to/cert.p12\""
-        echo "  export F5XC_P12_PASSWORD=\"your-password\""
+        echo "  export VES_API_URL=\"https://your-tenant.staging.volterra.us\""
+        echo "  export VES_API_P12_FILE=\"/path/to/cert.p12\""
+        echo "  export VES_P12_PASSWORD=\"your-password\""
         return 0
     fi
 
-    echo -e "Using API URL: ${GREEN}$F5XC_API_URL${NC}"
-    echo -e "Using P12 file: ${GREEN}$F5XC_API_P12_FILE${NC}"
-
-    # Set VES_P12_PASSWORD for the client
-    export VES_P12_PASSWORD="$F5XC_P12_PASSWORD"
+    echo -e "Using API URL: ${GREEN}$VES_API_URL${NC}"
+    echo -e "Using P12 file: ${GREEN}$VES_API_P12_FILE${NC}"
 
     go test $VERBOSE ./tests/integration/... 2>&1 | while IFS= read -r line; do
         if [[ $line == *"PASS"* ]]; then

--- a/tests/integration/auth_test.go
+++ b/tests/integration/auth_test.go
@@ -12,12 +12,12 @@ import (
 
 // TestAuthentication_P12Bundle tests authentication using P12 bundle
 func TestAuthentication_P12Bundle(t *testing.T) {
-	apiURL := os.Getenv("F5XC_API_URL")
-	p12File := os.Getenv("F5XC_API_P12_FILE")
-	p12Password := os.Getenv("F5XC_P12_PASSWORD")
+	apiURL := os.Getenv("VES_API_URL")
+	p12File := os.Getenv("VES_API_P12_FILE")
+	p12Password := os.Getenv("VES_P12_PASSWORD")
 
 	if apiURL == "" || p12File == "" || p12Password == "" {
-		t.Skip("Integration test environment not configured (F5XC_API_URL, F5XC_API_P12_FILE, F5XC_P12_PASSWORD)")
+		t.Skip("Integration test environment not configured (VES_API_URL, VES_API_P12_FILE, VES_P12_PASSWORD)")
 	}
 
 	// Verify P12 file exists
@@ -68,9 +68,9 @@ func TestAuthentication_P12Bundle(t *testing.T) {
 
 // TestAuthentication_Whoami tests the whoami endpoint
 func TestAuthentication_Whoami(t *testing.T) {
-	apiURL := os.Getenv("F5XC_API_URL")
-	p12File := os.Getenv("F5XC_API_P12_FILE")
-	p12Password := os.Getenv("F5XC_P12_PASSWORD")
+	apiURL := os.Getenv("VES_API_URL")
+	p12File := os.Getenv("VES_API_P12_FILE")
+	p12Password := os.Getenv("VES_P12_PASSWORD")
 
 	if apiURL == "" || p12File == "" || p12Password == "" {
 		t.Skip("Integration test environment not configured")
@@ -122,9 +122,9 @@ func TestAuthentication_Whoami(t *testing.T) {
 
 // TestAuthentication_InvalidP12 tests that invalid P12 fails appropriately
 func TestAuthentication_InvalidP12(t *testing.T) {
-	apiURL := os.Getenv("F5XC_API_URL")
+	apiURL := os.Getenv("VES_API_URL")
 	if apiURL == "" {
-		t.Skip("F5XC_API_URL not set")
+		t.Skip("VES_API_URL not set")
 	}
 
 	// Create a temporary invalid P12 file
@@ -155,8 +155,8 @@ func TestAuthentication_InvalidP12(t *testing.T) {
 
 // TestAuthentication_WrongPassword tests that wrong P12 password fails
 func TestAuthentication_WrongPassword(t *testing.T) {
-	apiURL := os.Getenv("F5XC_API_URL")
-	p12File := os.Getenv("F5XC_API_P12_FILE")
+	apiURL := os.Getenv("VES_API_URL")
+	p12File := os.Getenv("VES_API_P12_FILE")
 
 	if apiURL == "" || p12File == "" {
 		t.Skip("Integration test environment not configured")
@@ -186,8 +186,8 @@ func TestAuthentication_WrongPassword(t *testing.T) {
 
 // TestAuthentication_MissingPassword tests that missing P12 password fails
 func TestAuthentication_MissingPassword(t *testing.T) {
-	apiURL := os.Getenv("F5XC_API_URL")
-	p12File := os.Getenv("F5XC_API_P12_FILE")
+	apiURL := os.Getenv("VES_API_URL")
+	p12File := os.Getenv("VES_API_P12_FILE")
 
 	if apiURL == "" || p12File == "" {
 		t.Skip("Integration test environment not configured")

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -146,9 +146,9 @@ func TestCLI_ConfigureShow(t *testing.T) {
 func TestCLI_ListNamespaces(t *testing.T) {
 	binary := getBinaryPath(t)
 
-	apiURL := os.Getenv("F5XC_API_URL")
-	p12File := os.Getenv("F5XC_API_P12_FILE")
-	p12Password := os.Getenv("F5XC_P12_PASSWORD")
+	apiURL := os.Getenv("VES_API_URL")
+	p12File := os.Getenv("VES_API_P12_FILE")
+	p12Password := os.Getenv("VES_P12_PASSWORD")
 
 	if apiURL == "" || p12File == "" || p12Password == "" {
 		t.Skip("Integration test environment not configured")
@@ -175,9 +175,9 @@ func TestCLI_ListNamespaces(t *testing.T) {
 func TestCLI_HTTPLoadBalancerList(t *testing.T) {
 	binary := getBinaryPath(t)
 
-	apiURL := os.Getenv("F5XC_API_URL")
-	p12File := os.Getenv("F5XC_API_P12_FILE")
-	p12Password := os.Getenv("F5XC_P12_PASSWORD")
+	apiURL := os.Getenv("VES_API_URL")
+	p12File := os.Getenv("VES_API_P12_FILE")
+	p12Password := os.Getenv("VES_P12_PASSWORD")
 
 	if apiURL == "" || p12File == "" || p12Password == "" {
 		t.Skip("Integration test environment not configured")
@@ -202,9 +202,9 @@ func TestCLI_HTTPLoadBalancerList(t *testing.T) {
 func TestCLI_OutputFormatJSON(t *testing.T) {
 	binary := getBinaryPath(t)
 
-	apiURL := os.Getenv("F5XC_API_URL")
-	p12File := os.Getenv("F5XC_API_P12_FILE")
-	p12Password := os.Getenv("F5XC_P12_PASSWORD")
+	apiURL := os.Getenv("VES_API_URL")
+	p12File := os.Getenv("VES_API_P12_FILE")
+	p12Password := os.Getenv("VES_P12_PASSWORD")
 
 	if apiURL == "" || p12File == "" || p12Password == "" {
 		t.Skip("Integration test environment not configured")
@@ -236,9 +236,9 @@ func TestCLI_OutputFormatJSON(t *testing.T) {
 func TestCLI_OutputFormatTable(t *testing.T) {
 	binary := getBinaryPath(t)
 
-	apiURL := os.Getenv("F5XC_API_URL")
-	p12File := os.Getenv("F5XC_API_P12_FILE")
-	p12Password := os.Getenv("F5XC_P12_PASSWORD")
+	apiURL := os.Getenv("VES_API_URL")
+	p12File := os.Getenv("VES_API_P12_FILE")
+	p12Password := os.Getenv("VES_P12_PASSWORD")
 
 	if apiURL == "" || p12File == "" || p12Password == "" {
 		t.Skip("Integration test environment not configured")

--- a/tests/integration/namespace_test.go
+++ b/tests/integration/namespace_test.go
@@ -12,12 +12,12 @@ import (
 
 // getTestClient creates a client for integration tests
 func getTestClient(t *testing.T) *client.Client {
-	apiURL := os.Getenv("F5XC_API_URL")
-	p12File := os.Getenv("F5XC_API_P12_FILE")
-	p12Password := os.Getenv("F5XC_P12_PASSWORD")
+	apiURL := os.Getenv("VES_API_URL")
+	p12File := os.Getenv("VES_API_P12_FILE")
+	p12Password := os.Getenv("VES_P12_PASSWORD")
 
 	if apiURL == "" || p12File == "" || p12Password == "" {
-		t.Skip("Integration test environment not configured (F5XC_API_URL, F5XC_API_P12_FILE, F5XC_P12_PASSWORD)")
+		t.Skip("Integration test environment not configured (VES_API_URL, VES_API_P12_FILE, VES_P12_PASSWORD)")
 	}
 
 	if _, err := os.Stat(p12File); os.IsNotExist(err) {

--- a/tests/testutil/helpers.go
+++ b/tests/testutil/helpers.go
@@ -15,9 +15,9 @@ type TestConfig struct {
 // LoadTestConfig loads test configuration from environment variables
 func LoadTestConfig(t *testing.T) *TestConfig {
 	cfg := &TestConfig{
-		APIURL:      os.Getenv("F5XC_API_URL"),
-		P12File:     os.Getenv("F5XC_API_P12_FILE"),
-		P12Password: os.Getenv("F5XC_P12_PASSWORD"),
+		APIURL:      os.Getenv("VES_API_URL"),
+		P12File:     os.Getenv("VES_API_P12_FILE"),
+		P12Password: os.Getenv("VES_P12_PASSWORD"),
 	}
 
 	return cfg
@@ -28,13 +28,13 @@ func RequireIntegrationEnv(t *testing.T) *TestConfig {
 	cfg := LoadTestConfig(t)
 
 	if cfg.APIURL == "" {
-		t.Skip("F5XC_API_URL not set, skipping integration test")
+		t.Skip("VES_API_URL not set, skipping integration test")
 	}
 	if cfg.P12File == "" {
-		t.Skip("F5XC_API_P12_FILE not set, skipping integration test")
+		t.Skip("VES_API_P12_FILE not set, skipping integration test")
 	}
 	if cfg.P12Password == "" {
-		t.Skip("F5XC_P12_PASSWORD not set, skipping integration test")
+		t.Skip("VES_P12_PASSWORD not set, skipping integration test")
 	}
 
 	// Verify P12 file exists
@@ -48,26 +48,26 @@ func RequireIntegrationEnv(t *testing.T) *TestConfig {
 // SetupTestEnv sets up environment for integration tests
 func SetupTestEnv(cfg *TestConfig) func() {
 	// Store original values
-	origURL := os.Getenv("F5XC_API_URL")
-	origP12 := os.Getenv("F5XC_API_P12_FILE")
+	origURL := os.Getenv("VES_API_URL")
+	origP12 := os.Getenv("VES_API_P12_FILE")
 	origPass := os.Getenv("VES_P12_PASSWORD")
 
 	// Set test values
-	_ = os.Setenv("F5XC_API_URL", cfg.APIURL)
-	_ = os.Setenv("F5XC_API_P12_FILE", cfg.P12File)
+	_ = os.Setenv("VES_API_URL", cfg.APIURL)
+	_ = os.Setenv("VES_API_P12_FILE", cfg.P12File)
 	_ = os.Setenv("VES_P12_PASSWORD", cfg.P12Password)
 
 	// Return cleanup function
 	return func() {
 		if origURL != "" {
-			_ = os.Setenv("F5XC_API_URL", origURL)
+			_ = os.Setenv("VES_API_URL", origURL)
 		} else {
-			_ = os.Unsetenv("F5XC_API_URL")
+			_ = os.Unsetenv("VES_API_URL")
 		}
 		if origP12 != "" {
-			_ = os.Setenv("F5XC_API_P12_FILE", origP12)
+			_ = os.Setenv("VES_API_P12_FILE", origP12)
 		} else {
-			_ = os.Unsetenv("F5XC_API_P12_FILE")
+			_ = os.Unsetenv("VES_API_P12_FILE")
 		}
 		if origPass != "" {
 			_ = os.Setenv("VES_P12_PASSWORD", origPass)


### PR DESCRIPTION
## Summary
- Changed integration test environment variables from `F5XC_` to `VES_` prefix to match the original vesctl CLI convention
- Updated formatter tests to expect Table format as default (matching original vesctl behavior)
- Updated test.sh script to use VES_ environment variable prefix

## Environment Variables Changed
| Old Name | New Name |
|----------|----------|
| F5XC_API_URL | VES_API_URL |
| F5XC_API_P12_FILE | VES_API_P12_FILE |
| F5XC_P12_PASSWORD | VES_P12_PASSWORD (unchanged) |

## Test plan
- [x] Unit tests pass
- [x] Namespace integration tests pass with VES_ environment variables
- [x] Verified original vesctl uses table format as default output

🤖 Generated with [Claude Code](https://claude.com/claude-code)