### PR TITLE
fix: ensure Homebrew tap syncs with every release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,6 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
-      - ".github/workflows/docs.yml"
-      - ".github/workflows/ci.yml"
-      - ".github/workflows/compatibility-tests.yml"
 
 permissions:
   contents: write
@@ -24,13 +18,25 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Check for code changes
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            code:
+              - '**.go'
+              - 'go.mod'
+              - 'go.sum'
+
       - name: Set up Go
+        if: steps.changes.outputs.code == 'true'
         uses: actions/setup-go@v5
         with:
           go-version: "1.22"
           cache: true
 
       - name: Run tests
+        if: steps.changes.outputs.code == 'true'
         run: go test -v -race ./pkg/...
 
   semantic-release:


### PR DESCRIPTION
## Summary
- Remove paths-ignore from workflow trigger so semantic-release and GoReleaser always run
- Add dorny/paths-filter to conditionally skip tests when only documentation changes occur
- Fixes the Homebrew tap staying at v1.3.0 while GitHub releases progressed to v4.3.0

## Test plan
- [ ] Verify release workflow triggers on merge
- [ ] Confirm semantic-release runs and creates new version
- [ ] Verify GoReleaser builds binaries and updates Homebrew tap
- [ ] Test `brew upgrade vesctl` shows new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)