### PR TITLE
feat: add install docs generation to make docs target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,6 +206,23 @@ docs: build
 		--templates $(DOCS_TEMPLATES) \
 		--clean \
 		--update-mkdocs
+	@echo "Generating install documentation..."
+	@VERSION_OUTPUT=$$(./$(BINARY_NAME) version); \
+	VERSION=$$(echo "$$VERSION_OUTPUT" | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "dev"); \
+	COMMIT=$$(echo "$$VERSION_OUTPUT" | grep 'commit:' | awk '{print $$2}' || echo "local"); \
+	BUILT=$$(echo "$$VERSION_OUTPUT" | grep 'built:' | awk '{print $$2}' || echo "now"); \
+	GO_VER=$$(echo "$$VERSION_OUTPUT" | grep 'go:' | awk '{print $$2}' || echo ""); \
+	PLATFORM=$$(echo "$$VERSION_OUTPUT" | grep 'platform:' | awk '{print $$2}' || echo ""); \
+	$(PYTHON) scripts/generate-homebrew-docs.py \
+		--version "$$VERSION" \
+		--commit "$$COMMIT" \
+		--built "$$BUILT" \
+		--go-version "$$GO_VER" \
+		--platform "$$PLATFORM" \
+		--output docs/install/homebrew.md; \
+	$(PYTHON) scripts/generate-source-docs.py \
+		--go-version "$$(go version | grep -oE 'go[0-9]+\.[0-9]+\.[0-9]+')" \
+		--output docs/install/source.md
 	@echo "Documentation generated successfully!"
 	@echo "  Output: $(DOCS_OUTPUT)"
 	@echo "  Files: $$(find $(DOCS_OUTPUT) -name '*.md' | wc -l) markdown files"

--- a/docs/commands/api-endpoint/index.md
+++ b/docs/commands/api-endpoint/index.md
@@ -4,8 +4,8 @@ description: "Discover and manage API endpoints within F5 XC service mesh."
 keywords:
   - api-endpoint
   - vesctl
-  - F5 XC
   - F5 Distributed Cloud
+  - F5 XC
 command: "vesctl api-endpoint"
 command_group: "api-endpoint"
 ---

--- a/docs/commands/completion/index.md
+++ b/docs/commands/completion/index.md
@@ -2,10 +2,10 @@
 title: "vesctl completion"
 description: "Generate shell completion scripts for bash or zsh."
 keywords:
-  - vesctl
-  - F5 XC
-  - F5 Distributed Cloud
   - completion
+  - vesctl
+  - F5 Distributed Cloud
+  - F5 XC
 command: "vesctl completion"
 command_group: "completion"
 ---

--- a/docs/commands/configuration/index.md
+++ b/docs/commands/configuration/index.md
@@ -3,9 +3,9 @@ title: "vesctl configuration"
 description: "Manage F5 XC configuration objects using CRUD operations."
 keywords:
   - vesctl
-  - F5 XC
   - configuration
   - F5 Distributed Cloud
+  - F5 XC
 command: "vesctl configuration"
 command_group: "configuration"
 aliases:

--- a/docs/commands/help/index.md
+++ b/docs/commands/help/index.md
@@ -2,10 +2,10 @@
 title: "vesctl help"
 description: "Help about any command"
 keywords:
-  - vesctl
-  - F5 XC
-  - F5 Distributed Cloud
   - help
+  - vesctl
+  - F5 Distributed Cloud
+  - F5 XC
 command: "vesctl help"
 command_group: "help"
 ---

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -98,4 +98,4 @@ vesctl supports multiple output formats:
 
 ## Version
 
-Built from version: `v4.9.0-2-gdb8178f`
+Built from version: `v4.9.0-3-g5b68f0b-dirty`

--- a/docs/commands/request/index.md
+++ b/docs/commands/request/index.md
@@ -3,9 +3,9 @@ title: "vesctl request"
 description: "Execute custom API requests to F5 Distributed Cloud."
 keywords:
   - vesctl
-  - F5 XC
   - request
   - F5 Distributed Cloud
+  - F5 XC
 command: "vesctl request"
 command_group: "request"
 aliases:

--- a/docs/commands/site/index.md
+++ b/docs/commands/site/index.md
@@ -3,9 +3,9 @@ title: "vesctl site"
 description: "Deploy and manage F5 XC sites on public cloud providers."
 keywords:
   - vesctl
-  - F5 XC
   - site
   - F5 Distributed Cloud
+  - F5 XC
 command: "vesctl site"
 command_group: "site"
 aliases:

