### PR TITLE
feat: Add MkDocs documentation with GitHub Pages deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,110 @@
+name: Documentation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'scripts/generate-docs.sh'
+      - 'cmd/**'
+      - 'README.md'
+      - 'install.sh'
+      - '.github/workflows/docs.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'scripts/generate-docs.sh'
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+env:
+  GO_VERSION: '1.23'
+  PYTHON_VERSION: '3.11'
+
+jobs:
+  generate:
+    name: Generate Command Docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Build vesctl
+        run: go build -o vesctl .
+
+      - name: Generate command documentation
+        run: |
+          chmod +x scripts/generate-docs.sh
+          ./scripts/generate-docs.sh
+
+      - name: Upload generated docs
+        uses: actions/upload-artifact@v4
+        with:
+          name: generated-docs
+          path: docs/
+          retention-days: 1
+
+  build:
+    name: Build Documentation
+    runs-on: ubuntu-latest
+    needs: generate
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download generated docs
+        uses: actions/download-artifact@v4
+        with:
+          name: generated-docs
+          path: docs/
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install dependencies
+        run: pip install -r requirements-docs.txt
+
+      - name: Build site
+        run: mkdocs build --strict
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
+
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'release'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/commands/api-endpoint.md
+++ b/docs/commands/api-endpoint.md
@@ -1,0 +1,47 @@
+# API Endpoint Commands
+
+The `vesctl api-endpoint` command group manages API endpoint discovery.
+
+## Overview
+
+```text
+vesctl api-endpoint --help
+```
+
+## Description
+
+API endpoint commands help discover and manage API endpoints in your F5 XC tenant. This is useful for API security and management features.
+
+## Common Operations
+
+### List Discovered Endpoints
+
+```bash
+vesctl api-endpoint list -n <namespace>
+```
+
+### Get Endpoint Details
+
+```bash
+vesctl api-endpoint get <endpoint-name> -n <namespace>
+```
+
+## Related Resources
+
+API endpoint discovery works with:
+
+- HTTP Load Balancers
+- API Definitions
+- Service Policies
+
+## Configuration via Resources
+
+For full API definition management, use configuration commands:
+
+```bash
+# List API definitions
+vesctl configuration list api_definition -n my-namespace
+
+# Create API definition
+vesctl configuration create api_definition -i api-def.yaml
+```

--- a/docs/commands/configuration.md
+++ b/docs/commands/configuration.md
@@ -1,0 +1,113 @@
+# Configuration Commands
+
+The `vesctl configuration` command group manages F5 Distributed Cloud resources.
+
+## Overview
+
+```text
+vesctl configuration --help
+```
+
+!!! note "Auto-generated"
+    This page is automatically updated when the documentation is built.
+    The content below shows the command help output.
+
+## Subcommands
+
+### List Resources
+
+List all resources of a specific type:
+
+```bash
+vesctl configuration list <resource-type> [flags]
+```
+
+**Examples:**
+
+```bash
+# List all namespaces
+vesctl configuration list namespace
+
+# List HTTP load balancers in a namespace
+vesctl configuration list http_loadbalancer -n my-namespace
+
+# List with JSON output
+vesctl configuration list namespace --outfmt json
+```
+
+### Get Resource
+
+Get details of a specific resource:
+
+```bash
+vesctl configuration get <resource-type> <name> [flags]
+```
+
+**Examples:**
+
+```bash
+# Get namespace details
+vesctl configuration get namespace my-namespace
+
+# Get with YAML output
+vesctl configuration get http_loadbalancer my-lb -n my-namespace --outfmt yaml
+```
+
+### Create Resource
+
+Create a new resource from a YAML/JSON file:
+
+```bash
+vesctl configuration create <resource-type> -i <file> [flags]
+```
+
+**Examples:**
+
+```bash
+# Create from YAML file
+vesctl configuration create http_loadbalancer -i lb.yaml
+
+# Create with namespace
+vesctl configuration create origin_pool -i pool.yaml -n my-namespace
+```
+
+### Replace Resource
+
+Replace an existing resource:
+
+```bash
+vesctl configuration replace <resource-type> -i <file> [flags]
+```
+
+**Examples:**
+
+```bash
+# Replace from file
+vesctl configuration replace http_loadbalancer -i lb-updated.yaml
+```
+
+### Delete Resource
+
+Delete a resource:
+
+```bash
+vesctl configuration delete <resource-type> <name> [flags]
+```
+
+**Examples:**
+
+```bash
+# Delete a resource
+vesctl configuration delete http_loadbalancer my-lb -n my-namespace
+
+# Delete with confirmation bypass
+vesctl configuration delete origin_pool my-pool -n my-namespace --yes
+```
+
+## Common Flags
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `-n, --namespace` | `-n` | Namespace for the resource |
+| `-i, --input-file` | `-i` | Input file (YAML or JSON) |
+| `--outfmt` | `-o` | Output format (json, yaml, table) |

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -1,0 +1,111 @@
+# Command Reference
+
+This section provides detailed documentation for all vesctl commands.
+
+## Command Groups
+
+vesctl organizes commands into logical groups:
+
+| Command Group | Description |
+|---------------|-------------|
+| [configuration](configuration.md) | Manage F5 XC resources (CRUD operations) |
+| [request](request.md) | Low-level API requests and RPC calls |
+| [site](site.md) | Manage cloud and edge sites |
+| [api-endpoint](api-endpoint.md) | API endpoint discovery |
+| [utilities](utilities.md) | Version, completion, and configuration commands |
+
+## Command Structure
+
+All vesctl commands follow a consistent pattern:
+
+```
+vesctl <command-group> <action> [resource-type] [name] [flags]
+```
+
+### Examples
+
+```bash
+# List all namespaces
+vesctl configuration list namespace
+
+# Get a specific resource
+vesctl configuration get http_loadbalancer my-lb -n my-namespace
+
+# Create from file
+vesctl configuration create origin_pool -i pool.yaml
+
+# Delete a resource
+vesctl configuration delete healthcheck my-hc -n my-namespace
+```
+
+## Global Flags
+
+These flags are available for all commands:
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--config` | | Path to config file (default: ~/.vesconfig) |
+| `--server-urls` | `-u` | API server URL(s) |
+| `--cert` | `-c` | Path to client certificate file |
+| `--key` | `-k` | Path to client key file |
+| `--cacert` | | Path to CA certificate file |
+| `--p12-bundle` | | Path to P12 certificate bundle |
+| `--outfmt` | `-o` | Output format: json, yaml, table |
+| `--verbose` | `-v` | Enable verbose output |
+| `--debug` | | Enable debug logging |
+
+## Getting Help
+
+Every command supports the `--help` flag:
+
+```bash
+# Top-level help
+vesctl --help
+
+# Command group help
+vesctl configuration --help
+
+# Specific action help
+vesctl configuration list --help
+vesctl configuration get --help
+```
+
+## Output Formats
+
+Control output format with `--outfmt`:
+
+```bash
+# Table format (default)
+vesctl configuration list namespace
+
+# JSON output
+vesctl configuration list namespace --outfmt json
+
+# YAML output
+vesctl configuration list namespace --outfmt yaml
+```
+
+## Command Index
+
+### Configuration Commands
+
+- `vesctl configuration list <type>` - List resources
+- `vesctl configuration get <type> <name>` - Get resource details
+- `vesctl configuration create <type>` - Create a resource
+- `vesctl configuration replace <type>` - Replace a resource
+- `vesctl configuration delete <type> <name>` - Delete a resource
+
+### Request Commands
+
+- `vesctl request rpc` - Execute custom RPC calls
+- `vesctl request secrets` - Manage secrets
+
+### Site Commands
+
+- `vesctl site` - Manage cloud and edge sites
+
+### Utility Commands
+
+- `vesctl version` - Show version information
+- `vesctl completion` - Generate shell completions
+- `vesctl configure` - Interactive configuration setup

--- a/docs/commands/request.md
+++ b/docs/commands/request.md
@@ -1,0 +1,65 @@
+# Request Commands
+
+The `vesctl request` command group provides low-level API access.
+
+## Overview
+
+```text
+vesctl request --help
+```
+
+## Subcommands
+
+### RPC Request
+
+Execute custom API RPC calls:
+
+```bash
+vesctl request rpc <method> <path> [flags]
+```
+
+**Examples:**
+
+```bash
+# GET request
+vesctl request rpc GET /api/web/namespaces
+
+# POST request with body
+vesctl request rpc POST /api/some/endpoint -i request.json
+```
+
+### Secrets
+
+Manage secrets:
+
+```bash
+vesctl request secrets [subcommand] [flags]
+```
+
+## Common Use Cases
+
+### Custom API Calls
+
+For API endpoints not covered by standard commands:
+
+```bash
+# List available APIs
+vesctl request rpc GET /api
+
+# Get tenant information
+vesctl request rpc GET /api/web/tenant
+```
+
+### Working with Secrets
+
+```bash
+# Get secret help
+vesctl request secrets --help
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `-i, --input-file` | Request body from file |
+| `--outfmt` | Output format |

