### PR TITLE
fix: migrate from deprecated brews to homebrew_casks

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -294,8 +294,8 @@ jobs:
             brew tap robinmordasiewicz/tap
             brew update
 
-            # Try to install
-            if brew install vesctl 2>&1; then
+            # Try to install (using cask)
+            if brew install --cask vesctl 2>&1; then
               echo "Successfully installed vesctl"
               echo "homebrew_success=true" >> $GITHUB_OUTPUT
               exit 0
@@ -452,9 +452,9 @@ jobs:
         run: |
           set +e  # Disable errexit to capture exit codes properly
 
-          # Uninstall homebrew version first if present
+          # Uninstall homebrew version first if present (try both cask and formula)
           if command -v vesctl &>/dev/null; then
-            brew uninstall vesctl 2>/dev/null || true
+            brew uninstall --cask vesctl 2>/dev/null || brew uninstall vesctl 2>/dev/null || true
           fi
 
           # Run install script and capture output to file

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -126,25 +126,23 @@ release:
   footer: |
     **Full Changelog**: https://github.com/robinmordasiewicz/vesctl/compare/{{ .PreviousTag }}...{{ .Tag }}
 
-# Homebrew tap
-brews:
+# Homebrew cask (replaces deprecated brews section)
+# See: https://goreleaser.com/deprecations#brews
+homebrew_casks:
   - name: vesctl
+    binaries:
+      - vesctl
     repository:
       owner: robinmordasiewicz
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-    directory: Formula
+    directory: Casks
     commit_author:
       name: goreleaserbot
       email: bot@goreleaser.com
-    commit_msg_template: "chore: Update {{ .ProjectName }} formula to {{ .Tag }}"
+    commit_msg_template: "chore: Update {{ .ProjectName }} cask to {{ .Tag }}"
     homepage: https://github.com/robinmordasiewicz/vesctl
     description: Command-line interface for F5 Distributed Cloud
-    license: Apache-2.0
-    install: |
-      bin.install "vesctl"
-    test: |
-      system "#{bin}/vesctl", "version"
     caveats: |
       To get started with vesctl:
         1. Configure authentication: vesctl configure

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Full documentation is available at **[robinmordasiewicz.github.io/vesctl](https:
 
 ```bash
 brew tap robinmordasiewicz/tap
-brew install vesctl
+brew install --cask vesctl
 ```
 
 ### Install Script

--- a/scripts/templates/homebrew.md.j2
+++ b/scripts/templates/homebrew.md.j2
@@ -1,22 +1,22 @@
 # Homebrew (macOS/Linux)
 
-Homebrew install vesctl on macOS or Linux:
+Install vesctl on macOS or Linux using Homebrew:
 
 ```bash
 brew tap robinmordasiewicz/tap
-brew install vesctl
+brew install --cask vesctl
 ```
 
 **Upgrade to latest version:**
 
 ```bash
-brew upgrade vesctl
+brew upgrade --cask vesctl
 ```
 
 **Uninstall:**
 
 ```bash
-brew uninstall vesctl
+brew uninstall --cask vesctl
 ```
 
 ## Verify Installation


### PR DESCRIPTION
## Summary
- Migrate GoReleaser configuration from deprecated `brews:` section to `homebrew_casks:`
- Update all Homebrew documentation to use `--cask` flag
- Update docs workflow to use cask install/uninstall commands

## Changes
- `.goreleaser.yaml`: Replace `brews:` with `homebrew_casks:` configuration
- `scripts/templates/homebrew.md.j2`: Update install commands to use `--cask`
- `README.md`: Update Homebrew install command
- `.github/workflows/docs.yml`: Update brew commands to use cask format

## Why
GoReleaser v2.10+ shows deprecation warning:
> brews is being phased out in favor of homebrew_casks

The `brews` section was a "hack" - Homebrew Formulas are meant to compile from source, not install pre-compiled binaries. Casks are the correct approach for pre-compiled binaries.

## Test plan
- [x] `goreleaser check` passes without warnings
- [ ] Release workflow creates cask in `Casks/vesctl.rb`
- [ ] `brew install --cask robinmordasiewicz/tap/vesctl` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)