### PR TITLE
feat: disable strict compatibility testing workflow

### DIFF
--- a/.github/workflows/compatibility-tests.yml
+++ b/.github/workflows/compatibility-tests.yml
@@ -1,24 +1,9 @@
 name: Compatibility Tests
 
+# DISABLED: No longer enforcing strict compliance with original vesctl binary
+# Test scripts remain in claudedocs/compatibility/ for reference
+# To run manually, use workflow_dispatch
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'cmd/**'
-      - 'pkg/**'
-      - '*.go'
-      - 'go.mod'
-      - 'go.sum'
-      - 'claudedocs/compatibility/**'
-  pull_request:
-    branches: [main]
-    paths:
-      - 'cmd/**'
-      - 'pkg/**'
-      - '*.go'
-      - 'go.mod'
-      - 'go.sum'
-      - 'claudedocs/compatibility/**'
   workflow_dispatch:
     inputs:
       with_api:
@@ -122,56 +107,3 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "No summary generated. Check logs for details." >> $GITHUB_STEP_SUMMARY
           fi
-
-  offline-quick:
-    name: Quick Offline Tests
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - name: Build vesctl
-        run: |
-          go build -o vesctl .
-          chmod +x vesctl
-
-      - name: Download original vesctl
-        run: |
-          curl -sL "https://vesio.azureedge.net/releases/vesctl/${{ env.ORIGINAL_VESCTL_VERSION }}/vesctl.linux-amd64.gz" | gunzip > vesctl-${{ env.ORIGINAL_VESCTL_VERSION }}
-          chmod +x vesctl-${{ env.ORIGINAL_VESCTL_VERSION }}
-
-      - name: Run Phase 1 (Configure)
-        run: |
-          export ORIGINAL_VESCTL="$(pwd)/vesctl-${{ env.ORIGINAL_VESCTL_VERSION }}"
-          export OUR_VESCTL="$(pwd)/vesctl"
-          cd claudedocs/compatibility
-          chmod +x run-all-tests.sh
-          ./run-all-tests.sh --phase 1
-
-      - name: Run Phase 5 (Multi-Resource Help)
-        run: |
-          export ORIGINAL_VESCTL="$(pwd)/vesctl-${{ env.ORIGINAL_VESCTL_VERSION }}"
-          export OUR_VESCTL="$(pwd)/vesctl"
-          cd claudedocs/compatibility
-          ./run-all-tests.sh --phase 5
-
-      - name: Run Phase 6 (Request Commands)
-        run: |
-          export ORIGINAL_VESCTL="$(pwd)/vesctl-${{ env.ORIGINAL_VESCTL_VERSION }}"
-          export OUR_VESCTL="$(pwd)/vesctl"
-          cd claudedocs/compatibility
-          ./run-all-tests.sh --phase 6
-
-      - name: Run Phase 7 (Site Commands)
-        run: |
-          export ORIGINAL_VESCTL="$(pwd)/vesctl-${{ env.ORIGINAL_VESCTL_VERSION }}"
-          export OUR_VESCTL="$(pwd)/vesctl"
-          cd claudedocs/compatibility
-          ./run-all-tests.sh --phase 7

--- a/claudedocs/compatibility/run-all-tests.sh
+++ b/claudedocs/compatibility/run-all-tests.sh
@@ -189,13 +189,15 @@ run_phase() {
         PHASE_TIME[$phase]="${duration}s"
 
         # Extract pass/fail/warn counts from log (strip ANSI codes first)
-        # Use sed with extended regex and tr to ensure clean output
-        local clean_log=$(sed 's/\x1b\[[0-9;]*m//g' "${RESULTS_DIR}/phase${phase}.log" 2>/dev/null | tr -d '\r')
-        local pass_count=$(echo "$clean_log" | grep -c '\[PASS\]' 2>/dev/null || echo 0)
-        local fail_count=$(echo "$clean_log" | grep -c '\[FAIL\]' 2>/dev/null || echo 0)
-        local warn_count=$(echo "$clean_log" | grep -c '\[WARN\]' 2>/dev/null || echo 0)
+        # Use grep directly on the file to avoid issues with large logs and newlines
+        local pass_count=$(grep -c '\[PASS\]' "${RESULTS_DIR}/phase${phase}.log" 2>/dev/null | tr -d '\n\r' || echo 0)
+        local fail_count=$(grep -c '\[FAIL\]' "${RESULTS_DIR}/phase${phase}.log" 2>/dev/null | tr -d '\n\r' || echo 0)
+        local warn_count=$(grep -c '\[WARN\]' "${RESULTS_DIR}/phase${phase}.log" 2>/dev/null | tr -d '\n\r' || echo 0)
 
-        # Ensure counts are valid integers
+        # Ensure counts are valid integers (strip any remaining whitespace)
+        pass_count=$(echo "$pass_count" | tr -d '[:space:]')
+        fail_count=$(echo "$fail_count" | tr -d '[:space:]')
+        warn_count=$(echo "$warn_count" | tr -d '[:space:]')
         pass_count=${pass_count:-0}
         fail_count=${fail_count:-0}
         warn_count=${warn_count:-0}


### PR DESCRIPTION
## Description
This PR disables the strict compatibility testing workflow that was previously enforcing compliance with the original vesctl binary.

## Changes Made

### 1. GitHub Workflow (.github/workflows/compatibility-tests.yml)
- Disabled automatic push/pull_request triggers
- Retained workflow_dispatch for manual testing
- Removed offline-quick job
- Added documentation comment

### 2. Test Script (claudedocs/compatibility/run-all-tests.sh)
- Fixed log parsing for better accuracy
- Improved whitespace handling
- More robust grep-based counting

## Rationale
Compatibility tests are no longer enforced automatically but remain available for manual execution when needed.

Resolves #43