### PR TITLE
fix: sanitize home directory paths in docs generation

### DIFF
--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -40,7 +40,7 @@ These flags are available for all commands:
 | `--api-token` |  | bool | false | Authenticate using the API token from VES_API_TOKEN environment variable. |
 | `--cacert` | `-a` | string |  | Path to the server CA certificate file for TLS verification. |
 | `--cert` | `-c` | string |  | Path to the client certificate file for mTLS authentication. |
-| `--config` |  | string |  | Path to the configuration file containing API URL and credentials (default "/Users/r.mordasiewicz/.vesconfig"). |
+| `--config` |  | string |  | Path to the configuration file containing API URL and credentials (default "$HOME/.vesconfig"). |
 | `--hardwareKey` |  | bool | false | Use a YubiKey hardware security module for TLS authentication. |
 | `--key` | `-k` | string |  | Path to the client private key file for mTLS authentication. |
 | `--non-interactive` |  | bool | false | Disable interactive prompts and fail if required arguments are missing. |
@@ -98,4 +98,4 @@ vesctl supports multiple output formats:
 
 ## Version
 
-Built from version: `v4.15.2`
+Built from version: `v4.15.3`

--- a/scripts/generate-docs.py
+++ b/scripts/generate-docs.py
@@ -244,6 +244,15 @@ def sort_actions(actions: list) -> list:
     )
 
 
+def sanitize_path(value: str) -> str:
+    """Replace user-specific home directory paths with a generic placeholder."""
+    if not value:
+        return value
+    # Replace any home directory path pattern with $HOME placeholder
+    # Handles /Users/username, /home/username, /root, C:\Users\username
+    return re.sub(r'(/Users/[^/]+|/home/[^/]+|/root|C:\\Users\\[^\\]+)', '$HOME', value)
+
+
 @dataclass
 class Flag:
     """Represents a CLI flag."""
@@ -258,9 +267,9 @@ class Flag:
         return cls(
             name=d.get("name", ""),
             type=d.get("type", ""),
-            description=d.get("description", ""),
+            description=sanitize_path(d.get("description", "")),
             shorthand=d.get("shorthand", ""),
-            default=d.get("default", ""),
+            default=sanitize_path(d.get("default", "")),
         )
 
 


### PR DESCRIPTION
## Summary
Complete the idempotent docs generation by sanitizing home directory paths.

## Problem
The `--config` flag description contained `/Users/username/.vesconfig` or `/home/username/.vesconfig` depending on where docs were generated, causing CI failures.

## Solution
Added `sanitize_path()` function that replaces:
- `/Users/username/...` -> `$HOME/...`
- `/home/username/...` -> `$HOME/...`
- `/root/...` -> `$HOME/...`
- `C:\Users\username\...` -> `$HOME/...`

Applied to both flag descriptions and default values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)