### PR TITLE
feat: bundle shell completions with Homebrew cask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ vesctl.windows-*
 *.darwin-*
 *.linux-*
 *.windows-*
+
+# Generated shell completions (created during release)
+completions/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,6 +9,7 @@ before:
   hooks:
     - go mod tidy
     - go generate ./...
+    - ./scripts/completions.sh
 
 builds:
   - id: vesctl
@@ -46,6 +47,7 @@ archives:
     files:
       - README.md
       - LICENSE*
+      - completions/*
 
 checksum:
   name_template: "checksums.txt"
@@ -132,6 +134,10 @@ homebrew_casks:
   - name: vesctl
     binaries:
       - vesctl
+    completions:
+      bash: completions/vesctl.bash
+      zsh: completions/vesctl.zsh
+      fish: completions/vesctl.fish
     repository:
       owner: robinmordasiewicz
       name: homebrew-tap

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -7,28 +7,33 @@ import (
 )
 
 var completionCmd = &cobra.Command{
-	Use:   "completion [bash|zsh]",
-	Short: "Generate shell completion scripts for bash or zsh.",
+	Use:   "completion [bash|zsh|fish]",
+	Short: "Generate shell completion scripts for bash, zsh, or fish.",
 	Long: `To load completions:
+
 Bash:
+  $ source <(vesctl completion bash)
 
-$ source <(vesctl completion bash)
-
-# To load completions for each session, execute once:
-Linux:
-  $ vesctl completion bash > /etc/bash_completion.d/yourprogram
-MacOS:
-  $ vesctl completion bash > /usr/local/etc/bash_completion.d/yourprogram
+  # To load completions for each session, execute once:
+  Linux:
+    $ vesctl completion bash > /etc/bash_completion.d/vesctl
+  MacOS:
+    $ vesctl completion bash > /usr/local/etc/bash_completion.d/vesctl
 
 Zsh:
+  $ source <(vesctl completion zsh)
 
- $ source <(vesctl completion zsh)
+  # To load completions for each session, execute once:
+  $ vesctl completion zsh > "${fpath[1]}/_vesctl"
 
- # To load completions for each session, execute once:
- $ vesctl completion zsh > "${fpath[1]}/_vesctl"
+Fish:
+  $ vesctl completion fish | source
+
+  # To load completions for each session, execute once:
+  $ vesctl completion fish > ~/.config/fish/completions/vesctl.fish
 `,
 	DisableFlagsInUseLine: true,
-	ValidArgs:             []string{"bash", "zsh"},
+	ValidArgs:             []string{"bash", "zsh", "fish"},
 	Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
 	Run: func(cmd *cobra.Command, args []string) {
 		switch args[0] {
@@ -36,6 +41,8 @@ Zsh:
 			_ = cmd.Root().GenBashCompletion(os.Stdout)
 		case "zsh":
 			_ = cmd.Root().GenZshCompletion(os.Stdout)
+		case "fish":
+			_ = cmd.Root().GenFishCompletion(os.Stdout, true)
 		}
 	},
 }

--- a/scripts/completions.sh
+++ b/scripts/completions.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Generate shell completion files for GoReleaser builds
+set -e
+
+# Clean and create completions directory
+rm -rf completions
+mkdir -p completions
+
+# Generate completions for all supported shells
+for sh in bash zsh fish; do
+    echo "Generating ${sh} completions..."
+    go run . completion "${sh}" > "completions/vesctl.${sh}"
+done
+
+echo "Shell completions generated in completions/"
+ls -la completions/

--- a/scripts/templates/homebrew.md.j2
+++ b/scripts/templates/homebrew.md.j2
@@ -14,9 +14,6 @@ brew install --cask vesctl
 {{ install_output }}
 ```
 
-{% if generation_date %}
-*Output captured on {{ generation_date }}*
-{% endif %}
 {% endif %}
 
 **Upgrade to latest version:**


### PR DESCRIPTION
## Summary
- Add fish shell support to completion command
- Create scripts/completions.sh to generate completion files during release
- Update .goreleaser.yaml to include completions in archives and cask config
- Users get bash, zsh, and fish completions automatically after brew install

## Test plan
- [x] Verify fish completion generation works
- [x] Verify completions.sh script generates all three shell completions
- [x] Verify goreleaser config validates successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)