### PR TITLE
docs: add Windows installation documentation with dynamic output capture

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -248,10 +248,144 @@ jobs:
           path: docs/
           retention-days: 7
 
+  build-windows-docs:
+    name: Build Windows Docs
+    runs-on: windows-latest
+    needs: check-spec
+    # Run when there's a recent release (workflow_run) or on other triggers
+    if: |
+      always() && !failure() && !cancelled() &&
+      (github.event_name != 'workflow_run' || needs.check-spec.outputs.recent_release == 'true')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Python dependencies
+        run: pip install jinja2
+
+      - name: Wait for Windows release asset
+        id: wait-assets
+        shell: pwsh
+        run: |
+          $maxRetries = 10
+          $retryDelay = 30
+
+          # Get the latest release version
+          $latestTag = gh api repos/${{ github.repository }}/releases/latest --jq '.tag_name' 2>$null
+          if (-not $latestTag) {
+            Write-Host "::error::No releases found"
+            exit 1
+          }
+
+          Write-Host "Latest release: $latestTag"
+          $version = $latestTag.TrimStart('v')
+          $expectedAsset = "vesctl_${version}_windows_amd64.zip"
+
+          Write-Host "Waiting for asset: $expectedAsset"
+
+          for ($i = 1; $i -le $maxRetries; $i++) {
+            Write-Host "Check $i of $maxRetries..."
+
+            $assetCount = gh api repos/${{ github.repository }}/releases/latest --jq ".assets | map(select(.name == `"$expectedAsset`")) | length" 2>$null
+            if ($assetCount -gt 0) {
+              Write-Host "Asset $expectedAsset is available!"
+              echo "assets_ready=true" >> $env:GITHUB_OUTPUT
+              echo "version=$version" >> $env:GITHUB_OUTPUT
+              exit 0
+            }
+
+            if ($i -eq $maxRetries) {
+              Write-Host "::error::Asset $expectedAsset not available after $maxRetries attempts"
+              echo "assets_ready=false" >> $env:GITHUB_OUTPUT
+              exit 1
+            }
+
+            Write-Host "Asset not ready, waiting ${retryDelay}s before retry..."
+            Start-Sleep -Seconds $retryDelay
+          }
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Download and install vesctl
+        id: install
+        shell: pwsh
+        run: |
+          $version = "${{ steps.wait-assets.outputs.version }}"
+          $url = "https://github.com/${{ github.repository }}/releases/download/v$version/vesctl_${version}_windows_amd64.zip"
+
+          Write-Host "Downloading vesctl $version from $url"
+
+          # Capture installation output
+          $output = @()
+
+          # Download
+          $output += "Downloading vesctl_${version}_windows_amd64.zip..."
+          Invoke-WebRequest -Uri $url -OutFile vesctl.zip
+          $output += "Download complete."
+
+          # Extract
+          $installDir = "$env:LOCALAPPDATA\Programs\vesctl"
+          $output += "Extracting to $installDir..."
+          New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+          Expand-Archive -Path vesctl.zip -DestinationPath $installDir -Force
+          $output += "Extraction complete."
+
+          # Add to PATH
+          $env:PATH = "$installDir;$env:PATH"
+
+          # Verify installation
+          $output += ""
+          $output += "Verifying installation:"
+          $versionOutput = & "$installDir\vesctl.exe" version 2>&1
+          $output += $versionOutput
+
+          # Write output to file
+          $output | Out-File -FilePath install-output.txt -Encoding utf8
+
+          # Parse version info
+          $versionLine = $versionOutput | Select-String -Pattern "vesctl version"
+          $commitLine = $versionOutput | Select-String -Pattern "commit:"
+          $builtLine = $versionOutput | Select-String -Pattern "built:"
+          $goLine = $versionOutput | Select-String -Pattern "go:"
+          $platformLine = $versionOutput | Select-String -Pattern "platform:"
+
+          echo "version=$version" >> $env:GITHUB_OUTPUT
+          if ($commitLine) { echo "commit=$($commitLine -replace '.*commit:\s*', '')" >> $env:GITHUB_OUTPUT }
+          if ($builtLine) { echo "built=$($builtLine -replace '.*built:\s*', '')" >> $env:GITHUB_OUTPUT }
+          if ($goLine) { echo "go_version=$($goLine -replace '.*go:\s*', '')" >> $env:GITHUB_OUTPUT }
+          if ($platformLine) { echo "platform=$($platformLine -replace '.*platform:\s*', '')" >> $env:GITHUB_OUTPUT }
+
+          Write-Host "Installation output captured:"
+          Get-Content install-output.txt
+
+      - name: Generate Windows docs
+        shell: pwsh
+        run: |
+          python scripts/generate-windows-docs.py `
+            --version "${{ steps.install.outputs.version }}" `
+            --commit "${{ steps.install.outputs.commit }}" `
+            --built "${{ steps.install.outputs.built }}" `
+            --go-version "${{ steps.install.outputs.go_version }}" `
+            --platform "${{ steps.install.outputs.platform }}" `
+            --install-output (Get-Content install-output.txt -Raw) `
+            --output docs/install/windows.md
+
+      - name: Upload Windows docs artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-docs
+          path: docs/install/windows.md
+          retention-days: 7
+
   build:
     name: Build Documentation
     runs-on: macos-latest
-    needs: [check-spec, generate]
+    needs: [check-spec, generate, build-windows-docs]
     # Run unless: failed, cancelled, or workflow_run without recent release
     if: |
       always() && !failure() && !cancelled() &&
@@ -268,6 +402,13 @@ jobs:
         with:
           name: generated-docs
           path: docs/
+
+      - name: Download Windows docs
+        if: needs.build-windows-docs.result == 'success'
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-docs
+          path: docs/install/
 
       - name: Restore cached docs
         if: needs.generate.result == 'skipped'

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ docs/commands/
 docs/install/homebrew.md
 docs/install/script.md
 docs/install/source.md
+docs/install/windows.md
 
 # MkDocs build output
 site/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,6 +90,7 @@ nav:
     - install/index.md
     - Homebrew: install/homebrew.md
     - Scripted: install/script.md
+    - Windows: install/windows.md
     - Source: install/source.md
     - Shell Completions: install/completions.md
     - Environment Variables: install/environment-variables.md

--- a/scripts/generate-windows-docs.py
+++ b/scripts/generate-windows-docs.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""
+Generate Windows installation documentation with real version info.
+
+Usage:
+    python scripts/generate-windows-docs.py \
+        --version 1.2.0 \
+        --commit abc1234 \
+        --built 2024-12-09T10:00:00Z \
+        --go-version go1.23.4 \
+        --platform windows/amd64 \
+        --output docs/install/windows.md
+"""
+
+import argparse
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate Windows docs with real version info"
+    )
+    parser.add_argument("--version", help="vesctl version")
+    parser.add_argument("--commit", help="Git commit hash")
+    parser.add_argument("--built", help="Build timestamp")
+    parser.add_argument("--go-version", help="Go version used for build")
+    parser.add_argument("--platform", help="Target platform (os/arch)")
+    parser.add_argument("--install-output", help="Captured Windows installation output")
+    parser.add_argument(
+        "--output",
+        default="docs/install/windows.md",
+        help="Output file path"
+    )
+    parser.add_argument(
+        "--templates",
+        default="scripts/templates",
+        help="Templates directory"
+    )
+
+    args = parser.parse_args()
+
+    # Setup Jinja2
+    env = Environment(
+        loader=FileSystemLoader(args.templates),
+        trim_blocks=True,
+        lstrip_blocks=True,
+    )
+
+    template = env.get_template("windows.md.j2")
+
+    # Clean up install output (remove ANSI codes if present)
+    install_output = args.install_output
+    if install_output:
+        # Remove ANSI escape codes
+        install_output = re.sub(r'\x1b\[[0-9;]*m', '', install_output)
+        # Remove Windows-specific escape sequences
+        install_output = re.sub(r'\x1b\[[0-9;]*[A-Za-z]', '', install_output)
+        install_output = install_output.strip()
+
+    content = template.render(
+        version=args.version,
+        commit=args.commit,
+        built=args.built,
+        go_version=args.go_version,
+        platform=args.platform,
+        install_output=install_output,
+        generation_date=datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+    )
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(content)
+
+    print(f"Generated: {output_path}")
+    if args.version:
+        print(f"  Version:  {args.version}")
+        print(f"  Commit:   {args.commit}")
+        print(f"  Built:    {args.built}")
+        print(f"  Go:       {args.go_version}")
+        print(f"  Platform: {args.platform}")
+    else:
+        print("  (No version info provided, using template defaults)")
+    if install_output:
+        print(f"  Install output: {len(install_output)} characters")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/templates/windows.md.j2
+++ b/scripts/templates/windows.md.j2
@@ -1,0 +1,170 @@
+# Windows
+
+Install vesctl on Windows using PowerShell.
+
+## Quick Install
+
+Download and extract the latest release:
+
+=== "PowerShell (amd64)"
+
+    ```powershell
+    # Download latest release
+    $version = "{{ version or 'X.Y.Z' }}"
+    $url = "https://github.com/robinmordasiewicz/vesctl/releases/download/v$version/vesctl_${version}_windows_amd64.zip"
+    Invoke-WebRequest -Uri $url -OutFile vesctl.zip
+
+    # Extract to installation directory
+    $installDir = "$env:LOCALAPPDATA\Programs\vesctl"
+    New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+    Expand-Archive -Path vesctl.zip -DestinationPath $installDir -Force
+
+    # Add to PATH for current session
+    $env:PATH = "$installDir;$env:PATH"
+
+    # Verify installation
+    vesctl version
+    ```
+
+=== "PowerShell (arm64)"
+
+    ```powershell
+    # Download latest release
+    $version = "{{ version or 'X.Y.Z' }}"
+    $url = "https://github.com/robinmordasiewicz/vesctl/releases/download/v$version/vesctl_${version}_windows_arm64.zip"
+    Invoke-WebRequest -Uri $url -OutFile vesctl.zip
+
+    # Extract to installation directory
+    $installDir = "$env:LOCALAPPDATA\Programs\vesctl"
+    New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+    Expand-Archive -Path vesctl.zip -DestinationPath $installDir -Force
+
+    # Add to PATH for current session
+    $env:PATH = "$installDir;$env:PATH"
+
+    # Verify installation
+    vesctl version
+    ```
+
+{% if install_output %}
+**Example output:**
+
+```text
+{{ install_output }}
+```
+
+{% if generation_date %}
+*Output captured on {{ generation_date }}*
+{% endif %}
+{% endif %}
+
+## Permanent PATH Configuration
+
+To make vesctl available in all PowerShell sessions, add it to your user PATH:
+
+```powershell
+# Add to user PATH permanently
+$installDir = "$env:LOCALAPPDATA\Programs\vesctl"
+$currentPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+if ($currentPath -notlike "*$installDir*") {
+    [Environment]::SetEnvironmentVariable("PATH", "$installDir;$currentPath", "User")
+    Write-Host "Added $installDir to user PATH. Restart your terminal to apply."
+}
+```
+
+## Manual Download
+
+Alternatively, download directly from GitHub:
+
+1. Visit [GitHub Releases](https://github.com/robinmordasiewicz/vesctl/releases/latest)
+2. Download `vesctl_{{ version or 'X.Y.Z' }}_windows_amd64.zip` (or `arm64` for ARM processors)
+3. Extract to a directory of your choice
+4. Add the directory to your PATH
+
+## Verify Installation
+
+After installation, verify vesctl is working:
+
+```powershell
+vesctl version
+```
+
+{% if version and commit and built %}
+Expected output:
+
+```text
+vesctl version {{ version }}
+  commit:   {{ commit }}
+  built:    {{ built }}
+  go:       {{ go_version if go_version else "go1.23.x" }}
+  platform: {{ platform if platform else "windows/amd64" }}
+```
+{% endif %}
+
+## Shell Completion
+
+Enable PowerShell tab completion:
+
+```powershell
+# Load completions for current session
+vesctl completion powershell | Out-String | Invoke-Expression
+
+# Add to PowerShell profile for all sessions
+vesctl completion powershell >> $PROFILE
+```
+
+!!! note "PowerShell Profile"
+    If `$PROFILE` doesn't exist, create it first:
+    ```powershell
+    New-Item -ItemType File -Force -Path $PROFILE
+    ```
+
+## Upgrade
+
+To upgrade to a newer version:
+
+```powershell
+# Download and extract new version (same as install)
+$version = "NEW_VERSION"
+$url = "https://github.com/robinmordasiewicz/vesctl/releases/download/v$version/vesctl_${version}_windows_amd64.zip"
+Invoke-WebRequest -Uri $url -OutFile vesctl.zip
+Expand-Archive -Path vesctl.zip -DestinationPath "$env:LOCALAPPDATA\Programs\vesctl" -Force
+```
+
+## Uninstall
+
+Remove vesctl from your system:
+
+```powershell
+# Remove installation directory
+Remove-Item -Recurse -Force "$env:LOCALAPPDATA\Programs\vesctl"
+
+# Remove from user PATH
+$installDir = "$env:LOCALAPPDATA\Programs\vesctl"
+$currentPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+$newPath = ($currentPath -split ';' | Where-Object { $_ -ne $installDir }) -join ';'
+[Environment]::SetEnvironmentVariable("PATH", $newPath, "User")
+
+# Remove completion from profile (if added)
+# Edit $PROFILE and remove the vesctl completion line
+```
+
+## Troubleshooting
+
+### "vesctl is not recognized"
+
+Ensure the installation directory is in your PATH:
+
+```powershell
+$env:PATH -split ';' | Select-String "vesctl"
+```
+
+If not found, add it manually or restart your terminal after permanent PATH configuration.
+
+### Execution Policy Error
+
+If you get an execution policy error when loading completions:
+
+```powershell
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+```


### PR DESCRIPTION
## Summary

- Add Windows installation documentation following the same dynamic output capture pattern used for Homebrew, script, and source install docs
- Uses `windows-latest` GitHub Actions runner to capture real installation output
- Includes PowerShell installation instructions, PATH configuration, shell completions, and troubleshooting

## Changes

- **New**: `scripts/templates/windows.md.j2` - Jinja2 template for Windows docs
- **New**: `scripts/generate-windows-docs.py` - Python generator script
- **Modified**: `.github/workflows/docs.yml` - Added `build-windows-docs` job
- **Modified**: `.gitignore` - Added `docs/install/windows.md`
- **Modified**: `mkdocs.yml` - Added Windows to navigation

## Test plan

- [ ] Verify workflow runs successfully on `windows-latest`
- [ ] Verify Windows docs artifact is generated
- [ ] Verify Windows docs appear in MkDocs build
- [ ] Test documented PowerShell commands manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)