### PR TITLE
fix: ensure sidebar visibility during instant navigation

### DIFF
--- a/docs/javascripts/sidebar-fix.js
+++ b/docs/javascripts/sidebar-fix.js
@@ -1,0 +1,44 @@
+/**
+ * Fix for intermittent sidebar visibility with navigation.instant
+ *
+ * Material for MkDocs' instant loading can cause race conditions where
+ * the data-md-page attribute doesn't update correctly during navigation.
+ * This causes the home page CSS rule to incorrectly hide the sidebar.
+ *
+ * This script ensures the data-md-page attribute is correctly set based on URL.
+ */
+
+// Only set up once - check if already initialized
+if (!window.__sidebarFixInitialized) {
+  window.__sidebarFixInitialized = true;
+
+  function isHomePage(path) {
+    return path.endsWith('/vesctl/') || path.endsWith('/vesctl/index.html') || path === '/';
+  }
+
+  function fixSidebar() {
+    var path = window.location.pathname;
+    var currentAttr = document.documentElement.getAttribute('data-md-page');
+    var shouldBeHome = isHomePage(path);
+    var isCurrentlyHome = currentAttr === 'home';
+
+    // Only update if needed
+    if (shouldBeHome && !isCurrentlyHome) {
+      document.documentElement.setAttribute('data-md-page', 'home');
+    } else if (!shouldBeHome && isCurrentlyHome) {
+      document.documentElement.removeAttribute('data-md-page');
+    }
+  }
+
+  // Run immediately
+  fixSidebar();
+
+  // Subscribe to Material for MkDocs navigation events
+  // This is the key - document$ fires after each instant navigation
+  if (typeof document$ !== 'undefined') {
+    document$.subscribe(fixSidebar);
+  }
+
+  // Also handle browser back/forward
+  window.addEventListener('popstate', fixSidebar);
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,9 @@ extra:
 extra_css:
   - stylesheets/extra.css
 
+extra_javascript:
+  - javascripts/sidebar-fix.js
+
 nav:
   - Home: index.md
   - Install:


### PR DESCRIPTION
## Summary
- Fix intermittent sidebar visibility issue caused by Material for MkDocs `navigation.instant` feature
- Add JavaScript that subscribes to `document$` observable and toggles `data-md-page` attribute based on URL
- Home page correctly hides sidebar; all other pages correctly show sidebar during instant navigation

## Test plan
- [ ] Navigate to home page - sidebar should be hidden, tiles centered
- [ ] Click any navigation link using instant loading - sidebar should appear
- [ ] Navigate back to home - sidebar should hide again
- [ ] Use browser back/forward - sidebar state should update correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)