### PR TITLE
fix: clarify version variable comment for better documentation

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Build-time variables: set via ldflags, or auto-detected from VCS info
+// Build-time version variables: set via ldflags during release, or auto-detected from VCS info
 var (
 	Version   = "dev"
 	GitCommit = "local"


### PR DESCRIPTION
## Summary
- Improved the build-time variables comment to be more descriptive
- This triggers a full release pipeline test including GoReleaser and Sign macOS Binaries

## Test plan
- [ ] Documentation Check passes
- [ ] Semantic Release creates new version
- [ ] GoReleaser builds and uploads binaries
- [ ] Sign macOS Binaries signs and notarizes
- [ ] Homebrew cask hash update works

🤖 Generated with [Claude Code](https://claude.com/claude-code)