### PR TITLE
fix: use dynamic cache keys to prevent tar restore/save failures

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -126,7 +126,9 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: spec-hash-cached.txt
-          key: vesctl-spec-hash-v1
+          key: vesctl-spec-hash-${{ github.run_number }}
+          restore-keys: |
+            vesctl-spec-hash-
 
       - name: Compare spec hashes
         if: github.event_name != 'workflow_run' || steps.check-release.outputs.recent_release == 'true'
@@ -200,7 +202,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: spec-hash-cached.txt
-          key: vesctl-spec-hash-v1
+          key: vesctl-spec-hash-${{ github.run_number }}
 
       - name: Upload generated docs
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

- Fix cache warnings in docs.yml workflow by using dynamic cache keys
- Change spec hash cache from static key (`vesctl-spec-hash-v1`) to dynamic key with `github.run_number`
- Add `restore-keys` fallback for cache restore

## Problem

The docs.yml workflow shows 3 warnings on every run:

```
1. Check Spec Changes: Failed to restore: "/usr/bin/tar" failed with error: exit code 2
2. Generate Command Docs: Cache save failed.
3. Generate Command Docs: Failed to restore: "/usr/bin/tar" failed with error: exit code 2
```

## Root Cause

GitHub Actions caches are **immutable** - they cannot be overwritten. The static key `vesctl-spec-hash-v1` means:
- First run: Cache created successfully
- Subsequent runs: Cache save fails because entry already exists
- Tar errors occur due to cache state conflicts

## Solution

Use dynamic cache keys with `github.run_number`:
- **Restore**: `vesctl-spec-hash-${{ github.run_number }}` with `restore-keys: vesctl-spec-hash-` fallback
- **Save**: `vesctl-spec-hash-${{ github.run_number }}`

This ensures each run creates a unique cache entry, while the `restore-keys` prefix matching allows falling back to the most recent previous cache.

## Test plan

- [ ] Workflow runs without cache warnings
- [ ] Spec hash caching still functions correctly (cache hit on unchanged spec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)