### PR TITLE
docs: Improve command documentation and fix version reference

### DIFF
--- a/docs/commands/api-endpoint.md
+++ b/docs/commands/api-endpoint.md
@@ -1,6 +1,6 @@
 # API Endpoint Commands
 
-The `vesctl api-endpoint` command group manages API endpoint discovery.
+The `vesctl api-endpoint` command group manages API endpoint discovery and security.
 
 ## Overview
 
@@ -8,40 +8,224 @@ The `vesctl api-endpoint` command group manages API endpoint discovery.
 vesctl api-endpoint --help
 ```
 
-## Description
+API endpoint commands help you discover, monitor, and manage API endpoints in your
+F5 Distributed Cloud tenant. This is essential for API security, governance,
+and documentation.
 
-API endpoint commands help discover and manage API endpoints in your F5 XC tenant. This is useful for API security and management features.
+## Why API Discovery Matters
+
+- **Security visibility** - Identify all APIs exposed through your load balancers
+- **Shadow API detection** - Discover undocumented or forgotten endpoints
+- **Compliance** - Ensure all APIs are properly secured and monitored
+- **Documentation** - Generate accurate API inventories
 
 ## Common Operations
 
 ### List Discovered Endpoints
 
+View all discovered API endpoints in a namespace:
+
 ```bash
-vesctl api-endpoint list -n <namespace>
+vesctl api-endpoint list -n my-namespace
+```
+
+**Example Output:**
+
+```text
+NAME                    METHOD    PATH              LOAD BALANCER
+api-users-get           GET       /api/users        my-http-lb
+api-users-post          POST      /api/users        my-http-lb
+api-orders-get          GET       /api/orders       my-http-lb
+api-health              GET       /health           my-http-lb
 ```
 
 ### Get Endpoint Details
 
+Retrieve detailed information about a specific endpoint:
+
 ```bash
-vesctl api-endpoint get <endpoint-name> -n <namespace>
+vesctl api-endpoint get api-users-get -n my-namespace
 ```
 
-## Related Resources
-
-API endpoint discovery works with:
-
-- HTTP Load Balancers
-- API Definitions
-- Service Policies
-
-## Configuration via Resources
-
-For full API definition management, use configuration commands:
+**With YAML output:**
 
 ```bash
