### PR TITLE
fix: remove version from command reference docs

### DIFF
--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -95,7 +95,3 @@ vesctl supports multiple output formats:
 |----------|-------------|
 | `VES_API_TOKEN` | API token for authentication (use with `--api-token` flag) |
 | `VES_P12_PASSWORD` | Password for P12 bundle file |
-
-## Version
-
-Built from version: `v4.15.3`

--- a/scripts/templates/commands_index.md.j2
+++ b/scripts/templates/commands_index.md.j2
@@ -80,7 +80,3 @@ vesctl supports multiple output formats:
 |----------|-------------|
 | `VES_API_TOKEN` | API token for authentication (use with `--api-token` flag) |
 | `VES_P12_PASSWORD` | Password for P12 bundle file |
-
-## Version
-
-Built from version: `{{ version }}`


### PR DESCRIPTION
## Summary
Remove the version section from command reference docs to achieve true idempotency.

## Problem
Every release creates a new tag, which changes the version in generated docs, causing the docs check to fail even though the docs are "correct" for the new version.

## Solution
Remove version from template - it's already shown via `vesctl version` command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)