### PR TITLE
fix: simplify Homebrew cask caveats message

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -143,8 +143,4 @@ homebrew_casks:
     commit_msg_template: "chore: Update {{ .ProjectName }} cask to {{ .Tag }}"
     homepage: https://github.com/robinmordasiewicz/vesctl
     description: Command-line interface for F5 Distributed Cloud
-    caveats: |
-      To get started with vesctl:
-        1. Configure authentication: vesctl configure
-        2. List namespaces: vesctl configuration list namespace
-        3. Get help: vesctl --help
+    caveats: "Run 'vesctl configure' to set up authentication, then 'vesctl --help' for usage."


### PR DESCRIPTION
## Summary
- Simplify the Homebrew cask caveats from multi-line numbered list to single concise instruction

## Before
```
==> Caveats
  3. Get help: vesctl --help
```
(Multi-line caveats were not displaying correctly)

## After
```
==> Caveats
Run 'vesctl configure' to set up authentication, then 'vesctl --help' for usage.
```

## Test plan
- [x] `goreleaser check` passes
- [ ] Next release shows clean single-line caveat

🤖 Generated with [Claude Code](https://claude.com/claude-code)