### PR TITLE
docs: remove broken related commands links from request page

### DIFF
--- a/docs/commands/request/index.md
+++ b/docs/commands/request/index.md
@@ -163,8 +163,3 @@ vesctl request secrets get example-secret -n example-namespace
 ```bash
 vesctl request rpc GET /api/web/namespaces --outfmt json > namespaces.json
 ```
-
-## Related Commands
-
-- [configuration](configuration.md) - Standard resource management
-- [api-endpoint](api-endpoint.md) - API endpoint discovery


### PR DESCRIPTION
## Summary
Fixes broken links in the request command documentation that were left over from the previous restructuring.

## Changes
- Remove "Related Commands" section from `docs/commands/request/index.md`
- The links to `configuration.md` and `api-endpoint.md` are broken since these files were moved to subdirectories

## Type of Change
- [x] Documentation fix
- [x] Broken link cleanup