--- a/docs/commands/version/index.md
+++ b/docs/commands/version/index.md
@@ -3,9 +3,9 @@ title: "vesctl version"
 description: "Display vesctl version and build information"
 keywords:
   - vesctl
-  - F5 XC
-  - F5 Distributed Cloud
   - version
+  - F5 Distributed Cloud
+  - F5 XC
 command: "vesctl version"
 command_group: "version"
 ---

--- a/docs/install/homebrew.md
+++ b/docs/install/homebrew.md
@@ -30,11 +30,11 @@ vesctl version
 Expected output:
 
 ```text
-vesctl version 4.6.0
-  commit:   abc1234
-  built:    2024-12-09T10:00:00Z
-  go:       go1.23.4
-  platform: linux/amd64
+vesctl version 4.9.0
+  commit:   5b68f0b
+  built:    2025-12-10T04:16:38Z
+  go:       go1.25.5
+  platform: darwin/arm64
 ```
 
-*Version 4.6.0 - captured 2025-12-09*
+*Version 4.9.0 - captured 2025-12-10*

--- a/docs/install/source.md
+++ b/docs/install/source.md
@@ -8,18 +8,9 @@ Building from source requires:
 
 | Requirement | Version | Check Command |
 |-------------|---------|---------------|
-| Go | go1.23.4 | `go version` |
+| Go | go1.25.5 | `go version` |
 | Git | any | `git --version` |
 
-**Verify prerequisites:**
-
-```text
-$ go version
-go version go1.23.4 darwin/arm64
-
-$ git --version
-git version 2.44.0
-```
 
 ## Clone Repository
 
@@ -28,19 +19,6 @@ git clone https://github.com/robinmordasiewicz/vesctl.git
 cd vesctl
 ```
 
-**Example output:**
-
-```text
-$ git clone https://github.com/robinmordasiewicz/vesctl.git
-Cloning into 'vesctl'...
-remote: Enumerating objects: 1234, done.
-remote: Counting objects: 100% (234/234), done.
-remote: Compressing objects: 100% (156/156), done.
-remote: Total 1234 (delta 89), reused 180 (delta 72), pack-reused 1000
-Receiving objects: 100% (1234/1234), 256.00 KiB | 2.00 MiB/s, done.
-Resolving deltas: 100% (678/678), done.
-$ cd vesctl
-```
 
 ## Build
 
@@ -48,14 +26,6 @@ $ cd vesctl
 go build -o vesctl .
 ```
 
-Git commit and build date are automatically embedded when building from a git repository.
-
-**Example output:**
-
-```text
-$ go build -o vesctl .
-(no output - build successful)
-```
 
 ## Verify Build
 
@@ -63,16 +33,7 @@ $ go build -o vesctl .
 ./vesctl version
 ```
 
-**Example output:**
-
-```text
-$ ./vesctl version
-vesctl version dev
-  commit:   935d038
-  built:    2025-12-10T03:35:08Z
-  go:       go1.23.4
-  platform: darwin/arm64
-```
+Expected output shows version, commit hash, build timestamp, Go version, and platform.
 
 ## Install (Optional)
 
@@ -91,24 +52,14 @@ Move the binary to your PATH:
     sudo mv vesctl /usr/local/bin/
     ```
 
-## Build with Custom Version
+## Build with Version Info
 
-For release-quality builds with a custom version string and stripped binaries:
+For release-quality builds with embedded version information:
 
 ```bash
-go build -ldflags="-s -w -X github.com/robinmordasiewicz/vesctl/cmd.Version=1.0.0" \
+go build -ldflags="-X github.com/robinmordasiewicz/vesctl/cmd.Version=dev \
+  -X github.com/robinmordasiewicz/vesctl/cmd.GitCommit=$(git rev-parse --short HEAD) \
+  -X github.com/robinmordasiewicz/vesctl/cmd.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
   -o vesctl .
 ```
 
-**Example output:**
-
-```text
-$ ./vesctl version
-vesctl version 1.0.0
-  commit:   935d038
-  built:    2025-12-10T03:35:08Z
-  go:       go1.23.4
-  platform: darwin/arm64
-```
-
-The `-s -w` flags strip debug symbols for smaller binaries.


### PR DESCRIPTION
## Summary

- Integrate existing install documentation generation scripts into local `make docs` workflow
- Previously these scripts were only called during CI/CD deployment
- Regenerate install docs to sync with current version

## Changes

- **Makefile**: Add calls to `generate-homebrew-docs.py` and `generate-source-docs.py` after command docs generation
- **docs/install/homebrew.md**: Regenerated with current version info
- **docs/install/source.md**: Regenerated with current Go version

## Test plan

- [x] Run `make docs` locally - generates install docs with version info
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)