### PR TITLE
fix: remove caveats from Homebrew cask (code signing active)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -143,9 +143,3 @@ homebrew_casks:
     commit_msg_template: "chore: Update {{ .ProjectName }} cask to {{ .Tag }}"
     homepage: https://robinmordasiewicz.github.io/vesctl
     description: Command-line interface for F5 Distributed Cloud
-    caveats: |
-      vesctl is not signed with an Apple Developer ID.
-      If macOS shows "vesctl Not Opened" or blocks the app, run:
-        xattr -d com.apple.quarantine #{caskroom_path}/vesctl
-
-      Or go to System Settings > Privacy & Security and click "Open Anyway".


### PR DESCRIPTION
## Summary
- Remove caveats section from `.goreleaser.yaml` since macOS binaries are now properly code-signed and notarized
- Users no longer need the quarantine workaround instructions

## Issue
The caveats had syntax errors with unescaped quotes that broke Homebrew installation:
```ruby
"If macOS shows "vesctl Not Opened" or blocks the app, run:"
#                ^^^^^--- unescaped quotes
```

## Fix
Remove caveats entirely since code signing is now working.

**Note**: Also need to fix homebrew-tap repo directly since cask won't regenerate until next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)