### PR TITLE
feat: use macOS runner for Homebrew documentation generation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -250,7 +250,7 @@ jobs:
 
   build:
     name: Build Documentation
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     needs: [check-spec, generate]
     # Run unless: failed, cancelled, or workflow_run without recent release
     if: |
@@ -277,9 +277,6 @@ jobs:
           key: vesctl-docs-${{ needs.check-spec.outputs.spec_hash }}
           restore-keys: |
             vesctl-docs-
-
-      - name: Install Homebrew (Linux)
-        uses: Homebrew/actions/setup-homebrew@master
 
       - name: Install vesctl via Homebrew
         id: homebrew-install
@@ -414,9 +411,9 @@ jobs:
 
           echo "Latest release: $LATEST_TAG"
 
-          # Expected asset name for linux amd64 (what the runner will download)
+          # Expected asset name for darwin arm64 (what the macOS runner will download)
           VERSION="${LATEST_TAG#v}"
-          EXPECTED_ASSET="vesctl_${VERSION}_linux_amd64.tar.gz"
+          EXPECTED_ASSET="vesctl_${VERSION}_darwin_arm64.tar.gz"
 
           echo "Waiting for asset: $EXPECTED_ASSET"
 


### PR DESCRIPTION
## Summary
- Switch docs workflow build job from `ubuntu-latest` to `macos-latest`
- Remove Linux Homebrew setup step (Homebrew is native on macOS)
- Update asset wait check to `darwin_arm64` (macOS runner architecture)

## Benefits
- Authentic macOS terminal output in Homebrew documentation
- Real installation paths shown: `/opt/homebrew/Caskroom/vesctl/...`
- Platform correctly shows `darwin/arm64`
- Better documentation for the primary Homebrew audience (macOS users)

## Trade-offs
- macOS runners are more expensive (~10x Linux cost)
- Slightly slower execution (but acceptable for docs generation)

## Test plan
- [ ] Verify workflow runs successfully on macOS runner
- [ ] Check generated `docs/install/homebrew.md` shows macOS-style output

🤖 Generated with [Claude Code](https://claude.com/claude-code)