### PR TITLE
fix: prevent install script from exiting on shell completion RC update

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -666,8 +666,8 @@ setup_bash_completion() {
         if "$VESCTL_BIN" completion bash > "${BASH_COMPLETION_DIR}/vesctl" 2>/dev/null; then
             success "Bash completion installed to ${BASH_COMPLETION_DIR}/vesctl"
             # Automatically configure RC file if needed
-            add_bash_completion_config "${BASH_COMPLETION_DIR}/vesctl"
-            return
+            add_bash_completion_config "${BASH_COMPLETION_DIR}/vesctl" || true
+            return 0
         fi
     fi
 }
@@ -683,8 +683,8 @@ setup_zsh_completion() {
         if "$VESCTL_BIN" completion zsh > "${ZSH_COMPLETION_DIR}/_vesctl" 2>/dev/null; then
             success "Zsh completion installed to ${ZSH_COMPLETION_DIR}/_vesctl"
             # Automatically configure RC file
-            add_zsh_completion_config "$ZSH_COMPLETION_DIR"
-            return
+            add_zsh_completion_config "$ZSH_COMPLETION_DIR" || true
+            return 0
         fi
     fi
 }


### PR DESCRIPTION
## Summary
- Fix install script exiting with code 1 after successful completion
- Prevent non-zero return values from shell RC update functions from propagating

## Problem
The install script was failing with exit code 1 even after successfully:
- Downloading the binary
- Verifying the checksum
- Installing to the target directory
- Setting up shell completions

The issue was that `add_bash_completion_config()` and `add_zsh_completion_config()` return 1 to indicate "RC file was modified". With `set -eu` enabled, this non-zero return value propagated through the call chain and caused the script to exit.

## Solution
- Add `|| true` to ignore the return value from RC update functions
- Explicitly return 0 from completion setup functions to indicate success

## Test plan
- [ ] Merge to trigger release and docs workflow
- [ ] Verify install script completes successfully
- [ ] Verify shell completions are properly configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)