### PR TITLE
ci: temporarily disable automatic command documentation generation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,10 +52,10 @@ jobs:
       - name: Build vesctl
         run: go build -o vesctl .
 
-      - name: Generate command documentation
-        run: |
-          chmod +x scripts/generate-docs.sh
-          ./scripts/generate-docs.sh
+#      - name: Generate command documentation
+#        run: |
+#          chmod +x scripts/generate-docs.sh
+#          ./scripts/generate-docs.sh
 
       - name: Upload generated docs
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
Temporarily disables the automatic command documentation generation step in the docs workflow to prevent conflicts with manual documentation updates.

## Changes
- Comment out the `generate-docs.sh` step in `.github/workflows/docs.yml`
- Workflow still builds vesctl but skips auto-generation
- Allows manual documentation structure changes without being overwritten

## Rationale
Recent documentation restructuring (moving to subdirectories, removing reference section) would conflict with auto-generated docs. This change allows us to:
1. Continue manual documentation improvements
2. Re-enable generation once the script is updated to match new structure
3. Prevent CI failures from missing/conflicting files

## Future Work
- Update `scripts/generate-docs.sh` to generate docs in new subdirectory structure
- Re-enable automatic generation

## Type of Change
- [x] CI/CD configuration
- [x] Temporary workaround