### PR TITLE
fix: ensure docs workflow waits for release workflow to complete

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,13 +44,50 @@ env:
   PYTHON_VERSION: '3.13'
 
 jobs:
+  wait-for-release:
+    name: Wait for Release
+    runs-on: ubuntu-latest
+    # Only wait when triggered by push (not workflow_run which already means Release completed)
+    if: github.event_name == 'push'
+    outputs:
+      should_skip: ${{ steps.check-release-running.outputs.should_skip }}
+    steps:
+      - name: Check if Release workflow is running
+        id: check-release-running
+        run: |
+          # Check for in-progress Release workflow runs on the same commit
+          RUNNING_RELEASES=$(gh api repos/${{ github.repository }}/actions/workflows/release.yml/runs \
+            --jq '.workflow_runs | map(select(.head_sha == "${{ github.sha }}" and (.status == "in_progress" or .status == "queued"))) | length' \
+            2>/dev/null || echo "0")
+
+          echo "Running/queued Release workflows for this commit: $RUNNING_RELEASES"
+
+          if [ "$RUNNING_RELEASES" -gt 0 ]; then
+            echo "Release workflow is running - Documentation will be triggered by workflow_run event instead"
+            echo "should_skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "No Release workflow running - proceeding with docs build"
+            echo "should_skip=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
   check-spec:
     name: Check Spec Changes
     runs-on: ubuntu-latest
-    # Skip if workflow_run but Release workflow failed
+    needs: [wait-for-release]
+    # Skip if:
+    # 1. workflow_run but Release workflow failed
+    # 2. push trigger but Release workflow is running (will be triggered via workflow_run instead)
+    # Use always() to run even when wait-for-release is skipped (non-push triggers)
     if: |
-      github.event_name != 'workflow_run' ||
-      github.event.workflow_run.conclusion == 'success'
+      always() &&
+      (
+        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+        (github.event_name == 'push' && (needs.wait-for-release.result == 'skipped' || needs.wait-for-release.outputs.should_skip != 'true')) ||
+        github.event_name == 'release' ||
+        github.event_name == 'workflow_dispatch'
+      )
     outputs:
       needs_generation: ${{ steps.compare.outputs.needs_generation }}
       spec_hash: ${{ steps.spec-hash.outputs.hash }}


### PR DESCRIPTION
## Summary
When a PR is merged to main, both Release and Documentation workflows were triggering simultaneously. This caused the docs workflow to run before the release was published, missing the new version information.

## Changes
- Add `wait-for-release` job that checks if Release workflow is running for the same commit
- Skip docs push trigger if Release workflow is in progress (will be triggered via `workflow_run` instead)
- Preserve docs-only change behavior (proceeds immediately if no Release workflow running)

## How it works
1. On push to main, docs workflow checks if Release workflow is running/queued for the same commit
2. If Release is running → skip (workflow_run will trigger docs after Release completes)
3. If Release is not running → proceed with docs build (docs-only changes)

## Test plan
- [x] Verify workflow syntax is valid
- [ ] Test with code+docs PR merge (should skip push trigger, run via workflow_run)
- [ ] Test with docs-only PR merge (should run immediately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)