### PR TITLE
fix: add asset availability check for deterministic docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -400,6 +400,53 @@ jobs:
             --platform "$PLATFORM" \
             --output docs/install/homebrew.md
 
+      - name: Wait for release assets to be available
+        id: wait-assets
+        run: |
+          # Get the latest release version
+          LATEST_TAG=$(gh api repos/${{ github.repository }}/releases/latest --jq '.tag_name' 2>/dev/null || echo "")
+
+          if [ -z "$LATEST_TAG" ]; then
+            echo "::error::No releases found"
+            exit 1
+          fi
+
+          echo "Latest release: $LATEST_TAG"
+
+          # Expected asset name for linux amd64 (what the runner will download)
+          VERSION="${LATEST_TAG#v}"
+          EXPECTED_ASSET="vesctl_${VERSION}_linux_amd64.tar.gz"
+
+          echo "Waiting for asset: $EXPECTED_ASSET"
+
+          MAX_RETRIES=10
+          RETRY_DELAY=30
+
+          for i in $(seq 1 $MAX_RETRIES); do
+            echo "Check $i of $MAX_RETRIES..."
+
+            # Check if the asset exists
+            ASSET_COUNT=$(gh api repos/${{ github.repository }}/releases/latest \
+              --jq ".assets | map(select(.name == \"$EXPECTED_ASSET\")) | length" 2>/dev/null || echo "0")
+
+            if [ "$ASSET_COUNT" -gt 0 ]; then
+              echo "Asset $EXPECTED_ASSET is available!"
+              echo "assets_ready=true" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+
+            if [ $i -eq $MAX_RETRIES ]; then
+              echo "::error::Asset $EXPECTED_ASSET not available after $MAX_RETRIES attempts ($(($MAX_RETRIES * $RETRY_DELAY))s)"
+              echo "assets_ready=false" >> $GITHUB_OUTPUT
+              exit 1
+            fi
+
+            echo "Asset not ready, waiting ${RETRY_DELAY}s before retry..."
+            sleep $RETRY_DELAY
+          done
+        env:
+          GH_TOKEN: ${{ github.token }}
+
       - name: Test install script and capture output
         id: script-install
         run: |


### PR DESCRIPTION
## Summary
- Adds a new step that waits for release binary assets to be available before running the install script test
- Prevents race conditions where docs workflow starts before Release workflow uploads binaries
- Polls up to 5 minutes (10 attempts × 30 seconds) for assets to be ready

## Problem
When a push triggers both the Release and Documentation workflows simultaneously:
1. Release workflow creates a new tag and release
2. Docs workflow runs install script which queries GitHub API for the latest release
3. Install script tries to download binaries for the new release
4. But binaries aren't uploaded yet → 404 error → workflow fails

## Solution
Add a "Wait for release assets to be available" step that:
1. Gets the latest release tag from GitHub API
2. Checks if the expected asset (`vesctl_{version}_linux_amd64.tar.gz`) exists
3. Retries with 30s delay if not available
4. Fails after 10 attempts (5 minutes) with clear error message

This makes the workflow deterministic: it will always wait for assets to be ready before proceeding, rather than racing with the release workflow.

## Test plan
- [ ] Push to main and verify workflow waits for assets if release is in progress
- [ ] Verify workflow proceeds immediately if assets already exist
- [ ] Verify workflow fails with clear message if assets never become available

🤖 Generated with [Claude Code](https://claude.com/claude-code)