### PR TITLE
fix: use correct secret name HOMEBREW_TAP_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,7 +265,7 @@ jobs:
       - name: Update Homebrew cask with signed binary hashes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
           VERSION="${{ needs.goreleaser.outputs.version }}"
 


### PR DESCRIPTION
## Summary
Fix the secret name from `HOMEBREW_TAP_GITHUB_TOKEN` to `HOMEBREW_TAP_TOKEN`.

This matches the GoReleaser step which correctly uses `secrets.HOMEBREW_TAP_TOKEN`.

## Root Cause
Wrong secret name caused empty token, leading to git push authentication failure.

## Test plan
- [ ] Sign macOS Binaries job completes successfully
- [ ] Homebrew cask is pushed with correct SHA256 hashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)