### PR TITLE
feat: Add API token authentication support

### DIFF
--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -22,7 +22,7 @@ vesctl is an open-source command-line interface for managing F5 Distributed Clou
 ## Authentication Methods
 1. **P12 Bundle** (recommended): Downloaded from F5 XC Console
 2. **Certificate + Key**: Extracted from P12 or separate files
-3. **Environment Variables**: VES_P12_PASSWORD, VES_SERVER_URLS, etc.
+3. **Environment Variables**: VES_P12_PASSWORD, VES_API_URL, VES_API_TOKEN, etc.
 
 ## Configuration
 - Default config file: `~/.vesconfig`

--- a/docs/getting-started/authentication.md
+++ b/docs/getting-started/authentication.md
@@ -64,6 +64,57 @@ key: /path/to/key.pem
 vesctl --cert /path/to/cert.pem --key /path/to/key.pem configuration list namespace
 ```
 
+## API Token
+
+Use an API token for authentication without managing certificate files. Ideal for CI/CD pipelines and automation.
+
+### Obtaining an API Token
+
+1. Log in to the F5 XC Console
+2. Navigate to **Administration** > **Personal Management** > **Credentials**
+3. Click **Create Credentials**
+4. Select type **API Token**
+5. Copy the generated token
+
+### Configuration
+
+**Using environment variables (recommended):**
+
+```bash
+export VES_API_TOKEN="your-api-token"
+export VES_API_URL="https://your-tenant.console.ves.volterra.io"  # Optional, overrides config
+
+vesctl configuration list namespace
+```
+
+**Using configuration file (~/.vesconfig):**
+
+```yaml
+server-urls:
+  - https://your-tenant.console.ves.volterra.io/api
+api-token: true  # Token value from VES_API_TOKEN environment variable
+```
+
+**Using interactive configuration:**
+
+```bash
+vesctl configure
+# Select option 3: API Token
+```
+
+**Using command-line flag:**
+
+```bash
+vesctl --api-token configuration list namespace
+```
+
+**Using login command:**
+
+```bash
+export VES_API_TOKEN='your-api-token'
+vesctl login --tenant my-tenant --api-token
+```
+
 ## Configuration File
 
 The default configuration file location is `~/.vesconfig`.
@@ -81,6 +132,9 @@ p12-bundle: /path/to/api-creds.p12
 # OR certificate/key authentication
 # cert: /path/to/cert.pem
 # key: /path/to/key.pem
+
+# OR API token authentication (token from VES_API_TOKEN env var)
+# api-token: true
 
 # Optional CA certificate for custom trust
 # cacert: /path/to/ca.pem
@@ -100,17 +154,19 @@ Override configuration with environment variables:
 
 | Variable | Description |
 |----------|-------------|
+| `VES_API_TOKEN` | API token for authentication |
+| `VES_API_URL` | API server URL (overrides server-urls in config) |
 | `VES_P12_PASSWORD` | Password for P12 bundle |
-| `VES_SERVER_URLS` | API server URL(s) |
-| `VES_P12_BUNDLE` | Path to P12 bundle |
+| `VES_API_URL` | API server URL(s) |
+| `VES_P12_FILE` | Path to P12 bundle |
 | `VES_CERT` | Path to client certificate |
 | `VES_KEY` | Path to client key |
 
 ### Example
 
 ```bash
-export VES_SERVER_URLS="https://your-tenant.console.ves.volterra.io/api"
-export VES_P12_BUNDLE="/path/to/api-creds.p12"
+export VES_API_URL="https://your-tenant.console.ves.volterra.io/api"
+export VES_P12_FILE="/path/to/api-creds.p12"
 export VES_P12_PASSWORD="your-password"
 
 vesctl configuration list namespace
@@ -127,9 +183,9 @@ vesctl configure
 This will prompt for:
 
 1. API server URL
-2. Authentication method (P12 or cert/key)
-3. File paths
-4. (Optional) P12 password
+2. Authentication method (P12, cert/key, or API token)
+3. File paths (for P12 or cert/key) or environment variable instructions (for API token)
+4. Default output format
 
 ## Verifying Authentication
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -25,7 +25,7 @@ Create `~/.vesconfig`:
 ```yaml
 server-urls:
   - https://your-tenant.console.ves.volterra.io/api
-p12-bundle: ~/.vesconfig/api-creds.p12
+p12-bundle: ~/api-creds.p12
 ```
 
 Set the P12 password:

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -7,7 +7,7 @@ vesctl can be configured using environment variables.
 | Variable | Description | Example |
 |----------|-------------|---------|
 | `VES_P12_PASSWORD` | Password for P12 bundle | `export VES_P12_PASSWORD="secret"` |
-| `VES_P12_BUNDLE` | Path to P12 bundle | `export VES_P12_BUNDLE="/path/to/creds.p12"` |
+| `VES_P12_FILE` | Path to P12 bundle | `export VES_P12_FILE="/path/to/creds.p12"` |
 | `VES_CERT` | Path to client certificate | `export VES_CERT="/path/to/cert.pem"` |
 | `VES_KEY` | Path to client key | `export VES_KEY="/path/to/key.pem"` |
 
@@ -15,7 +15,7 @@ vesctl can be configured using environment variables.
 
 | Variable | Description | Example |
 |----------|-------------|---------|
