### PR TITLE
fix: disable golangci-lint-action cache to eliminate warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           version: latest
           args: --timeout=5m
+          skip-cache: true
 
   test:
     name: Test


### PR DESCRIPTION
## Summary

- Adds `skip-cache: true` to golangci-lint-action to eliminate remaining Lint job cache warnings

## Problem

The CI Lint job showed two cache-related warnings:
- "Failed to save: services unavailable"  
- "Failed to restore: Cache service responded with 400"

## Root Cause

The `golangci-lint-action@v4` has its own built-in caching mechanism (separate from `setup-go`). Even though we disabled caching in setup-go, the lint action's internal caching was still causing transient GitHub cache service errors.

## Solution

Added `skip-cache: true` to disable the golangci-lint-action's internal caching. This eliminates the warnings while maintaining full lint functionality (caching is optional for linting).

## Test Plan

- [ ] CI workflow runs without cache warnings in the Lint job
- [ ] Linting still functions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)