--- a/docs/commands/site.md
+++ b/docs/commands/site.md
@@ -1,0 +1,80 @@
+# Site Commands
+
+The `vesctl site` command group manages cloud and edge sites.
+
+## Overview
+
+```text
+vesctl site --help
+```
+
+## Site Types
+
+vesctl supports managing various site types:
+
+| Site Type | Description |
+|-----------|-------------|
+| AWS VPC Site | Sites deployed in AWS VPCs |
+| Azure VNet Site | Sites deployed in Azure VNets |
+| GCP VPC Site | Sites deployed in Google Cloud VPCs |
+| Edge Sites | Physical or virtual edge deployments |
+
+## Common Operations
+
+### List Sites
+
+```bash
+# List all sites
+vesctl site list
+
+# List sites in a namespace
+vesctl site list -n system
+```
+
+### Get Site Details
+
+```bash
+vesctl site get <site-name> -n <namespace>
+```
+
+### Site Status
+
+Check the status and health of deployed sites:
+
+```bash
+vesctl site status <site-name> -n <namespace>
+```
+
+## Cloud Site Management
+
+### AWS VPC Sites
+
+```bash
+# Get AWS VPC site help
+vesctl site aws-vpc --help
+
+# List AWS VPC sites
+vesctl configuration list aws_vpc_site -n system
+```
+
+### Azure VNet Sites
+
+```bash
+# Get Azure VNet site help
+vesctl site azure-vnet --help
+
+# List Azure VNet sites
+vesctl configuration list azure_vnet_site -n system
+```
+
+## Related Commands
+
+For detailed site resource management, use the `configuration` commands:
+
+```bash
+# Create AWS VPC site
+vesctl configuration create aws_vpc_site -i aws-site.yaml -n system
+
+# Get site details
+vesctl configuration get aws_vpc_site my-aws-site -n system --outfmt yaml
+```

--- a/docs/commands/utilities.md
+++ b/docs/commands/utilities.md
@@ -1,0 +1,107 @@
+# Utility Commands
+
+Additional utility commands for vesctl.
+
+## Version
+
+Display version information:
+
+```bash
+vesctl version
+```
+
+**Example Output:**
+
+```text
+vesctl version 0.1.0
+  commit: abc1234
+  built:  2024-01-01T00:00:00Z
+```
+
+### Version Flags
+
+| Flag | Description |
+|------|-------------|
+| `--short` | Print version number only |
+| `--json` | Output as JSON |
+
+## Completion
+
+Generate shell completion scripts for command auto-completion.
+
+```bash
+vesctl completion [bash|zsh|fish|powershell]
+```
+
+### Bash Completion
+
+```bash
+# Current session
+source <(vesctl completion bash)
+
+# Permanent (Linux)
+vesctl completion bash > /etc/bash_completion.d/vesctl
+
+# Permanent (macOS with Homebrew)
+vesctl completion bash > $(brew --prefix)/etc/bash_completion.d/vesctl
+```
+
+### Zsh Completion
+
+```bash
+# Enable completion
+echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+# Install completion
+vesctl completion zsh > "${fpath[1]}/_vesctl"
+```
+
+### Fish Completion
+
+```bash
+vesctl completion fish > ~/.config/fish/completions/vesctl.fish
+```
+
+### PowerShell Completion
+
+```powershell
+vesctl completion powershell | Out-String | Invoke-Expression
+```
+
+## Configure
+
+Interactive configuration setup:
+
+```bash
+vesctl configure
+```
+
+This command guides you through:
+
+1. Setting the API server URL
+2. Choosing authentication method
+3. Configuring credential file paths
+4. Testing the connection
+
+### Configuration File
+
+The `configure` command creates or updates `~/.vesconfig`:
+
+```yaml
+server-urls:
+  - https://your-tenant.console.ves.volterra.io/api
+p12-bundle: /path/to/credentials.p12
+```
+
+## Help
+
+Get help for any command:
+
+```bash
+# General help
+vesctl --help
+
+# Command-specific help
+vesctl configuration --help
+vesctl configuration list --help
+```

