### PR TITLE
fix: improve install script error handling and output redirection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -269,7 +269,7 @@ Try one of:
 # ============================================
 
 get_latest_version() {
-    status "Fetching latest version from GitHub..."
+    status "Fetching latest version from GitHub..." >&2
 
     RESPONSE=$(http_get "$GITHUB_API")
 
@@ -283,10 +283,14 @@ Or download manually from:
   https://github.com/${GITHUB_REPO}/releases/latest"
     fi
 
-    # Try to parse with jq if available, otherwise use sed
+    # Try to parse with jq if available, fall back to sed if jq fails or isn't installed
+    VERSION=""
     if command_exists jq; then
         VERSION=$(echo "$RESPONSE" | jq -r '.tag_name' 2>/dev/null | sed 's/^v//')
-    else
+    fi
+
+    # Fall back to sed if jq failed or wasn't available
+    if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
         VERSION=$(echo "$RESPONSE" | grep '"tag_name":' | sed -E 's/.*"v?([^"]+)".*/\1/')
     fi
 


### PR DESCRIPTION
## Description
This PR improves the install.sh script's error handling and fixes output redirection for better reliability in automated environments.

## Changes Made

### Output Redirection Fix
- Redirect status message to stderr: `status "..." >&2`
- Ensures clean stdout for version detection
- Separates user messages from data output

### Enhanced jq Fallback Logic
- Initialize VERSION variable before parsing
- Check if jq returned empty or "null"
- Proper fallback from jq to sed
- More robust version detection

### Code Improvement

**Before:**
```bash
if command_exists jq; then
    VERSION=$(... | jq ...)
else
    VERSION=$(... | sed ...)
fi
```

**After:**
```bash
VERSION=""
if command_exists jq; then
    VERSION=$(... | jq ... 2>/dev/null ...)
fi

if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
    VERSION=$(... | sed ...)
fi
```

## Benefits

✅ More reliable: Handles jq failures gracefully
✅ Better UX: Status messages don't interfere with output
✅ Automation friendly: Clean stdout for parsing
✅ Robust: Multiple fallback layers
✅ Error prevention: Catches edge cases

## Use Cases

**Clean piping:**
```bash
VERSION=$(./install.sh --version)  # No status message contamination
```

**CI/CD automation:**
- Status messages → stderr (visible in logs)
- Version → stdout (captured by scripts)

## Statistics
- **1 file changed**
- **7 insertions(+)**
- **3 deletions(-)**

Resolves #60