### PR TITLE
fix: polish Homebrew cask following best practices

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -141,6 +141,5 @@ homebrew_casks:
       name: goreleaserbot
       email: bot@goreleaser.com
     commit_msg_template: "chore: Update {{ .ProjectName }} cask to {{ .Tag }}"
-    homepage: https://github.com/robinmordasiewicz/vesctl
+    homepage: https://robinmordasiewicz.github.io/vesctl
     description: Command-line interface for F5 Distributed Cloud
-    caveats: "Run 'vesctl configure' to set up authentication, then 'vesctl --help' for usage."


### PR DESCRIPTION
## Summary
- Remove `caveats` stanza - per Homebrew Cask Cookbook guidelines, caveats should be "used sparingly and exclusively for installation-related matters", not for getting started information
- Update `homepage` from GitHub repo to docs site for better user experience post-install

## Changes
| Setting | Before | After |
|---------|--------|-------|
| `caveats` | Getting started tips | **Removed** |
| `homepage` | `https://github.com/robinmordasiewicz/vesctl` | `https://robinmordasiewicz.github.io/vesctl` |

## Expected Result

**Before:**
```
==> Caveats
Run 'vesctl configure' to set up authentication, then 'vesctl --help' for usage.

==> Installing Cask vesctl
==> Linking Binary 'vesctl' to '/opt/homebrew/bin/vesctl'
🍺  vesctl was successfully installed!
```

**After:**
```
==> Installing Cask vesctl
==> Linking Binary 'vesctl' to '/opt/homebrew/bin/vesctl'
🍺  vesctl was successfully installed!
```

## Reference
- [Homebrew Cask Cookbook](https://docs.brew.sh/Cask-Cookbook) - Official cask stanza documentation

## Test plan
- [ ] `goreleaser check` passes
- [ ] Next release generates cask without caveats
- [ ] `brew info --cask vesctl` shows docs site URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)