-# List API definitions
-vesctl configuration list api_definition -n my-namespace
+vesctl api-endpoint get api-users-get -n my-namespace --outfmt yaml
+```
+
+### Filter by Load Balancer
+
+List endpoints for a specific HTTP load balancer:
+
+```bash
+vesctl api-endpoint list -n my-namespace --lb my-http-lb
+```
+
+## Discovery Workflow
+
+### Step 1: Enable API Discovery
+
+API discovery is configured on your HTTP load balancer. Ensure your load balancer has API discovery enabled:
+
+```yaml
+metadata:
+  name: my-http-lb
+  namespace: my-namespace
+spec:
+  domains:
+    - api.example.com
+  api_discovery:
+    enable: true
+    discovered_api_settings:
+      purge_duration_for_inactive_endpoints: 168h
+```
+
+### Step 2: Deploy the Load Balancer
+
+```bash
+vesctl configuration create http_loadbalancer -i lb-with-discovery.yaml
+```
+
+### Step 3: Generate Traffic
+
+Send traffic through the load balancer to trigger endpoint discovery. The system
+analyzes request patterns to identify API endpoints.
+
+### Step 4: Review Discovered Endpoints
+
+```bash
+# List all discovered endpoints
+vesctl api-endpoint list -n my-namespace
+
+# Export to JSON for analysis
+vesctl api-endpoint list -n my-namespace --outfmt json > endpoints.json
+```
+
+### Step 5: Create API Definition
+
+Use discovered endpoints to create a formal API definition:
+
+```bash
+# Get endpoint details
+vesctl api-endpoint get api-users-get -n my-namespace --outfmt yaml > endpoint.yaml
 
 # Create API definition
 vesctl configuration create api_definition -i api-def.yaml
 ```
+
+## API Definition Management
+
+For comprehensive API management, use configuration commands with API definitions:
+
+### List API Definitions
+
+```bash
+vesctl configuration list api_definition -n my-namespace
+```
+
+### Create API Definition
+
+**api-definition.yaml:**
+
+```yaml
+metadata:
+  name: my-api-definition
+  namespace: my-namespace
+spec:
+  swagger:
+    openapi: "3.0.0"
+    info:
+      title: "My API"
+      version: "1.0.0"
+    paths:
+      /api/users:
+        get:
+          summary: "List users"
+        post:
+          summary: "Create user"
+```
+
+```bash
+vesctl configuration create api_definition -i api-definition.yaml
+```
+
+### Get API Definition
+
+```bash
+vesctl configuration get api_definition my-api-definition -n my-namespace --outfmt yaml
+```
+
+## Integration with Security Policies
+
+Discovered endpoints can be protected with service policies:
+
+### Create Endpoint-Specific Policy
+
+```yaml
+metadata:
+  name: protect-user-api
+  namespace: my-namespace
+spec:
+  algo: FIRST_MATCH
+  rules:
+    - metadata:
+        name: block-unauthorized
+      spec:
+        action: DENY
+        api_endpoint:
+          methods:
+            - POST
+            - DELETE
+          path:
+            prefix: /api/users
+```
+
+```bash
+vesctl configuration create service_policy -i policy.yaml
+```
+
+## Flags
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `-n, --namespace` | `-n` | Target namespace |
+| `--lb` | | Filter by load balancer name |
+| `--outfmt` | `-o` | Output format (json, yaml, table) |
+
+## Best Practices
+
+1. **Enable discovery early** - Configure API discovery when creating load balancers
+2. **Regular reviews** - Periodically review discovered endpoints for shadow APIs
+3. **Document findings** - Export discovered endpoints and create formal API definitions
+4. **Apply security** - Use service policies to protect discovered endpoints
+5. **Monitor changes** - Track new endpoints appearing in your environment
+
+## Troubleshooting
+
+### No Endpoints Discovered
+
+If no endpoints appear:
+
+1. Verify API discovery is enabled on the load balancer
+2. Confirm traffic is flowing through the load balancer
+3. Check the namespace is correct
+4. Allow time for discovery (endpoints appear after traffic analysis)
+
+```bash
+# Check load balancer configuration
+vesctl configuration get http_loadbalancer my-lb -n my-namespace --outfmt yaml | grep -A5 api_discovery
+```
+
+### Debug Mode
+
+Enable verbose output for troubleshooting:
+
+```bash
+vesctl --debug api-endpoint list -n my-namespace
+```
+
+## Related Commands
+
+- [configuration](configuration.md) - Manage API definitions and policies
+- [request](request.md) - Low-level API access
+- [Load Balancer Examples](../examples/load-balancer.md) - HTTP load balancer configuration

--- a/docs/commands/request.md
+++ b/docs/commands/request.md
@@ -1,6 +1,6 @@
 # Request Commands
 
-The `vesctl request` command group provides low-level API access.
+The `vesctl request` command group provides low-level API access for advanced operations.
 
 ## Overview
 
@@ -8,58 +8,163 @@ The `vesctl request` command group provides low-level API access.
 vesctl request --help
 ```
 
+The request commands enable direct interaction with the F5 Distributed Cloud API,
+allowing you to execute custom RPC calls and manage secrets programmatically.
+
 ## Subcommands
 
 ### RPC Request
 
-Execute custom API RPC calls:
+Execute custom API RPC calls for operations not covered by standard commands:
 
 ```bash
 vesctl request rpc <method> <path> [flags]
 ```
 
-**Examples:**
+**Supported Methods:**
+
+| Method | Description |
+|--------|-------------|
+| `GET` | Retrieve resources or data |
+| `POST` | Create resources or execute actions |
+| `PUT` | Update existing resources |
+| `DELETE` | Remove resources |
+
+## Common Use Cases
+
+### Retrieve Tenant Information
 
 ```bash
-# GET request
-vesctl request rpc GET /api/web/namespaces
-
-# POST request with body
-vesctl request rpc POST /api/some/endpoint -i request.json
+vesctl request rpc GET /api/web/tenant
 ```
 
-### Secrets
+**Example Output:**
 
