### PR TITLE
fix: unlock keychain and search correct keychain for signing identity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,6 +203,20 @@ jobs:
           VERSION="${{ needs.goreleaser.outputs.version }}"
           echo "Signing version: $VERSION"
 
+          # Unlock keychain for this step
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Find the Developer ID Application certificate from our keychain
+          echo "Available signing identities:"
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+
+          SIGNING_IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep "Developer ID" | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          if [ -z "$SIGNING_IDENTITY" ]; then
+            echo "ERROR: No Developer ID signing identity found"
+            exit 1
+          fi
+          echo "Using signing identity: $SIGNING_IDENTITY"
+
           # Process each macOS architecture
           for ARCH in amd64 arm64; do
             ASSET_NAME="vesctl_${VERSION}_darwin_${ARCH}.tar.gz"
@@ -218,10 +232,6 @@ jobs:
             # Sign the binary
             BINARY_PATH="$RUNNER_TEMP/sign_${ARCH}/vesctl"
             echo "Signing $BINARY_PATH..."
-
-            # Find the Developer ID Application certificate
-            SIGNING_IDENTITY=$(security find-identity -v -p codesigning | grep "Developer ID Application" | head -1 | sed 's/.*"\(.*\)".*/\1/')
-            echo "Using signing identity: $SIGNING_IDENTITY"
 
             codesign --force --options runtime --sign "$SIGNING_IDENTITY" --timestamp "$BINARY_PATH"
 


### PR DESCRIPTION
## Summary
Fix the signing step that failed because it couldn't find the signing identity.

## Root Cause
The `security find-identity` command was searching all keychains instead of our specific keychain, and the keychain wasn't unlocked for the signing step.

## Changes
- Unlock the keychain at the start of the signing step
- Search specifically in our keychain for the signing identity
- Add debug output showing available identities
- Improve error handling when identity is not found

🤖 Generated with [Claude Code](https://claude.com/claude-code)