### PR TITLE
fix: show command group parents in navigation sidebar

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -485,13 +485,9 @@ html {
   display: none;
 }
 
-/* Hide section index links in navigation sidebar
-   With navigation.indexes and navigation.tabs enabled, the section is
-   already identified via the tab bar and breadcrumb. The index link
-   inside the container is redundant and creates alignment issues. */
-.md-nav__container > a.md-nav__link {
-  display: none;
-}
+/* Section index links - KEPT VISIBLE for command group hierarchy
+   These links provide the parent labels (Api Endpoint, Configuration, etc.)
+   which are essential for proper navigation hierarchy */
 
 /* Table of contents (right sidebar) - Compact styling */
 .md-nav--secondary {


### PR DESCRIPTION
## Summary
- Remove CSS rule that was hiding section index links in the navigation sidebar
- This restores visibility of the 7 command group parents (Api Endpoint, Configuration, Request, Site, etc.)
- Children were showing directly at the top level instead of under their expandable parent groups

## Test plan
- [x] Verified locally with `mkdocs serve`
- [x] Commands page shows all 7 command groups as expandable parents
- [x] Install section shows correct hierarchy
- [x] Guides section shows correct hierarchy

🤖 Generated with [Claude Code](https://claude.com/claude-code)