-Manage secrets:
+```json
+{
+  "name": "my-tenant",
+  "uid": "abc123-def456",
+  "tenant_type": "CUSTOMER"
+}
+```
+
+### List Available API Endpoints
+
+```bash
+vesctl request rpc GET /api
+```
+
+### Query Namespace Details
+
+```bash
+vesctl request rpc GET /api/web/namespaces/my-namespace
+```
+
+### Execute Custom Queries
+
+For complex queries, use a request body file:
+
+**query.json:**
+
+```json
+{
+  "namespace": "my-namespace",
+  "label_selector": "app=web"
+}
+```
+
+```bash
+vesctl request rpc POST /api/custom/query -i query.json
+```
+
+## Advanced Examples
+
+### GET with Output Formatting
+
+```bash
+# JSON output
+vesctl request rpc GET /api/web/namespaces --outfmt json
+
+# YAML output
+vesctl request rpc GET /api/web/namespaces --outfmt yaml
+```
+
+### POST with Request Body
+
+Create a custom resource using a JSON payload:
+
+**payload.json:**
+
+```json
+{
+  "metadata": {
+    "name": "my-resource",
+    "namespace": "my-namespace"
+  },
+  "spec": {
+    "description": "Created via RPC"
+  }
+}
+```
+
+```bash
+vesctl request rpc POST /api/config/namespaces/my-namespace/resources -i payload.json
+```
+
+### Debug API Calls
+
+Enable verbose output to troubleshoot API interactions:
+
+```bash
+vesctl --debug request rpc GET /api/web/tenant
+```
+
+This displays:
+
+- Request URL and headers
+- Response status code
+- Response body
+
+## Secrets Management
+
+Manage secrets through the request interface:
 
 ```bash
 vesctl request secrets [subcommand] [flags]
 ```
 
-## Common Use Cases
-
-### Custom API Calls
-
-For API endpoints not covered by standard commands:
+### List Secrets
 
 ```bash
-# List available APIs
-vesctl request rpc GET /api
-
-# Get tenant information
-vesctl request rpc GET /api/web/tenant
+vesctl request secrets list -n my-namespace
 ```
 
-### Working with Secrets
+### Get Secret Details
 
 ```bash
-# Get secret help
-vesctl request secrets --help
+vesctl request secrets get my-secret -n my-namespace
 ```
 
 ## Flags
 
-| Flag | Description |
-|------|-------------|
-| `-i, --input-file` | Request body from file |
-| `--outfmt` | Output format |
+| Flag | Short | Description |
+|------|-------|-------------|
+| `-i, --input-file` | `-i` | Request body from file (JSON or YAML) |
+| `--outfmt` | `-o` | Output format (json, yaml, table) |
+| `-n, --namespace` | `-n` | Target namespace |
+
+## Best Practices
+
+1. **Use standard commands first** - The `configuration` commands handle most operations
+2. **Test with GET** - Verify endpoints before making changes
+3. **Enable debug mode** - Use `--debug` when troubleshooting
+4. **Save responses** - Redirect output to files for complex operations
+
+```bash
+vesctl request rpc GET /api/web/namespaces --outfmt json > namespaces.json
+```
+
+## Related Commands
+
+- [configuration](configuration.md) - Standard resource management
+- [api-endpoint](api-endpoint.md) - API endpoint discovery

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -8,7 +8,7 @@ Before installing vesctl, ensure you have:
 
 - A terminal or command prompt
 - Network access to download the binary
-- (Optional) Go 1.23+ if building from source
+- (Optional) Go 1.22+ if building from source
 
 ## Installation Methods
 


### PR DESCRIPTION
## Summary

- Fix Go version requirement from 1.23 to 1.22 in getting-started guide (matches go.mod)
- Expand `request.md` with comprehensive RPC examples, HTTP methods table, debug instructions, and secrets management documentation
- Expand `api-endpoint.md` with API discovery workflow, security policy integration, troubleshooting guide, and best practices

## Changes

| File | Before | After | Description |
|------|--------|-------|-------------|
| `docs/getting-started/index.md` | Go 1.23+ | Go 1.22+ | Version correction |
| `docs/commands/request.md` | 66 lines | 171 lines | Comprehensive RPC documentation |
| `docs/commands/api-endpoint.md` | 48 lines | 231 lines | Full discovery workflow guide |

## Test plan

- [ ] Verify markdown linting passes
- [ ] Review documentation renders correctly in MkDocs
- [ ] Confirm examples are accurate for vesctl commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)