### PR TITLE
fix: Comprehensive skip logic for vesctl-0.2.35 buggy commands

### DIFF
--- a/claudedocs/compatibility/run-all-tests.sh
+++ b/claudedocs/compatibility/run-all-tests.sh
@@ -189,9 +189,16 @@ run_phase() {
         PHASE_TIME[$phase]="${duration}s"
 
         # Extract pass/fail/warn counts from log (strip ANSI codes first)
-        local pass_count=$(sed 's/\x1b\[[0-9;]*m//g' "${RESULTS_DIR}/phase${phase}.log" 2>/dev/null | grep -c '\[PASS\]' || echo 0)
-        local fail_count=$(sed 's/\x1b\[[0-9;]*m//g' "${RESULTS_DIR}/phase${phase}.log" 2>/dev/null | grep -c '\[FAIL\]' || echo 0)
-        local warn_count=$(sed 's/\x1b\[[0-9;]*m//g' "${RESULTS_DIR}/phase${phase}.log" 2>/dev/null | grep -c '\[WARN\]' || echo 0)
+        # Use sed with extended regex and tr to ensure clean output
+        local clean_log=$(sed 's/\x1b\[[0-9;]*m//g' "${RESULTS_DIR}/phase${phase}.log" 2>/dev/null | tr -d '\r')
+        local pass_count=$(echo "$clean_log" | grep -c '\[PASS\]' 2>/dev/null || echo 0)
+        local fail_count=$(echo "$clean_log" | grep -c '\[FAIL\]' 2>/dev/null || echo 0)
+        local warn_count=$(echo "$clean_log" | grep -c '\[WARN\]' 2>/dev/null || echo 0)
+
+        # Ensure counts are valid integers
+        pass_count=${pass_count:-0}
+        fail_count=${fail_count:-0}
+        warn_count=${warn_count:-0}
 
         PHASE_PASS[$phase]=$pass_count
         PHASE_FAIL[$phase]=$fail_count

--- a/claudedocs/compatibility/tests/phase5-resources/test-resource-help.sh
+++ b/claudedocs/compatibility/tests/phase5-resources/test-resource-help.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 # test-resource-help.sh - Test help text compatibility for multiple resource types
 # Phase 5: Multi-Resource Validation
+#
+# NOTE: vesctl-0.2.35 has bugs where "configuration list <resource> --help" hangs.
+# All "list" tests are skipped for this reason.
+# The is_buggy_command() function from lib/common.sh handles this detection.
 
 set +e
 
@@ -194,9 +198,17 @@ echo ""
 for resource in "${RESOURCES[@]}"; do
     echo "Testing: $resource"
 
-    # Test list --help
-    test_help_structure "list-${resource}" configuration list "$resource" || true
-    test_flags_section "list-${resource}-flags" configuration list "$resource" || true
+    # Test list --help - SKIP due to vesctl-0.2.35 bug
+    if is_buggy_command "configuration" "list"; then
+        log_skip "list-${resource} (vesctl-0.2.35 hangs on configuration list --help)"
+        mkdir -p "${RESULTS_DIR}/list-${resource}"
+        echo "SKIP" > "${RESULTS_DIR}/list-${resource}/result.txt"
+        mkdir -p "${RESULTS_DIR}/list-${resource}-flags"
+        echo "SKIP" > "${RESULTS_DIR}/list-${resource}-flags/result.txt"
+    else
+        test_help_structure "list-${resource}" configuration list "$resource" || true
+        test_flags_section "list-${resource}-flags" configuration list "$resource" || true
+    fi
 
     # Test get --help
     test_help_structure "get-${resource}" configuration get "$resource" || true
@@ -217,8 +229,14 @@ echo ""
 for resource in "${ADDITIONAL_RESOURCES[@]}"; do
     echo "Testing: $resource"
 
-    # Test list --help only
-    test_help_structure "list-${resource}" configuration list "$resource" || true
+    # Test list --help only - SKIP due to vesctl-0.2.35 bug
+    if is_buggy_command "configuration" "list"; then
+        log_skip "list-${resource} (vesctl-0.2.35 hangs on configuration list --help)"
+        mkdir -p "${RESULTS_DIR}/list-${resource}"
+        echo "SKIP" > "${RESULTS_DIR}/list-${resource}/result.txt"
+    else
+        test_help_structure "list-${resource}" configuration list "$resource" || true
+    fi
 
     echo ""
 done


### PR DESCRIPTION
## Summary
Adds comprehensive skip logic for known buggy commands in vesctl-0.2.35 that hang at 100% CPU.

## Changes

### lib/common.sh
- Added `KNOWN_BUGGY_COMMANDS` array documenting all buggy commands
- Added `is_buggy_command()` helper function for centralized detection
- Added `run_original_vesctl_safe()` wrapper with timeout protection
- Added `ORIGINAL_VESCTL_TIMEOUT` configuration (default: 10s)

### test-no-api.sh (Phase 3)
- Updated to use centralized `is_buggy_command()` function from common.sh
- Removed local buggy subcommand detection

### test-resource-help.sh (Phase 5)
- Added skip logic for all `configuration list` commands
- Properly creates SKIP result files for skipped tests

### run-all-tests.sh
- Improved ANSI code stripping using `tr` for clean output
- Added default value handling for count variables

## Known Buggy Commands in vesctl-0.2.35
Commands that hang at 100% CPU and never return:
- `configuration status --help`
- `configuration patch --help`
- `configuration replace --help`
- `configuration add-labels --help`
- `configuration remove-labels --help`
- `configuration list <any-resource> --help`

## Test plan
- [x] Phase 3 tests now skip buggy configuration subcommands
- [x] Phase 5 tests now skip all configuration list tests
- [x] Centralized buggy command list in common.sh

🤖 Generated with [Claude Code](https://claude.com/claude-code)