-| `VES_SERVER_URLS` | API server URL(s) | `export VES_SERVER_URLS="https://tenant.console.ves.volterra.io/api"` |
+| `VES_API_URL` | API server URL(s) | `export VES_API_URL="https://tenant.console.ves.volterra.io/api"` |
 | `VES_CACERT` | Path to CA certificate | `export VES_CACERT="/path/to/ca.pem"` |
 
 ## Output Variables
@@ -36,10 +36,10 @@ vesctl can be configured using environment variables.
 
 ```bash
 # Set server URL
-export VES_SERVER_URLS="https://your-tenant.console.ves.volterra.io/api"
+export VES_API_URL="https://your-tenant.console.ves.volterra.io/api"
 
 # Set P12 credentials
-export VES_P12_BUNDLE="/path/to/api-creds.p12"
+export VES_P12_FILE="/path/to/api-creds.p12"
 export VES_P12_PASSWORD="your-password"
 
 # Run command
@@ -49,7 +49,7 @@ vesctl configuration list namespace
 ### Certificate Authentication
 
 ```bash
-export VES_SERVER_URLS="https://your-tenant.console.ves.volterra.io/api"
+export VES_API_URL="https://your-tenant.console.ves.volterra.io/api"
 export VES_CERT="/path/to/cert.pem"
 export VES_KEY="/path/to/key.pem"
 
@@ -72,24 +72,24 @@ Add to your shell profile for persistent configuration:
 ### Bash (~/.bashrc)
 
 ```bash
-export VES_SERVER_URLS="https://your-tenant.console.ves.volterra.io/api"
-export VES_P12_BUNDLE="$HOME/.vesconfig/api-creds.p12"
+export VES_API_URL="https://your-tenant.console.ves.volterra.io/api"
+export VES_P12_FILE="$HOME/api-creds.p12"
 export VES_P12_PASSWORD="your-password"
 ```
 
 ### Zsh (~/.zshrc)
 
 ```bash
-export VES_SERVER_URLS="https://your-tenant.console.ves.volterra.io/api"
-export VES_P12_BUNDLE="$HOME/.vesconfig/api-creds.p12"
+export VES_API_URL="https://your-tenant.console.ves.volterra.io/api"
+export VES_P12_FILE="$HOME/api-creds.p12"
 export VES_P12_PASSWORD="your-password"
 ```
 
 ### Fish (~/.config/fish/config.fish)
 
 ```fish
-set -x VES_SERVER_URLS "https://your-tenant.console.ves.volterra.io/api"
-set -x VES_P12_BUNDLE "$HOME/.vesconfig/api-creds.p12"
+set -x VES_API_URL "https://your-tenant.console.ves.volterra.io/api"
+set -x VES_P12_FILE "$HOME/api-creds.p12"
 set -x VES_P12_PASSWORD "your-password"
 ```
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,9 @@ type Config struct {
 
 	// Key is the path to the client key file
 	Key string `yaml:"key,omitempty"`
+
+	// APIToken indicates API token authentication mode (actual token from VES_API_TOKEN env var)
+	APIToken bool `yaml:"api-token,omitempty"`
 }
 
 // rawConfig is used for flexible YAML parsing (supports both single string and array)
@@ -28,6 +31,7 @@ type rawConfig struct {
 	P12Bundle  string      `yaml:"p12-bundle"`
 	Cert       string      `yaml:"cert"`
 	Key        string      `yaml:"key"`
+	APIToken   bool        `yaml:"api-token"`
 }
 
 // Load reads and parses a vesctl config file
@@ -50,6 +54,7 @@ func Load(path string) (*Config, error) {
 		P12Bundle: raw.P12Bundle,
 		Cert:      raw.Cert,
 		Key:       raw.Key,
+		APIToken:  raw.APIToken,
 	}
 
 	// Handle server-urls as either single string or array
@@ -89,12 +94,13 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("server-urls is required")
 	}
 
-	// Must have either P12 bundle or cert/key pair
+	// Must have either P12 bundle, cert/key pair, or API token
 	hasP12 := c.P12Bundle != ""
 	hasCertKey := c.Cert != "" && c.Key != ""
+	hasAPIToken := c.APIToken
 
-	if !hasP12 && !hasCertKey {
-		return fmt.Errorf("either p12-bundle or cert/key pair is required for authentication")
+	if !hasP12 && !hasCertKey && !hasAPIToken {
+		return fmt.Errorf("authentication required: p12-bundle, cert/key pair, or api-token")
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
- Add API token as third authentication method (alongside P12 and cert/key)
- Token stored in `VES_API_TOKEN` env var, config has `api-token: true` flag
- Add `VES_API_URL` env var to override server-urls in config
- Update configure wizard with Option 3 for API token auth
- Fix incorrect env var names (`VES_SERVER_URLS` → `VES_API_URL`, `VES_P12_BUNDLE` → `VES_P12_FILE`)
- Fix `.vesconfig` directory references (it's a file, not a directory)

## Usage
```bash
export VES_API_TOKEN='your-token'
export VES_API_URL='https://tenant.console.ves.volterra.io'
vesctl --api-token configuration list namespace
```

## Test plan
- [x] Unit tests added for API token authentication
- [x] Manual testing against staging environment verified working
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)