### PR TITLE
feat: auto-detect version info from VCS for development builds

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -3,16 +3,43 @@ package cmd
 import (
 	"fmt"
 	"runtime"
+	runtimedebug "runtime/debug"
 
 	"github.com/spf13/cobra"
 )
 
-// Build-time variables (set via ldflags)
+// Build-time variables (set via ldflags, or auto-detected from VCS info)
 var (
 	Version   = "dev"
-	GitCommit = "unknown"
-	BuildDate = "unknown"
+	GitCommit = "local"
+	BuildDate = "now"
 )
+
+func init() {
+	// Auto-detect version info from Go's embedded VCS data
+	// Only override if still at defaults (not set via ldflags)
+	if info, ok := runtimedebug.ReadBuildInfo(); ok {
+		for _, setting := range info.Settings {
+			switch setting.Key {
+			case "vcs.revision":
+				if GitCommit == "local" && setting.Value != "" {
+					// Use short commit hash (7 chars) like git
+					if len(setting.Value) > 7 {
+						GitCommit = setting.Value[:7]
+					} else {
+						GitCommit = setting.Value
+					}
+				}
+			case "vcs.time":
+				if BuildDate == "now" && setting.Value != "" {
+					BuildDate = setting.Value
+				}
+			}
+		}
+	}
+
+	rootCmd.AddCommand(versionCmd)
+}
 
 var versionCmd = &cobra.Command{
 	Use:     "version",
@@ -32,8 +59,4 @@ var versionCmd = &cobra.Command{
 		fmt.Printf("  go:       %s\n", runtime.Version())
 		fmt.Printf("  platform: %s/%s\n", runtime.GOOS, runtime.GOARCH)
 	},
-}
-
-func init() {
-	rootCmd.AddCommand(versionCmd)
 }

--- a/docs/install/source.md
+++ b/docs/install/source.md
@@ -48,6 +48,8 @@ $ cd vesctl
 go build -o vesctl .
 ```
 
+Git commit and build date are automatically embedded when building from a git repository.
+
 **Example output:**
 
 ```text
@@ -66,13 +68,11 @@ $ go build -o vesctl .
 ```text
 $ ./vesctl version
 vesctl version dev
-  commit:   unknown
-  built:    unknown
+  commit:   935d038
+  built:    2025-12-10T03:35:08Z
   go:       go1.23.4
   platform: darwin/arm64
 ```
-
-*Built from source on 2025-12-09*
 
 ## Install (Optional)
 
@@ -91,14 +91,12 @@ Move the binary to your PATH:
     sudo mv vesctl /usr/local/bin/
     ```
 
-## Build with Version Info
+## Build with Custom Version
 
-For release-quality builds with embedded version information:
+For release-quality builds with a custom version string and stripped binaries:
 
 ```bash
-go build -ldflags="-X github.com/robinmordasiewicz/vesctl/cmd.Version=dev \
-  -X github.com/robinmordasiewicz/vesctl/cmd.GitCommit=$(git rev-parse --short HEAD) \
-  -X github.com/robinmordasiewicz/vesctl/cmd.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+go build -ldflags="-s -w -X github.com/robinmordasiewicz/vesctl/cmd.Version=1.0.0" \
   -o vesctl .
 ```
 
@@ -106,9 +104,11 @@ go build -ldflags="-X github.com/robinmordasiewicz/vesctl/cmd.Version=dev \
 
 ```text
 $ ./vesctl version
-vesctl version dev
-  commit:   abc1234
-  built:    2024-12-09T15:30:00Z
+vesctl version 1.0.0
+  commit:   935d038
+  built:    2025-12-10T03:35:08Z
   go:       go1.23.4
   platform: darwin/arm64
 ```
+
+The `-s -w` flags strip debug symbols for smaller binaries.


### PR DESCRIPTION
## Summary

- Simplify source builds by auto-detecting git commit and build date
- Use Go's `runtime/debug.ReadBuildInfo()` for VCS information
- Update default values from "unknown" to "local"/"now" for clarity
- Simplify documentation with easier build instructions

## Changes

**cmd/version.go**
- Add VCS auto-detection using `runtime/debug` package
- Only use VCS info if variables are still at defaults (ldflags take precedence)
- Short commit hash (7 chars) for consistency with GitHub

**docs/install/source.md**
- Simplified build instructions - just `go build -o vesctl .`
- Updated example output to show real commit/date values

## Benefits

1. **Simple development builds**: `go build .` automatically includes real git info
2. **No breaking changes**: GoReleaser ldflags still work and take precedence
3. **No external tools**: Uses Go's built-in functionality
4. **Cross-platform**: Works on all platforms without shell commands

## Test plan

- [x] Build without ldflags: `go build -o vesctl .` → shows real commit/date
- [x] Build with ldflags: custom values take precedence
- [ ] CI passes (lint, test, build)
- [ ] GoReleaser dry run succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)