### PR TITLE
fix: regenerate checksums.txt after signing macOS binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -262,6 +262,31 @@ jobs:
 
           echo "macOS binaries signed and uploaded successfully!"
 
+      - name: Regenerate checksums.txt with signed binary hashes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ needs.goreleaser.outputs.version }}"
+          echo "Regenerating checksums.txt for version $VERSION..."
+
+          # Create working directory
+          mkdir -p $RUNNER_TEMP/checksums
+          cd $RUNNER_TEMP/checksums
+
+          # Download all release assets
+          echo "Downloading all release assets..."
+          GH_TOKEN="$GITHUB_TOKEN" gh release download "v${VERSION}" --repo "${{ github.repository }}"
+
+          # Generate new checksums.txt
+          echo "Computing SHA256 checksums..."
+          shasum -a 256 vesctl_${VERSION}_*.tar.gz vesctl_${VERSION}_*.zip 2>/dev/null | tee checksums.txt
+
+          # Upload new checksums.txt to replace the old one
+          echo "Uploading updated checksums.txt..."
+          GH_TOKEN="$GITHUB_TOKEN" gh release upload "v${VERSION}" checksums.txt --clobber --repo "${{ github.repository }}"
+
+          echo "checksums.txt regenerated successfully!"
+
       - name: Update Homebrew cask with signed binary hashes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Fix install script checksum verification failure after macOS signing
- Add step to regenerate checksums.txt with signed binary hashes
- Upload updated checksums.txt to release after signing

## Problem
After the Sign macOS Binaries job replaces the macOS binaries with signed versions, the checksums in `checksums.txt` no longer match because they were computed by GoReleaser before signing. This causes the install script to fail checksum verification.

## Solution
Add a new step that:
1. Downloads all release assets (including the newly signed macOS binaries)
2. Regenerates `checksums.txt` with correct SHA256 hashes
3. Uploads the updated file to replace the GoReleaser-generated one

## Test plan
- [ ] Merge to trigger release pipeline
- [ ] Verify Sign macOS Binaries job regenerates checksums.txt
- [ ] Verify docs workflow passes checksum verification
- [ ] Test install script downloads and verifies signed binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)