--- a/docs/examples/cloud-sites.md
+++ b/docs/examples/cloud-sites.md
@@ -1,0 +1,207 @@
+# Cloud Site Examples
+
+Examples for deploying F5 Distributed Cloud sites in AWS and Azure.
+
+## AWS VPC Site
+
+### Basic AWS VPC Site
+
+Deploy an F5 XC site in an AWS VPC.
+
+**aws-vpc-site.yaml:**
+
+```yaml
+metadata:
+  name: my-aws-site
+  namespace: system
+spec:
+  aws:
+    region: us-east-1
+  vpc:
+    vpc_id: vpc-12345678
+  ingress_egress_gw:
+    aws_certified_hw: aws-byol-voltmesh
+    instance_type: t3.xlarge
+  nodes:
+    - aws_az_name: us-east-1a
+      reserved_inside_subnet:
+        existing_subnet_id: subnet-inside-123
+```
+
+**Deploy:**
+
+```bash
+# Create cloud credentials first
+vesctl configuration create cloud_credentials -i aws-creds.yaml -n system
+
+# Create site
+vesctl configuration create aws_vpc_site -i aws-vpc-site.yaml -n system
+
+# Check status
+vesctl configuration get aws_vpc_site my-aws-site -n system
+```
+
+### AWS Site with Multiple Nodes
+
+**multi-az-site.yaml:**
+
+```yaml
+metadata:
+  name: my-multi-az-site
+  namespace: system
+spec:
+  aws:
+    region: us-east-1
+  vpc:
+    vpc_id: vpc-12345678
+  ingress_egress_gw:
+    aws_certified_hw: aws-byol-voltmesh
+    instance_type: t3.xlarge
+  nodes:
+    - aws_az_name: us-east-1a
+      reserved_inside_subnet:
+        existing_subnet_id: subnet-inside-1a
+    - aws_az_name: us-east-1b
+      reserved_inside_subnet:
+        existing_subnet_id: subnet-inside-1b
+    - aws_az_name: us-east-1c
+      reserved_inside_subnet:
+        existing_subnet_id: subnet-inside-1c
+```
+
+## Azure VNet Site
+
+### Basic Azure VNet Site
+
+Deploy an F5 XC site in an Azure VNet.
+
+**azure-vnet-site.yaml:**
+
+```yaml
+metadata:
+  name: my-azure-site
+  namespace: system
+spec:
+  azure:
+    region: eastus
+  resource_group: my-resource-group
+  vnet:
+    vnet_name: my-vnet
+  ingress_egress_gw:
+    azure_certified_hw: azure-byol-voltmesh
+    instance_type: Standard_D3_v2
+  nodes:
+    - azure_az: "1"
+      inside_subnet:
+        subnet_name: inside-subnet
+```
+
+**Deploy:**
+
+```bash
+# Create cloud credentials
+vesctl configuration create cloud_credentials -i azure-creds.yaml -n system
+
+# Create site
+vesctl configuration create azure_vnet_site -i azure-vnet-site.yaml -n system
+```
+
+## Cloud Credentials
+
+### AWS Credentials
+
+**aws-creds.yaml:**
+
+```yaml
+metadata:
+  name: my-aws-creds
+  namespace: system
+spec:
+  aws_secret_key:
+    access_key: AKIAIOSFODNN7EXAMPLE
+    secret_key:
+      blindfold_secret_info:
+        location: string:///base64-encoded-secret
+```
+
+### Azure Credentials
+
+**azure-creds.yaml:**
+
+```yaml
+metadata:
+  name: my-azure-creds
+  namespace: system
+spec:
+  azure_client_secret:
+    subscription_id: your-subscription-id
+    tenant_id: your-tenant-id
+    client_id: your-client-id
+    client_secret:
+      blindfold_secret_info:
+        location: string:///base64-encoded-secret
+```
+
+## Site Management Commands
+
+### List Sites
+
+```bash
+# List AWS sites
+vesctl configuration list aws_vpc_site -n system
+
+# List Azure sites
+vesctl configuration list azure_vnet_site -n system
+```
+
+### Get Site Details
+
+```bash
+# Get AWS site
+vesctl configuration get aws_vpc_site my-aws-site -n system --outfmt yaml
+
+# Get Azure site
+vesctl configuration get azure_vnet_site my-azure-site -n system --outfmt yaml
+```
+
+### Site Status
+
+```bash
+# Check site registration status
+vesctl site status my-aws-site -n system
+```
+
+### Delete Site
+
+```bash
+# Delete AWS site
+vesctl configuration delete aws_vpc_site my-aws-site -n system --yes
+
+# Delete Azure site
+vesctl configuration delete azure_vnet_site my-azure-site -n system --yes
+```
+
+## Troubleshooting
+
+### Check Site Status
+
+```bash
+vesctl configuration get aws_vpc_site my-site -n system --outfmt json | jq '.status'
+```
+
+### List All Cloud Resources
+
+```bash
+# List all cloud credentials
+vesctl configuration list cloud_credentials -n system
+
+# List all sites
+vesctl configuration list aws_vpc_site -n system
+vesctl configuration list azure_vnet_site -n system
+```
+
+### Debug Mode
+
+```bash
+vesctl --debug configuration get aws_vpc_site my-site -n system
+```

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,0 +1,112 @@
+# Examples
+
+Real-world examples for common vesctl use cases.
+
+## Contents
+
+| Example | Description |
+|---------|-------------|
+| [Load Balancers](load-balancer.md) | HTTP and TCP load balancer configuration |
+| [Cloud Sites](cloud-sites.md) | AWS and Azure site deployment |
+
+## Quick Examples
+
+### List All Namespaces
+
+```bash
+vesctl configuration list namespace
+```
+
+**Output:**
+
+```text
+NAME           DESCRIPTION
+default        Default namespace
+my-namespace   My application namespace
+system         System namespace
+```
+
+### Create Resource from File
+
+```bash
+vesctl configuration create http_loadbalancer -i lb.yaml
+```
+
+### Get Resource as YAML
+
+```bash
+vesctl configuration get namespace my-namespace --outfmt yaml
+```
+
+**Output:**
+
+```yaml
+metadata:
+  name: my-namespace
+  uid: abc123
+spec:
+  description: My application namespace
+```
+
+### Delete Resource
+
+```bash
+vesctl configuration delete http_loadbalancer my-lb -n my-namespace --yes
+```
+
+## Common Workflows
+
+### Deploy HTTP Load Balancer
+
+1. Create an origin pool:
+
+```bash
+vesctl configuration create origin_pool -i origin-pool.yaml
+```
+
+2. Create a health check:
+
+```bash
+vesctl configuration create healthcheck -i healthcheck.yaml
+```
+
+3. Create the load balancer:
+
+```bash
+vesctl configuration create http_loadbalancer -i lb.yaml
+```
+
+4. Verify deployment:
+
+```bash
+vesctl configuration get http_loadbalancer my-lb -n my-namespace
+```
+
+### Update Configuration
+
+1. Export current configuration:
+
+```bash
+vesctl configuration get http_loadbalancer my-lb -n my-namespace --outfmt yaml > lb.yaml
+```
+
+2. Edit the file as needed
+
+3. Apply changes:
+
+```bash
+vesctl configuration replace http_loadbalancer -i lb.yaml
+```
+
+### Cleanup Resources
+
+```bash
+# Delete load balancer
+vesctl configuration delete http_loadbalancer my-lb -n my-namespace --yes
+
+# Delete origin pool
+vesctl configuration delete origin_pool my-pool -n my-namespace --yes
+
+# Delete health check
+vesctl configuration delete healthcheck my-hc -n my-namespace --yes
+```

--- a/docs/examples/load-balancer.md
+++ b/docs/examples/load-balancer.md
@@ -1,0 +1,243 @@
+# Load Balancer Examples
+
+Examples for configuring HTTP and TCP load balancers.
+
+## HTTP Load Balancer
+
+### Basic HTTP Load Balancer
+
+Create a simple HTTP load balancer with a single origin pool.
+
+**origin-pool.yaml:**
+
+```yaml
+metadata:
+  name: my-origin-pool
+  namespace: my-namespace
+spec:
+  origin_servers:
+    - public_ip:
+        ip: 192.168.1.100
+  port: 8080
+  loadbalancer_algorithm: ROUND_ROBIN
+```
+
+**http-lb.yaml:**
+
+```yaml
+metadata:
+  name: my-http-lb
+  namespace: my-namespace
+spec:
+  domains:
+    - example.com
+  http:
+    port: 80
+  default_route_pools:
+    - pool:
+        name: my-origin-pool
+        namespace: my-namespace
+```
+
+**Deploy:**
+
+```bash
+# Create origin pool
+vesctl configuration create origin_pool -i origin-pool.yaml
+
+# Create load balancer
+vesctl configuration create http_loadbalancer -i http-lb.yaml
+
+# Verify
+vesctl configuration get http_loadbalancer my-http-lb -n my-namespace
+```
+
+### HTTPS Load Balancer
+
+Add TLS termination to your load balancer.
+
+**https-lb.yaml:**
+
+```yaml
+metadata:
+  name: my-https-lb
+  namespace: my-namespace
+spec:
+  domains:
+    - example.com
+  https_auto_cert:
+    http_redirect: true
+    add_hsts: true
+  default_route_pools:
+    - pool:
+        name: my-origin-pool
+        namespace: my-namespace
+```
+
+### Load Balancer with WAF
+
+Add Web Application Firewall protection.
+
+**waf-lb.yaml:**
+
+```yaml
+metadata:
+  name: my-waf-lb
+  namespace: my-namespace
+spec:
+  domains:
+    - example.com
+  https_auto_cert:
+    http_redirect: true
+  default_route_pools:
+    - pool:
+        name: my-origin-pool
+        namespace: my-namespace
+  app_firewall:
+    name: my-waf-policy
+    namespace: my-namespace
+```
+
+## TCP Load Balancer
+
+### Basic TCP Load Balancer
+
+**tcp-lb.yaml:**
+
+```yaml
+metadata:
+  name: my-tcp-lb
+  namespace: my-namespace
+spec:
+  listen_port: 3306
+  origin_pools:
+    - pool:
+        name: my-db-pool
+        namespace: my-namespace
+```
+
+**Deploy:**
+
+```bash
+vesctl configuration create tcp_loadbalancer -i tcp-lb.yaml
+```
+
+## Health Checks
+
+### HTTP Health Check
+
+**healthcheck.yaml:**
+
+```yaml
+metadata:
+  name: my-healthcheck
+  namespace: my-namespace
+spec:
+  http_health_check:
+    path: /health
+    expected_status_codes:
+      - "200"
+  interval: 30
+  timeout: 10
+  unhealthy_threshold: 3
+  healthy_threshold: 2
+```
+
+### TCP Health Check
+
+**tcp-healthcheck.yaml:**
+
+```yaml
+metadata:
+  name: my-tcp-healthcheck
+  namespace: my-namespace
+spec:
+  tcp_health_check: {}
+  interval: 15
+  timeout: 5
+```
+
+## Origin Pool Options
+
+### Multiple Origin Servers
+
+```yaml
+metadata:
+  name: multi-origin-pool
+  namespace: my-namespace
+spec:
+  origin_servers:
+    - public_ip:
+        ip: 192.168.1.100
+    - public_ip:
+        ip: 192.168.1.101
+    - public_ip:
+        ip: 192.168.1.102
+  port: 8080
+  loadbalancer_algorithm: ROUND_ROBIN
+  healthcheck:
+    - name: my-healthcheck
+      namespace: my-namespace
+```
+
+### Origin Pool with DNS
+
+```yaml
+metadata:
+  name: dns-origin-pool
+  namespace: my-namespace
+spec:
+  origin_servers:
+    - public_name:
+        dns_name: backend.example.com
+  port: 443
+  use_tls:
+    use_host_header_as_sni: {}
+```
+
+## Management Commands
+
+### List Load Balancers
+
+```bash
+# List all HTTP load balancers
+vesctl configuration list http_loadbalancer -n my-namespace
+
+# List all TCP load balancers
+vesctl configuration list tcp_loadbalancer -n my-namespace
+```
+
+### Get Details
+
+```bash
+# Get as table
+vesctl configuration get http_loadbalancer my-lb -n my-namespace
+
+# Get as YAML
+vesctl configuration get http_loadbalancer my-lb -n my-namespace --outfmt yaml
+
+# Get as JSON
+vesctl configuration get http_loadbalancer my-lb -n my-namespace --outfmt json
+```
+
+### Update Load Balancer
+
+```bash
+# Export current config
+vesctl configuration get http_loadbalancer my-lb -n my-namespace --outfmt yaml > lb.yaml
+
+# Edit lb.yaml...
+
+# Apply changes
+vesctl configuration replace http_loadbalancer -i lb.yaml
+```
+
+### Delete Load Balancer
+
+```bash
+# With confirmation
+vesctl configuration delete http_loadbalancer my-lb -n my-namespace
+
+# Skip confirmation
+vesctl configuration delete http_loadbalancer my-lb -n my-namespace --yes
+```

