### PR TITLE
fix: improve certificate import for code signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,18 +152,43 @@ jobs:
           KEYCHAIN_PATH=$RUNNER_TEMP/signing.keychain-db
           KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
 
+          # Store for later steps
+          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> $GITHUB_ENV
+          echo "KEYCHAIN_PASSWORD=$KEYCHAIN_PASSWORD" >> $GITHUB_ENV
+
           # Decode certificate
           echo "$APPLE_CERTIFICATE_BASE64" | base64 --decode > $RUNNER_TEMP/certificate.p12
+          echo "Certificate decoded, checking..."
+
+          # Verify p12 is valid
+          openssl pkcs12 -info -in $RUNNER_TEMP/certificate.p12 -noout -passin pass:"$APPLE_CERTIFICATE_PASSWORD" || {
+            echo "ERROR: Invalid p12 file or wrong password"
+            exit 1
+          }
 
           # Create and configure keychain
           security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security default-keychain -s $KEYCHAIN_PATH
           security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
 
-          # Import certificate
-          security import $RUNNER_TEMP/certificate.p12 -P "$APPLE_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
-          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          # Import certificate with proper options
+          echo "Importing certificate..."
+          security import $RUNNER_TEMP/certificate.p12 \
+            -k $KEYCHAIN_PATH \
+            -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+
+          # Allow codesign to access the keychain
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+
+          # Add to search list
           security list-keychain -d user -s $KEYCHAIN_PATH
+
+          # Verify import worked
+          echo "Verifying certificate import..."
+          security find-identity -v -p codesigning $KEYCHAIN_PATH
 
           # Clean up certificate file
           rm $RUNNER_TEMP/certificate.p12


### PR DESCRIPTION
## Summary
Fix the certificate import step that failed in the initial signing attempt.

## Changes
- Add verification of p12 file before import to catch password issues early
- Use explicit `-T` options instead of deprecated `-A` flag
- Set as default keychain before import
- Add `codesign:` to partition list
- Add verification step after import to confirm certificate is available

## Test plan
- [ ] Verify certificate validation step passes
- [ ] Verify certificate import succeeds
- [ ] Verify signing identity is found

🤖 Generated with [Claude Code](https://claude.com/claude-code)