### PR TITLE
fix: resolve CI workflow cache and GoReleaser warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.22"
-          cache: true
+          cache: false
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v4
@@ -55,7 +55,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
-          cache: true
+          cache: false
 
       - name: Download dependencies
         run: go mod download
@@ -83,7 +83,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.22"
-          cache: true
+          cache: false
 
       - name: Build for all platforms
         run: |
@@ -128,16 +128,16 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.22"
-          cache: true
+          cache: false
 
       - name: Check GoReleaser config
         uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
+          version: "~> v2"
           args: check
 
       - name: Run GoReleaser (dry run)
         uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
+          version: "~> v2"
           args: release --snapshot --skip=publish --clean


### PR DESCRIPTION
## Summary

- Disable Go module caching in all CI jobs to prevent cache conflicts
- Pin GoReleaser version to `~> v2` instead of `latest`

## Problem

The ci.yml workflow shows 7 warnings:

```
1. Test (ubuntu-latest, 1.21): Failed to restore: tar exit code 2
2. Test (ubuntu-latest, 1.22): Failed to restore: tar exit code 2
3. Test (macos-latest, 1.22): Failed to restore: gtar exit code 2
4. Lint: Failed to save: services unavailable
5. Lint: Failed to restore: Cache service 400
6. Lint: Failed to restore: tar exit code 2
7. Test (macos-latest, 1.21): Failed to restore: gtar exit code 2
```

## Root Cause

1. **Cache tar failures**: `actions/setup-go@v5` with `cache: true` uses immutable GitHub caches. When multiple matrix jobs or runs try to use/save the same cache key, conflicts occur.

2. **GoReleaser version warning**: Using `version: latest` triggers a deprecation warning.

## Solution

1. Change `cache: true` to `cache: false` in all 4 jobs (lint, test, build, goreleaser-check)
2. Change `version: latest` to `version: "~> v2"` for GoReleaser

## Test plan

- [ ] CI workflow runs without cache warnings
- [ ] All jobs still pass (lint, test, build, goreleaser-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)