### PR TITLE
feat: add Homebrew caveats for macOS Gatekeeper workaround

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -143,3 +143,9 @@ homebrew_casks:
     commit_msg_template: "chore: Update {{ .ProjectName }} cask to {{ .Tag }}"
     homepage: https://robinmordasiewicz.github.io/vesctl
     description: Command-line interface for F5 Distributed Cloud
+    caveats: |
+      vesctl is not signed with an Apple Developer ID.
+      If macOS shows "vesctl Not Opened" or blocks the app, run:
+        xattr -d com.apple.quarantine #{caskroom_path}/vesctl
+
+      Or go to System Settings > Privacy & Security and click "Open Anyway".


### PR DESCRIPTION
## Summary
- Add `caveats` field to GoReleaser's `homebrew_casks` configuration
- Displays instructions for handling macOS Gatekeeper warning after installation

## User Experience
After `brew install --cask vesctl`, users will see:
```
==> Caveats
vesctl is not signed with an Apple Developer ID.
If macOS shows "vesctl Not Opened" or blocks the app, run:
  xattr -d com.apple.quarantine /opt/homebrew/Caskroom/vesctl/<version>/vesctl

Or go to System Settings > Privacy & Security and click "Open Anyway".
```

## Test plan
- [x] `goreleaser check` validates config
- [ ] Next release will include caveats in generated cask

🤖 Generated with [Claude Code](https://claude.com/claude-code)