### PR TITLE
fix: resolve GoReleaser workflow warnings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,12 +122,12 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.22"
-          cache: true
+          cache: false
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
+          version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Pin GoReleaser version to `~> v2` instead of `latest`
- Disable Go module caching in goreleaser job

## Problem

The release.yml workflow shows 2 warnings:

```
1. GoReleaser: You are using 'latest' as default version. Will lock to '~> v2'.
2. GoReleaser: Failed to restore: "/usr/bin/tar" failed with error: exit code 2
```

## Root Cause

1. **GoReleaser version warning**: The `goreleaser-action@v6` emits a deprecation warning when `version: latest` is used, encouraging explicit version pinning

2. **Cache tar failure**: The `actions/setup-go@v5` built-in cache (`cache: true`) uses immutable GitHub Actions caches. When the cache key already exists, restore fails with tar exit code 2

## Solution

1. Change `version: latest` to `version: "~> v2"` for explicit version control
2. Change `cache: true` to `cache: false` in the goreleaser job (caching provides minimal benefit for infrequent release builds)

## Test plan

- [ ] Next release workflow run completes without these warnings
- [ ] GoReleaser still builds and publishes releases correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)