--- a/docs/getting-started/authentication.md
+++ b/docs/getting-started/authentication.md
@@ -1,0 +1,190 @@
+# Authentication
+
+vesctl supports multiple authentication methods to connect to the F5 Distributed Cloud API.
+
+## P12 Bundle (Recommended)
+
+The recommended authentication method uses a P12 certificate bundle.
+
+### Obtaining Credentials
+
+1. Log in to the F5 XC Console
+2. Navigate to **Administration** > **Personal Management** > **Credentials**
+3. Click **Create Credentials**
+4. Select type **API Certificate**
+5. Download the P12 file
+6. Note the password provided
+
+### Configuration
+
+**Using configuration file (~/.vesconfig):**
+
+```yaml
+server-urls:
+  - https://your-tenant.console.ves.volterra.io/api
+p12-bundle: /path/to/api-creds.p12
+```
+
+**Set the password as environment variable:**
+
+```bash
+export VES_P12_PASSWORD="your-p12-password"
+```
+
+## Certificate and Key
+
+Use separate certificate and key files instead of a P12 bundle.
+
+### Extract from P12
+
+If you have a P12 file, extract the certificate and key:
+
+```bash
+# Extract certificate
+openssl pkcs12 -in api-creds.p12 -nodes -nokeys -out cert.pem
+
+# Extract private key
+openssl pkcs12 -in api-creds.p12 -nodes -nocerts -out key.pem
+```
+
+### Configuration
+
+**Using configuration file (~/.vesconfig):**
+
+```yaml
+server-urls:
+  - https://your-tenant.console.ves.volterra.io/api
+cert: /path/to/cert.pem
+key: /path/to/key.pem
+```
+
+**Using command-line flags:**
+
+```bash
+vesctl --cert /path/to/cert.pem --key /path/to/key.pem configuration list namespace
+```
+
+## Configuration File
+
+The default configuration file location is `~/.vesconfig`.
+
+### Full Example
+
+```yaml
+# API server URL
+server-urls:
+  - https://your-tenant.console.ves.volterra.io/api
+
+# P12 bundle authentication
+p12-bundle: /path/to/api-creds.p12
+
+# OR certificate/key authentication
+# cert: /path/to/cert.pem
+# key: /path/to/key.pem
+
+# Optional CA certificate for custom trust
+# cacert: /path/to/ca.pem
+```
+
+### Custom Config Location
+
+Specify a custom configuration file:
+
+```bash
+vesctl --config /path/to/custom-config.yaml configuration list namespace
+```
+
+## Environment Variables
+
+Override configuration with environment variables:
+
+| Variable | Description |
+|----------|-------------|
+| `VES_P12_PASSWORD` | Password for P12 bundle |
+| `VES_SERVER_URLS` | API server URL(s) |
+| `VES_P12_BUNDLE` | Path to P12 bundle |
+| `VES_CERT` | Path to client certificate |
+| `VES_KEY` | Path to client key |
+
+### Example
+
+```bash
+export VES_SERVER_URLS="https://your-tenant.console.ves.volterra.io/api"
+export VES_P12_BUNDLE="/path/to/api-creds.p12"
+export VES_P12_PASSWORD="your-password"
+
+vesctl configuration list namespace
+```
+
+## Interactive Configuration
+
+Use `vesctl configure` for interactive setup:
+
+```bash
+vesctl configure
+```
+
+This will prompt for:
+
+1. API server URL
+2. Authentication method (P12 or cert/key)
+3. File paths
+4. (Optional) P12 password
+
+## Verifying Authentication
+
+Test your configuration:
+
+```bash
+# List namespaces to verify connection
+vesctl configuration list namespace
+
+# Check with verbose output for troubleshooting
+vesctl --verbose configuration list namespace
+```
+
+## Security Best Practices
+
+1. **Protect your credentials** - Keep P12 files and keys secure with appropriate file permissions
+2. **Use environment variables** - Never commit passwords to version control
+3. **Rotate credentials** - Periodically rotate your API certificates
+4. **Limit scope** - Use credentials with minimum required permissions
+
+### File Permissions
+
+```bash
+# Restrict access to credential files
+chmod 600 ~/.vesconfig
+chmod 600 /path/to/api-creds.p12
+chmod 600 /path/to/key.pem
+```
+
+## Troubleshooting
+
+### Certificate Errors
+
+```
+Error: x509: certificate signed by unknown authority
+```
+
+Add the CA certificate:
+
+```yaml
+cacert: /path/to/ca-bundle.pem
+```
+
+### Invalid Password
+
+```
+Error: pkcs12: decryption password incorrect
+```
+
+Verify `VES_P12_PASSWORD` is set correctly.
+
+### Connection Refused
+
+```
+Error: dial tcp: connection refused
+```
+
+Check the server URL and network connectivity.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,0 +1,52 @@
+# Getting Started
+
+This guide will help you get started with vesctl, the command-line interface for F5 Distributed Cloud.
+
+## Prerequisites
+
+Before installing vesctl, ensure you have:
+
+- A terminal or command prompt
+- Network access to download the binary
+- (Optional) Go 1.23+ if building from source
+
+## Installation Methods
+
+Choose the installation method that works best for you:
+
+| Method | Best For |
+|--------|----------|
+| [Quick Install](installation.md#quick-install) | Most users |
+| [Manual Download](installation.md#manual-installation) | Custom locations |
+| [Build from Source](installation.md#build-from-source) | Development |
+
+## First Steps
+
+1. **[Install vesctl](installation.md)** - Get the binary installed on your system
+2. **[Configure Authentication](authentication.md)** - Set up your API credentials
+3. **[Quick Start Tutorial](quickstart.md)** - Learn the basics with hands-on examples
+
+## System Requirements
+
+| Platform | Architecture | Status |
+|----------|--------------|--------|
+| Linux | amd64 | Supported |
+| Linux | arm64 | Supported |
+| macOS | amd64 | Supported |
+| macOS | arm64 (Apple Silicon) | Supported |
+| Windows | amd64 | Supported |
+
+## Getting Help
+
+If you encounter issues:
+
+```bash
+# View general help
+vesctl --help
+
+# View help for specific commands
+vesctl configuration --help
+vesctl configuration list --help
+```
+
+For additional support, visit the [GitHub repository](https://github.com/robinmordasiewicz/vesctl).

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,178 @@
+# Installation
+
+This guide covers all methods for installing vesctl.
+
+## Quick Install
+
+The easiest way to install vesctl is with the install script:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/robinmordasiewicz/vesctl/main/install.sh | sh
+```
+
+This will:
+
+- Detect your platform (Linux/macOS, amd64/arm64)
+- Download the latest release
+- Verify the checksum
+- Install to `/usr/local/bin`
+- Set up shell completion
+
+### Install Options
+
+**Install a specific version:**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/robinmordasiewicz/vesctl/main/install.sh | VESCTL_VERSION=0.1.0 sh
+```
+
+**Install to a custom directory:**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/robinmordasiewicz/vesctl/main/install.sh | VESCTL_INSTALL_DIR=$HOME/.local/bin sh
+```
+
+**Uninstall:**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/robinmordasiewicz/vesctl/main/install.sh | sh -s -- --uninstall
+```
+
+## Manual Installation
+
+Download the appropriate binary from [GitHub Releases](https://github.com/robinmordasiewicz/vesctl/releases).
+
+### Linux (amd64)
+
+```bash
+curl -LO https://github.com/robinmordasiewicz/vesctl/releases/latest/download/vesctl_linux_amd64.tar.gz
+tar -xzf vesctl_linux_amd64.tar.gz
+sudo mv vesctl /usr/local/bin/
+```
+
+### Linux (arm64)
+
+```bash
+curl -LO https://github.com/robinmordasiewicz/vesctl/releases/latest/download/vesctl_linux_arm64.tar.gz
+tar -xzf vesctl_linux_arm64.tar.gz
+sudo mv vesctl /usr/local/bin/
+```
+
+### macOS (Intel)
+
+```bash
+curl -LO https://github.com/robinmordasiewicz/vesctl/releases/latest/download/vesctl_darwin_amd64.tar.gz
+tar -xzf vesctl_darwin_amd64.tar.gz
+sudo mv vesctl /usr/local/bin/
+```
+
+### macOS (Apple Silicon)
+
+```bash
+curl -LO https://github.com/robinmordasiewicz/vesctl/releases/latest/download/vesctl_darwin_arm64.tar.gz
+tar -xzf vesctl_darwin_arm64.tar.gz
+sudo mv vesctl /usr/local/bin/
+```
+
+## Build from Source
+
+Build vesctl from source code:
+
+```bash
+# Clone the repository
+git clone https://github.com/robinmordasiewicz/vesctl.git
+cd vesctl
+
+# Build the binary
+go build -o vesctl .
+
+# Install (optional)
+sudo mv vesctl /usr/local/bin/
+```
+
+### Build Requirements
+
+- Go 1.23 or later
+- Git
+
+## Verify Installation
+
+After installation, verify vesctl is working:
+
+```bash
+vesctl version
+```
+
+Expected output:
+
+```text
+vesctl version 0.1.0
+  commit: abc1234
+  built:  2024-01-01T00:00:00Z
+```
+
+## Shell Completion
+
+Enable tab completion for your shell:
+
+### Bash
+
+```bash
+# Current session
+source <(vesctl completion bash)
+
+# Permanent (Linux)
+vesctl completion bash > /etc/bash_completion.d/vesctl
+
+# Permanent (macOS with Homebrew)
+vesctl completion bash > $(brew --prefix)/etc/bash_completion.d/vesctl
+```
+
+### Zsh
+
+```bash
+# Enable completion system
+echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+# Install completion
+vesctl completion zsh > "${fpath[1]}/_vesctl"
+```
+
+### Fish
+
+```bash
+vesctl completion fish > ~/.config/fish/completions/vesctl.fish
+```
+
+### PowerShell
+
+```powershell
+vesctl completion powershell | Out-String | Invoke-Expression
+```
+
+## Troubleshooting
+
+### Permission Denied
+
+If you get a permission denied error:
+
+```bash
+# Make the binary executable
+chmod +x vesctl
+
+# Or use sudo for installation
+sudo mv vesctl /usr/local/bin/
+```
+
+### Command Not Found
+
+Ensure the installation directory is in your PATH:
+
+```bash
+# Add to ~/.bashrc or ~/.zshrc
+export PATH="$PATH:/usr/local/bin"
+```
+
+### Checksum Verification Failed
+
+If the checksum doesn't match, try downloading again or verify the release on GitHub.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,0 +1,96 @@
+# Quick Start
+
+Get up and running with vesctl in minutes.
+
+## Step 1: Install vesctl
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/robinmordasiewicz/vesctl/main/install.sh | sh
+```
+
+## Step 2: Configure Authentication
+
+### Option A: Interactive Setup
+
+Run the configure command to set up your credentials interactively:
+
+```bash
+vesctl configure
+```
+
+### Option B: Configuration File
+
+Create `~/.vesconfig`:
+
+```yaml
+server-urls:
+  - https://your-tenant.console.ves.volterra.io/api
+p12-bundle: ~/.f5xc/api-creds.p12
+```
+
+Set the P12 password:
+
+```bash
+export VES_P12_PASSWORD="your-p12-password"
+```
+
+## Step 3: Verify Connection
+
+Test your configuration by listing namespaces:
+
+```bash
+vesctl configuration list namespace
+```
+
+You should see a list of available namespaces in your tenant.
+
+## Step 4: Explore Resources
+
+### List All Namespaces
+
+```bash
+vesctl configuration list namespace
+```
+
+### Get Namespace Details
+
+```bash
+vesctl configuration get namespace default --outfmt yaml
+```
+
+### List HTTP Load Balancers
+
+```bash
+vesctl configuration list http_loadbalancer -n my-namespace
+```
+
+## Common Commands
+
+| Task | Command |
+|------|---------|
+| List namespaces | `vesctl configuration list namespace` |
+| Get resource details | `vesctl configuration get <type> <name> -n <namespace>` |
+| Create resource | `vesctl configuration create <type> -i file.yaml` |
+| Delete resource | `vesctl configuration delete <type> <name> -n <namespace>` |
+| Show version | `vesctl version` |
+
+## Output Formats
+
+Control output format with the `--outfmt` flag:
+
+```bash
+# Default table format
+vesctl configuration list namespace
+
+# JSON output
+vesctl configuration list namespace --outfmt json
+
+# YAML output
+vesctl configuration list namespace --outfmt yaml
+```
+
+## Next Steps
+
+- [Authentication Details](authentication.md) - Learn about all authentication methods
+- [Command Reference](../commands/index.md) - Full command documentation
+- [Examples](../examples/index.md) - Real-world usage examples

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,71 @@
+# vesctl Documentation
+
+**vesctl** is an open-source command-line interface for managing F5 Distributed Cloud (formerly Volterra) resources.
+
+## Features
+
+- **Full API Coverage** - Manage all F5 XC resources from the command line
+- **Multiple Output Formats** - JSON, YAML, table, and TSV output formats
+- **Shell Completion** - Auto-completion for Bash, Zsh, Fish, and PowerShell
+- **Secure Authentication** - P12 bundle or certificate/key pair authentication
+- **Cross-Platform** - Available for Linux, macOS, and Windows
+
+## Quick Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/robinmordasiewicz/vesctl/main/install.sh | sh
+```
+
+## Basic Usage
+
+```bash
+# Configure authentication
+vesctl configure
+
+# List namespaces
+vesctl configuration list namespace
+
+# Get resource details
+vesctl configuration get namespace my-namespace --outfmt json
+
+# Create a resource from file
+vesctl configuration create http_loadbalancer -i lb.yaml
+```
+
+## Command Structure
+
+vesctl commands follow a consistent pattern:
+
+```
+vesctl <command-group> <action> [resource-type] [name] [flags]
+```
+
+### Command Groups
+
+| Group | Description |
+|-------|-------------|
+| `configuration` | Manage F5 XC resources (CRUD operations) |
+| `request` | Low-level API requests |
+| `site` | Manage cloud and edge sites |
+| `api-endpoint` | API endpoint discovery |
+| `configure` | Interactive configuration setup |
+| `version` | Display version information |
+| `completion` | Generate shell completions |
+
+## Getting Help
+
+```bash
+# General help
+vesctl --help
+
+# Command-specific help
+vesctl configuration --help
+vesctl configuration list --help
+```
+
+## Next Steps
+
+- [Installation Guide](getting-started/installation.md) - Detailed installation instructions
+- [Quick Start](getting-started/quickstart.md) - Get up and running quickly
+- [Authentication](getting-started/authentication.md) - Configure API credentials
+- [Command Reference](commands/index.md) - Complete command documentation

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,0 +1,110 @@
+# Environment Variables
+
+vesctl can be configured using environment variables.
+
+## Authentication Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `VES_P12_PASSWORD` | Password for P12 bundle | `export VES_P12_PASSWORD="secret"` |
+| `VES_P12_BUNDLE` | Path to P12 bundle | `export VES_P12_BUNDLE="/path/to/creds.p12"` |
+| `VES_CERT` | Path to client certificate | `export VES_CERT="/path/to/cert.pem"` |
+| `VES_KEY` | Path to client key | `export VES_KEY="/path/to/key.pem"` |
+
+## Connection Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `VES_SERVER_URLS` | API server URL(s) | `export VES_SERVER_URLS="https://tenant.console.ves.volterra.io/api"` |
+| `VES_CACERT` | Path to CA certificate | `export VES_CACERT="/path/to/ca.pem"` |
+
+## Output Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `VES_OUTPUT` | Default output format | `export VES_OUTPUT="json"` |
+
+## Configuration Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `VES_CONFIG` | Path to config file | `export VES_CONFIG="/path/to/config.yaml"` |
+
+## Usage Examples
+
+### Basic Setup
+
+```bash
+# Set server URL
+export VES_SERVER_URLS="https://your-tenant.console.ves.volterra.io/api"
+
+# Set P12 credentials
+export VES_P12_BUNDLE="/path/to/api-creds.p12"
+export VES_P12_PASSWORD="your-password"
+
+# Run command
+vesctl configuration list namespace
+```
+
+### Certificate Authentication
+
+```bash
+export VES_SERVER_URLS="https://your-tenant.console.ves.volterra.io/api"
+export VES_CERT="/path/to/cert.pem"
+export VES_KEY="/path/to/key.pem"
+
+vesctl configuration list namespace
+```
+
+### JSON Output Default
+
+```bash
+export VES_OUTPUT="json"
+
+# All commands now output JSON by default
+vesctl configuration list namespace
+```
+
+## Shell Configuration
+
+Add to your shell profile for persistent configuration:
+
+### Bash (~/.bashrc)
+
+```bash
+export VES_SERVER_URLS="https://your-tenant.console.ves.volterra.io/api"
+export VES_P12_BUNDLE="$HOME/.f5xc/api-creds.p12"
+export VES_P12_PASSWORD="your-password"
+```
+
+### Zsh (~/.zshrc)
+
+```bash
+export VES_SERVER_URLS="https://your-tenant.console.ves.volterra.io/api"
+export VES_P12_BUNDLE="$HOME/.f5xc/api-creds.p12"
+export VES_P12_PASSWORD="your-password"
+```
+
+### Fish (~/.config/fish/config.fish)
+
+```fish
+set -x VES_SERVER_URLS "https://your-tenant.console.ves.volterra.io/api"
+set -x VES_P12_BUNDLE "$HOME/.f5xc/api-creds.p12"
+set -x VES_P12_PASSWORD "your-password"
+```
+
+## Precedence
+
+Environment variables override config file settings but are overridden by command-line flags:
+
+1. Command-line flags (highest priority)
+2. **Environment variables**
+3. Configuration file
+4. Default values (lowest priority)
+
+## Security Considerations
+
+- Never commit environment variables with secrets to version control
+- Use secret management tools for production environments
+- Consider using `.envrc` with direnv for project-specific settings
+- Ensure proper file permissions on shell configuration files

--- a/docs/reference/global-flags.md
+++ b/docs/reference/global-flags.md
@@ -1,0 +1,83 @@
+# Global Flags
+
+These flags are available for all vesctl commands.
+
+## Connection Flags
+
+| Flag | Short | Description | Default |
+|------|-------|-------------|---------|
+| `--config` | | Path to config file | `~/.vesconfig` |
+| `--server-urls` | `-u` | API server URL(s) | From config |
+| `--cert` | `-c` | Path to client certificate | From config |
+| `--key` | `-k` | Path to client key | From config |
+| `--cacert` | | Path to CA certificate | System CA |
+| `--p12-bundle` | | Path to P12 certificate bundle | From config |
+
+## Output Flags
+
+| Flag | Short | Description | Default |
+|------|-------|-------------|---------|
+| `--outfmt` | `-o` | Output format (json, yaml, table) | `table` |
+| `--query` | | JMESPath query for filtering | |
+
+## Logging Flags
+
+| Flag | Short | Description | Default |
+|------|-------|-------------|---------|
+| `--verbose` | `-v` | Increase logging verbosity | `false` |
+| `--debug` | | Enable debug logging | `false` |
+| `--only-show-errors` | | Only show errors | `false` |
+
+## Operation Flags
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--no-wait` | Don't wait for long-running operations | `false` |
+| `--yes` | Skip confirmation prompts | `false` |
+
+## Examples
+
+### Specify Config File
+
+```bash
+vesctl --config /path/to/custom-config.yaml configuration list namespace
+```
+
+### Override Server URL
+
+```bash
+vesctl --server-urls https://custom.api.url/api configuration list namespace
+```
+
+### Use Custom Certificates
+
+```bash
+vesctl --cert /path/to/cert.pem --key /path/to/key.pem configuration list namespace
+```
+
+### Enable Debug Output
+
+```bash
+vesctl --debug configuration list namespace
+```
+
+### JSON Output
+
+```bash
+vesctl --outfmt json configuration list namespace
+```
+
+### Combine Flags
+
+```bash
+vesctl --verbose --outfmt yaml configuration get namespace my-ns
+```
+
+## Precedence
+
+Flags override configuration in this order (highest to lowest):
+
+1. Command-line flags
+2. Environment variables
+3. Configuration file (`~/.vesconfig`)
+4. Default values

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,41 @@
+# Reference
+
+This section contains detailed reference documentation for vesctl.
+
+## Contents
+
+| Reference | Description |
+|-----------|-------------|
+| [Global Flags](global-flags.md) | Command-line flags available for all commands |
+| [Environment Variables](environment-variables.md) | Environment variables for configuration |
+| [Resources](resources.md) | Supported F5 XC resource types |
+
+## Quick Reference
+
+### Authentication
+
+```bash
+# P12 bundle
+export VES_P12_PASSWORD="your-password"
+
+# Or certificate/key in config
+# cert: /path/to/cert.pem
+# key: /path/to/key.pem
+```
+
+### Common Commands
+
+```bash
+vesctl configuration list <type>           # List resources
+vesctl configuration get <type> <name>     # Get resource
+vesctl configuration create <type> -i f    # Create from file
+vesctl configuration delete <type> <name>  # Delete resource
+```
+
+### Output Formats
+
+```bash
+--outfmt json   # JSON output
+--outfmt yaml   # YAML output
+--outfmt table  # Table output (default)
+```

--- a/docs/reference/resources.md
+++ b/docs/reference/resources.md
@@ -1,0 +1,171 @@
+# Supported Resources
+
+vesctl supports the following F5 Distributed Cloud resource types.
+
+## Resource Types
+
+### Load Balancing
+
+| Resource Type | Description |
+|---------------|-------------|
+| `http_loadbalancer` | HTTP Load Balancer for L7 traffic |
+| `tcp_loadbalancer` | TCP Load Balancer for L4 traffic |
+| `origin_pool` | Origin Pool for backend servers |
+| `healthcheck` | Health Check for monitoring backends |
+
+### Security
+
+| Resource Type | Description |
+|---------------|-------------|
+| `app_firewall` | Application Firewall (WAF) policy |
+| `service_policy` | Service Policy for traffic control |
+| `rate_limiter` | Rate Limiter policy |
+| `ip_prefix_set` | IP Prefix Set for allowlist/blocklist |
+
+### API Security
+
+| Resource Type | Description |
+|---------------|-------------|
+| `api_definition` | API Definition for OpenAPI specs |
+| `api_endpoint` | Discovered API endpoints |
+
+### Infrastructure
+
+| Resource Type | Description |
+|---------------|-------------|
+| `namespace` | Namespace for resource organization |
+| `certificate` | TLS Certificate management |
+| `virtual_host` | Virtual Host configuration |
+
+### Cloud Sites
+
+| Resource Type | Description |
+|---------------|-------------|
+| `aws_vpc_site` | AWS VPC Site for cloud connectivity |
+| `azure_vnet_site` | Azure VNet Site for cloud connectivity |
+| `gcp_vpc_site` | GCP VPC Site for cloud connectivity |
+
+### Credentials
+
+| Resource Type | Description |
+|---------------|-------------|
+| `cloud_credentials` | Cloud provider credentials |
+
+### Identity
+
+| Resource Type | Description |
+|---------------|-------------|
+| `user` | User account (read-only) |
+
+## Usage
+
+### List Resources
+
+```bash
+vesctl configuration list <resource-type> [flags]
+```
+
+Examples:
+
+```bash
+# List all namespaces
+vesctl configuration list namespace
+
+# List HTTP load balancers in a namespace
+vesctl configuration list http_loadbalancer -n my-namespace
+```
+
+### Get Resource
+
+```bash
+vesctl configuration get <resource-type> <name> [flags]
+```
+
+Examples:
+
+```bash
+# Get namespace details
+vesctl configuration get namespace my-namespace
+
+# Get with JSON output
+vesctl configuration get http_loadbalancer my-lb -n my-ns --outfmt json
+```
+
+### Create Resource
+
+```bash
+vesctl configuration create <resource-type> -i <file> [flags]
+```
+
+Examples:
+
+```bash
+# Create HTTP load balancer from file
+vesctl configuration create http_loadbalancer -i lb.yaml
+
+# Create in specific namespace
+vesctl configuration create origin_pool -i pool.yaml -n my-namespace
+```
+
+### Delete Resource
+
+```bash
+vesctl configuration delete <resource-type> <name> [flags]
+```
+
+Examples:
+
+```bash
+# Delete with confirmation
+vesctl configuration delete http_loadbalancer my-lb -n my-namespace
+
+# Delete without confirmation
+vesctl configuration delete origin_pool my-pool -n my-namespace --yes
+```
+
+## Resource YAML Format
+
+Resources are defined in YAML format:
+
+```yaml
+metadata:
+  name: resource-name
+  namespace: my-namespace
+  labels:
+    key: value
+spec:
+  # Resource-specific configuration
+```
+
+### Example: HTTP Load Balancer
+
+```yaml
+metadata:
+  name: my-http-lb
+  namespace: my-namespace
+spec:
+  domains:
+    - example.com
+  http:
+    port: 80
+  default_route_pools:
+    - pool:
+        name: my-origin-pool
+        namespace: my-namespace
+```
+
+### Example: Origin Pool
+
+```yaml
+metadata:
+  name: my-origin-pool
+  namespace: my-namespace
+spec:
+  origin_servers:
+    - public_ip:
+        ip: 192.168.1.100
+  port: 8080
+  healthcheck:
+    - name: my-healthcheck
+      namespace: my-namespace
+```

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,66 @@
+/* vesctl Documentation Custom Styles */
+
+/* Terminal-style code blocks */
+.md-typeset code {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+}
+
+/* Command output styling */
+.md-typeset pre > code {
+  font-size: 0.85em;
+}
+
+/* Admonition styling */
+.md-typeset .admonition.note {
+  border-left-color: #7c4dff;
+}
+
+/* Table styling */
+.md-typeset table:not([class]) {
+  font-size: 0.85em;
+}
+
+.md-typeset table:not([class]) th {
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+/* Code in tables */
+.md-typeset table:not([class]) code {
+  font-size: 0.9em;
+  padding: 0.1em 0.4em;
+}
+
+/* Header styling */
+.md-typeset h1 {
+  font-weight: 700;
+}
+
+/* Footer link styling */
+.md-footer-meta__inner {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+}
+
+/* Navigation improvements */
+.md-nav__link {
+  font-size: 0.75rem;
+}
+
+/* Search improvements */
+.md-search__input {
+  font-size: 0.9rem;
+}
+
+/* Inline code improvements */
+.md-typeset :not(pre) > code {
+  padding: 0.1em 0.3em;
+  border-radius: 3px;
+}
+
+/* Tab styling */
+.md-typeset .tabbed-labels > label {
+  font-size: 0.75rem;
+  font-weight: 600;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,93 @@
+site_name: vesctl Documentation
+site_description: Open-source CLI for F5 Distributed Cloud
+site_url: https://robinmordasiewicz.github.io/vesctl/
+repo_name: robinmordasiewicz/vesctl
+repo_url: https://github.com/robinmordasiewicz/vesctl
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: deep purple
+      accent: purple
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: deep purple
+      accent: purple
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.path
+    - navigation.top
+    - navigation.footer
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.code.annotate
+    - content.tabs.link
+  icon:
+    repo: fontawesome/brands/github
+
+plugins:
+  - search
+  - minify:
+      minify_html: true
+  - git-revision-date-localized:
+      enable_creation_date: true
+      type: date
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.details
+  - pymdownx.mark
+  - admonition
+  - tables
+  - toc:
+      permalink: true
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/robinmordasiewicz/vesctl
+  generator: false
+
+extra_css:
+  - stylesheets/extra.css
+
+nav:
+  - Home: index.md
+  - Getting Started:
+    - getting-started/index.md
+    - Installation: getting-started/installation.md
+    - Quick Start: getting-started/quickstart.md
+    - Authentication: getting-started/authentication.md
+  - Commands:
+    - commands/index.md
+    - Configuration: commands/configuration.md
+    - Request: commands/request.md
+    - Site: commands/site.md
+    - API Endpoint: commands/api-endpoint.md
+    - Utilities: commands/utilities.md
+  - Reference:
+    - reference/index.md
+    - Global Flags: reference/global-flags.md
+    - Environment Variables: reference/environment-variables.md
+    - Resources: reference/resources.md
+  - Examples:
+    - examples/index.md
+    - Load Balancers: examples/load-balancer.md
+    - Cloud Sites: examples/cloud-sites.md

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,5 @@
+mkdocs>=1.5.0
+mkdocs-material>=9.5.0
+mkdocs-minify-plugin>=0.7.0
+mkdocs-git-revision-date-localized-plugin>=1.2.0
+pymdown-extensions>=10.0

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -1,0 +1,264 @@
+#!/bin/bash
+# generate-docs.sh - Generate command reference documentation from vesctl CLI
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DOCS_DIR="${PROJECT_ROOT}/docs"
+
+# Build vesctl if needed
+if [[ ! -x "${PROJECT_ROOT}/vesctl" ]]; then
+    echo "Building vesctl..."
+    cd "$PROJECT_ROOT"
+    go build -o vesctl .
+fi
+
+VESCTL="${PROJECT_ROOT}/vesctl"
+
+echo "Generating command documentation..."
+
+# Generate configuration command docs
+cat > "${DOCS_DIR}/commands/configuration.md" << 'HEADER'
+# Configuration Commands
+
+The `vesctl configuration` command group manages F5 Distributed Cloud resources.
+
+## Overview
+
+```text
+HEADER
+
+"$VESCTL" configuration --help >> "${DOCS_DIR}/commands/configuration.md" 2>&1 || true
+
+cat >> "${DOCS_DIR}/commands/configuration.md" << 'MIDDLE'
+```
+
+## Subcommands
+
+### List Resources
+
+List all resources of a specific type:
+
+```text
+MIDDLE
+
+"$VESCTL" configuration list --help >> "${DOCS_DIR}/commands/configuration.md" 2>&1 || true
+
+cat >> "${DOCS_DIR}/commands/configuration.md" << 'FOOTER'
+```
+
+### Get Resource
+
+Get details of a specific resource:
+
+```text
+FOOTER
+
+"$VESCTL" configuration get --help >> "${DOCS_DIR}/commands/configuration.md" 2>&1 || true
+
+cat >> "${DOCS_DIR}/commands/configuration.md" << 'END'
+```
+
+### Create Resource
+
+Create a new resource from a YAML/JSON file:
+
+```text
+END
+
+"$VESCTL" configuration create --help >> "${DOCS_DIR}/commands/configuration.md" 2>&1 || true
+
+cat >> "${DOCS_DIR}/commands/configuration.md" << 'END2'
+```
+
+### Replace Resource
+
+Replace an existing resource:
+
+```text
+END2
+
+"$VESCTL" configuration replace --help >> "${DOCS_DIR}/commands/configuration.md" 2>&1 || true
+
+cat >> "${DOCS_DIR}/commands/configuration.md" << 'END3'
+```
+
+### Delete Resource
+
+Delete a resource:
+
+```text
+END3
+
+"$VESCTL" configuration delete --help >> "${DOCS_DIR}/commands/configuration.md" 2>&1 || true
+
+echo '```' >> "${DOCS_DIR}/commands/configuration.md"
+
+# Generate request command docs
+cat > "${DOCS_DIR}/commands/request.md" << 'HEADER'
+# Request Commands
+
+The `vesctl request` command group provides low-level API access.
+
+## Overview
+
+```text
+HEADER
+
+"$VESCTL" request --help >> "${DOCS_DIR}/commands/request.md" 2>&1 || true
+
+cat >> "${DOCS_DIR}/commands/request.md" << 'MIDDLE'
+```
+
+## Subcommands
+
+### RPC Request
+
+Execute custom API RPC calls:
+
+```text
+MIDDLE
+
+"$VESCTL" request rpc --help >> "${DOCS_DIR}/commands/request.md" 2>&1 || true
+
+cat >> "${DOCS_DIR}/commands/request.md" << 'FOOTER'
+```
+
+### Secrets
+
+Manage secrets:
+
+```text
+FOOTER
+
+"$VESCTL" request secrets --help >> "${DOCS_DIR}/commands/request.md" 2>&1 || true
+
+echo '```' >> "${DOCS_DIR}/commands/request.md"
+
+# Generate site command docs
+cat > "${DOCS_DIR}/commands/site.md" << 'HEADER'
+# Site Commands
+
+The `vesctl site` command group manages cloud and edge sites.
+
+## Overview
+
+```text
+HEADER
+
+"$VESCTL" site --help >> "${DOCS_DIR}/commands/site.md" 2>&1 || true
+
+echo '```' >> "${DOCS_DIR}/commands/site.md"
+
+# Generate api-endpoint command docs
+cat > "${DOCS_DIR}/commands/api-endpoint.md" << 'HEADER'
+# API Endpoint Commands
+
+The `vesctl api-endpoint` command group manages API endpoint discovery.
+
+## Overview
+
+```text
+HEADER
+
+"$VESCTL" api-endpoint --help >> "${DOCS_DIR}/commands/api-endpoint.md" 2>&1 || true
+
+echo '```' >> "${DOCS_DIR}/commands/api-endpoint.md"
+
+# Generate utilities docs
+cat > "${DOCS_DIR}/commands/utilities.md" << 'HEADER'
+# Utility Commands
+
+Additional utility commands for vesctl.
+
+## Version
+
+Display version information:
+
+```text
+HEADER
+
+"$VESCTL" version --help >> "${DOCS_DIR}/commands/utilities.md" 2>&1 || true
+
+cat >> "${DOCS_DIR}/commands/utilities.md" << 'MIDDLE'
+```
+
+### Example Output
+
+```text
+MIDDLE
+
+"$VESCTL" version >> "${DOCS_DIR}/commands/utilities.md" 2>&1 || true
+
+cat >> "${DOCS_DIR}/commands/utilities.md" << 'FOOTER'
+```
+
+## Completion
+
+Generate shell completion scripts:
+
+```text
+FOOTER
+
+"$VESCTL" completion --help >> "${DOCS_DIR}/commands/utilities.md" 2>&1 || true
+
+cat >> "${DOCS_DIR}/commands/utilities.md" << 'END'
+```
+
+## Configure
+
+Interactive configuration setup:
+
+```text
+END
+
+"$VESCTL" configure --help >> "${DOCS_DIR}/commands/utilities.md" 2>&1 || true
+
+echo '```' >> "${DOCS_DIR}/commands/utilities.md"
+
+# Generate resources list
+cat > "${DOCS_DIR}/reference/resources.md" << 'HEADER'
+# Supported Resources
+
+vesctl supports the following F5 Distributed Cloud resource types.
+
+## Resource Types
+
+The following resources can be managed with `vesctl configuration` commands:
+
+| Resource Type | Description |
+|---------------|-------------|
+HEADER
+
+# Extract resource types from configuration list help
+"$VESCTL" configuration list --help 2>&1 | grep -E '^\s+[a-z]' | while read -r line; do
+    resource=$(echo "$line" | awk '{print $1}')
+    if [[ -n "$resource" ]]; then
+        echo "| \`$resource\` | F5 XC resource type |" >> "${DOCS_DIR}/reference/resources.md"
+    fi
+done
+
+cat >> "${DOCS_DIR}/reference/resources.md" << 'FOOTER'
+
+## Usage Examples
+
+### List all namespaces
+
+```bash
+vesctl configuration list namespace
+```
+
+### Get a specific namespace
+
+```bash
+vesctl configuration get namespace my-namespace
+```
+
+### Create a resource from file
+
+```bash
+vesctl configuration create namespace -i namespace.yaml
+```
+FOOTER
+
+echo "Documentation generated successfully!"


### PR DESCRIPTION
## Summary
- Add MkDocs configuration with Material theme for documentation
- Add comprehensive documentation for commands, examples, and reference guides
- Add GitHub Actions workflow for automatic documentation deployment to GitHub Pages
- Add generate-docs.sh script for auto-generating command documentation from vesctl

## Documentation Structure
- **Getting Started**: Installation, authentication, quickstart
- **Commands**: API endpoint, configuration, request, site, utilities
- **Examples**: Cloud sites, load balancer configurations
- **Reference**: Environment variables, global flags, resources

## Test plan
- [x] Verify MkDocs builds successfully
- [x] Check GitHub Actions workflow syntax
- [ ] Verify GitHub Pages deployment after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)