### PR TITLE
docs: add platform tabs to environment variables page

### DIFF
--- a/docs/install/environment-variables.md
+++ b/docs/install/environment-variables.md
@@ -4,66 +4,105 @@ vesctl can be configured using environment variables.
 
 ## Authentication Variables
 
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `VES_P12_PASSWORD` | Password for P12 bundle | `export VES_P12_PASSWORD="secret"` |
-| `VES_P12_FILE` | Path to P12 bundle | `export VES_P12_FILE="/path/to/creds.p12"` |
-| `VES_CERT` | Path to client certificate | `export VES_CERT="/path/to/cert.pem"` |
-| `VES_KEY` | Path to client key | `export VES_KEY="/path/to/key.pem"` |
+| Variable | Description |
+|----------|-------------|
+| `VES_P12_PASSWORD` | Password for P12 bundle |
+| `VES_P12_FILE` | Path to P12 bundle |
+| `VES_CERT` | Path to client certificate |
+| `VES_KEY` | Path to client key |
 
 ## Connection Variables
 
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `VES_API_URL` | API server URL(s) | `export VES_API_URL="https://tenant.console.ves.volterra.io/api"` |
-| `VES_CACERT` | Path to CA certificate | `export VES_CACERT="/path/to/ca.pem"` |
+| Variable | Description |
+|----------|-------------|
+| `VES_API_URL` | API server URL(s) |
+| `VES_CACERT` | Path to CA certificate |
 
 ## Output Variables
 
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `VES_OUTPUT` | Default output format | `export VES_OUTPUT="json"` |
+| Variable | Description |
+|----------|-------------|
+| `VES_OUTPUT` | Default output format |
 
 ## Configuration Variables
 
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `VES_CONFIG` | Path to config file | `export VES_CONFIG="/path/to/config.yaml"` |
+| Variable | Description |
+|----------|-------------|
+| `VES_CONFIG` | Path to config file |
 
 ## Usage Examples
 
 ### Basic Setup
 
-```bash
-# Set server URL
-export VES_API_URL="https://your-tenant.console.ves.volterra.io/api"
+=== "Mac/Linux"
 
-# Set P12 credentials
-export VES_P12_FILE="/path/to/api-creds.p12"
-export VES_P12_PASSWORD="your-password"
+    ```bash
+    # Set server URL
+    export VES_API_URL="https://your-tenant.console.ves.volterra.io/api"
 
-# Run command
-vesctl configuration list namespace
-```
+    # Set P12 credentials
+    export VES_P12_FILE="/path/to/api-creds.p12"
+    export VES_P12_PASSWORD="your-password"
+
+    # Run command
+    vesctl configuration list namespace
+    ```
+
+=== "Windows"
+
+    ```powershell
+    # Set server URL
+    $env:VES_API_URL = "https://your-tenant.console.ves.volterra.io/api"
+
+    # Set P12 credentials
+    $env:VES_P12_FILE = "C:\path\to\api-creds.p12"
+    $env:VES_P12_PASSWORD = "your-password"
+
+    # Run command
+    vesctl configuration list namespace
+    ```
 
 ### Certificate Authentication
 
-```bash
-export VES_API_URL="https://your-tenant.console.ves.volterra.io/api"
-export VES_CERT="/path/to/cert.pem"
-export VES_KEY="/path/to/key.pem"
+=== "Mac/Linux"
 
-vesctl configuration list namespace
-```
+    ```bash
+    export VES_API_URL="https://your-tenant.console.ves.volterra.io/api"
+    export VES_CERT="/path/to/cert.pem"
+    export VES_KEY="/path/to/key.pem"
+
+    vesctl configuration list namespace
+    ```
+
+=== "Windows"
+
+    ```powershell
+    $env:VES_API_URL = "https://your-tenant.console.ves.volterra.io/api"
+    $env:VES_CERT = "C:\path\to\cert.pem"
+    $env:VES_KEY = "C:\path\to\key.pem"
+
+    vesctl configuration list namespace
+    ```
 
 ### JSON Output Default
 
-```bash
-export VES_OUTPUT="json"
+=== "Mac/Linux"
 
-# All commands now output JSON by default
-vesctl configuration list namespace
-```
+    ```bash
+    export VES_OUTPUT="json"
+
+    # All commands now output JSON by default
+    vesctl configuration list namespace
+    ```
+
+=== "Windows"
+
+    ```powershell
+    $env:VES_OUTPUT = "json"
+
+    # All commands now output JSON by default
+    vesctl configuration list namespace
+    ```
 
 ## Shell Configuration
 
@@ -92,6 +131,20 @@ set -x VES_API_URL "https://your-tenant.console.ves.volterra.io/api"
 set -x VES_P12_FILE "$HOME/api-creds.p12"
 set -x VES_P12_PASSWORD "your-password"
 ```
+
+### PowerShell ($PROFILE)
+
+```powershell
+$env:VES_API_URL = "https://your-tenant.console.ves.volterra.io/api"
+$env:VES_P12_FILE = "$env:USERPROFILE\api-creds.p12"
+$env:VES_P12_PASSWORD = "your-password"
+```
+
+!!! note "PowerShell Profile"
+    Add to your `$PROFILE` for persistent configuration. Create it first if needed:
+    ```powershell
+    New-Item -ItemType File -Force -Path $PROFILE
+    ```
 
 ## Precedence
 


### PR DESCRIPTION
## Summary
- Add Mac/Linux and Windows tabs to all usage examples
- Add PowerShell section to shell configuration
- Simplify variable tables (examples now in tabbed sections)
- Users can select their platform for environment variable syntax

## Test plan
- [ ] Verify tabs render correctly on the documentation site
- [ ] Test tab selection syncs across the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)