### PR TITLE
fix: ensure deploy job runs when generate job is skipped

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -530,11 +530,16 @@ jobs:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
     needs: build
+    # Use always() to evaluate condition even when upstream jobs in chain were skipped
     if: |
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      github.event_name == 'release' ||
-      github.event_name == 'workflow_run' ||
-      github.event_name == 'workflow_dispatch'
+      always() &&
+      needs.build.result == 'success' &&
+      (
+        (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+        github.event_name == 'release' ||
+        github.event_name == 'workflow_run' ||
+        github.event_name == 'workflow_dispatch'
+      )
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary

Fixes the issue where the Deploy to GitHub Pages job was being skipped even when build succeeded.

## Root Cause

When the `generate` job is skipped (because spec hash is unchanged), the `build` job runs using `always()`. However, the `deploy` job's condition didn't include `always()`, causing GitHub Actions to propagate the "skip" status through the dependency chain.

```
generate (SKIPPED)
    ↓
build (SUCCESS with always())
    ↓
deploy (SKIPPED - inherited skip from chain) ← BUG
```

## Fix

Add `always()` to the deploy job condition and explicitly check for build success:

```yaml
if: |
  always() &&
  needs.build.result == 'success' &&
  (original event conditions...)
```

## Test plan

- [ ] CI passes
- [ ] After merge, trigger workflow_dispatch to deploy current 4.11.0 docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)