### PR TITLE
fix: add retry logic with exponential backoff to install script download

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -596,13 +596,36 @@ jobs:
             brew uninstall --cask vesctl 2>/dev/null || brew uninstall vesctl 2>/dev/null || true
           fi
 
-          # Run install script and capture output to file
-          # Using script execution to capture both stdout and stderr
-          curl -fsSL https://raw.githubusercontent.com/${{ github.repository }}/main/install.sh > /tmp/install.sh
-          CURL_EXIT=$?
+          # Download install script with retry and exponential backoff
+          MAX_RETRIES=5
+          RETRY_COUNT=0
+          BASE_DELAY=5
+          CURL_EXIT=1
+
+          echo "Downloading install script from raw.githubusercontent.com..."
+
+          while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+            RETRY_COUNT=$((RETRY_COUNT + 1))
+            echo "Attempt $RETRY_COUNT of $MAX_RETRIES..."
+
+            curl -fsSL --connect-timeout 30 --max-time 60 \
+              https://raw.githubusercontent.com/${{ github.repository }}/main/install.sh > /tmp/install.sh
+            CURL_EXIT=$?
+
+            if [ $CURL_EXIT -eq 0 ]; then
+              echo "Successfully downloaded install script"
+              break
+            fi
+
+            if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
+              DELAY=$((BASE_DELAY * (2 ** (RETRY_COUNT - 1))))
+              echo "::warning::Download failed (exit code: $CURL_EXIT), retrying in ${DELAY}s..."
+              sleep $DELAY
+            fi
+          done
 
           if [ $CURL_EXIT -ne 0 ]; then
-            echo "::error::Failed to download install script (exit code: $CURL_EXIT)"
+            echo "::error::Failed to download install script after $MAX_RETRIES attempts (exit code: $CURL_EXIT)"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
- Add 5 retry attempts with exponential backoff (5s, 10s, 20s, 40s, 80s) to the install script download step
- Add connect timeout (30s) and max time (60s) to curl command
- Log each attempt and emit warnings on transient failures
- Prevents workflow failures from transient network errors (like exit code 56)

## Problem
The docs workflow was failing intermittently with curl exit code 56 (connection reset) when downloading the install script from raw.githubusercontent.com. This required manual re-runs of failed jobs.

## Solution
Implemented deterministic retry logic with exponential backoff, ensuring the workflow can recover from transient network issues without manual intervention.

## Test plan
- [ ] Workflow runs successfully on PR
- [ ] Retry logic activates if network issues occur (verified by logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)