### PR TITLE
fix: make docs generation idempotent

### DIFF
--- a/docs/commands/api-endpoint/index.md
+++ b/docs/commands/api-endpoint/index.md
@@ -3,9 +3,9 @@ title: "vesctl api-endpoint"
 description: "Discover and manage API endpoints within F5 XC service mesh."
 keywords:
   - F5 Distributed Cloud
-  - vesctl
-  - api-endpoint
   - F5 XC
+  - api-endpoint
+  - vesctl
 command: "vesctl api-endpoint"
 command_group: "api-endpoint"
 ---

--- a/docs/commands/completion/index.md
+++ b/docs/commands/completion/index.md
@@ -3,9 +3,9 @@ title: "vesctl completion"
 description: "Generate shell completion scripts for bash or zsh."
 keywords:
   - F5 Distributed Cloud
-  - vesctl
   - F5 XC
   - completion
+  - vesctl
 command: "vesctl completion"
 command_group: "completion"
 ---

--- a/docs/commands/configuration/index.md
+++ b/docs/commands/configuration/index.md
@@ -3,9 +3,9 @@ title: "vesctl configuration"
 description: "Manage F5 XC configuration objects using CRUD operations."
 keywords:
   - F5 Distributed Cloud
-  - vesctl
   - F5 XC
   - configuration
+  - vesctl
 command: "vesctl configuration"
 command_group: "configuration"
 aliases:

--- a/docs/commands/help/index.md
+++ b/docs/commands/help/index.md
@@ -3,9 +3,9 @@ title: "vesctl help"
 description: "Help about any command"
 keywords:
   - F5 Distributed Cloud
-  - vesctl
-  - help
   - F5 XC
+  - help
+  - vesctl
 command: "vesctl help"
 command_group: "help"
 ---

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -98,4 +98,4 @@ vesctl supports multiple output formats:
 
 ## Version
 
-Built from version: `v4.15.2-3-g3a4e3ba`
+Built from version: `v4.15.2`

--- a/docs/commands/request/index.md
+++ b/docs/commands/request/index.md
@@ -3,9 +3,9 @@ title: "vesctl request"
 description: "Execute custom API requests to F5 Distributed Cloud."
 keywords:
   - F5 Distributed Cloud
-  - vesctl
-  - request
   - F5 XC
+  - request
+  - vesctl
 command: "vesctl request"
 command_group: "request"
 aliases:

--- a/docs/commands/site/index.md
+++ b/docs/commands/site/index.md
@@ -3,9 +3,9 @@ title: "vesctl site"
 description: "Deploy and manage F5 XC sites on public cloud providers."
 keywords:
   - F5 Distributed Cloud
-  - vesctl
   - F5 XC
   - site
+  - vesctl
 command: "vesctl site"
 command_group: "site"
 aliases:

--- a/docs/commands/version/index.md
+++ b/docs/commands/version/index.md
@@ -3,9 +3,9 @@ title: "vesctl version"
 description: "Display vesctl version and build information"
 keywords:
   - F5 Distributed Cloud
-  - vesctl
-  - version
   - F5 XC
+  - version
+  - vesctl
 command: "vesctl version"
 command_group: "version"
 ---


### PR DESCRIPTION
## Summary
Fix CI docs check failing on every commit by making docs generation idempotent.

## Root Cause
1. **Keyword ordering**: `list(set(keywords))` produced random order each run
2. **Version string**: Included commit hash suffix that changed every commit

## Solution
1. `sorted(set(keywords))` - alphabetical ordering
2. `re.sub(r'-\d+-g[a-f0-9]+(-dirty)?$', '', version)` - strip commit suffix

Now `make docs` produces identical output on repeated runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)