### PR TITLE
fix: add missing endif in homebrew.md.j2 template

### DIFF
--- a/scripts/templates/homebrew.md.j2
+++ b/scripts/templates/homebrew.md.j2
@@ -50,3 +50,4 @@ vesctl version {{ version }}
   go:       {{ go_version if go_version else "go1.23.x" }}
   platform: {{ platform if platform else "darwin/arm64" }} [Possible values: linux/amd64,linux/arm64,darwin/amd64,darwin/arm64]
 ```
+{% endif %}


### PR DESCRIPTION
## Summary
- Add missing `{% endif %}` tag in homebrew.md.j2 template
- Fixes Jinja2 syntax error causing Documentation workflow failure

## Root cause
The template was missing the closing `{% endif %}` for the `{% if version and commit and built %}` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)