### PR TITLE
fix: create install directory if it doesn't exist

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -232,7 +232,13 @@ determine_install_strategy() {
 
     # If user explicitly set install dir, respect it
     if [ -n "${VES_INSTALL_DIR:-}" ]; then
-        if [ -w "$REQUESTED_DIR" ] || [ -w "$(dirname "$REQUESTED_DIR")" ]; then
+        # Create directory if it doesn't exist and parent is writable
+        if [ ! -d "$REQUESTED_DIR" ]; then
+            if mkdir -p "$REQUESTED_DIR" 2>/dev/null; then
+                echo "custom:"
+                return
+            fi
+        elif [ -w "$REQUESTED_DIR" ]; then
             echo "custom:"
             return
         fi


### PR DESCRIPTION
## Summary
- Fix install script failing when `VES_INSTALL_DIR` points to a non-existent directory
- The script now creates the directory with `mkdir -p` before checking writability

## Problem
When running in CI with `VES_INSTALL_DIR=$HOME/.local/bin`, the script failed with:
```
Error: Cannot write to /home/runner/.local/bin and sudo is not available.
```

This occurred because `~/.local/bin` doesn't exist by default on GitHub Actions runners.

## Solution
Create the directory if it doesn't exist (and parent is writable), then return success for the "custom:" strategy.

## Test plan
- [x] Tested locally with `VES_INSTALL_DIR=/tmp/vesctl-test`
- [ ] CI workflow should now complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)