### PR TITLE
docs: add shell completion setup instructions for Homebrew

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -149,3 +149,15 @@ homebrew_casks:
     commit_msg_template: "chore: Update {{ .ProjectName }} cask to {{ .Tag }}"
     homepage: https://robinmordasiewicz.github.io/vesctl
     description: Command-line interface for F5 Distributed Cloud
+    caveats: |
+      Shell completions have been installed for bash, zsh, and fish.
+
+      For setup instructions, see:
+        https://robinmordasiewicz.github.io/vesctl/install/homebrew/#shell-completions
+
+      Quick start:
+        Zsh: Usually works automatically. Restart your terminal.
+        Bash: Run 'brew install bash-completion@2' first.
+        Fish: Works automatically.
+
+      Test with: vesctl [TAB]

--- a/scripts/templates/homebrew.md.j2
+++ b/scripts/templates/homebrew.md.j2
@@ -29,6 +29,56 @@ brew upgrade --cask vesctl
 brew uninstall --cask vesctl
 ```
 
+## Shell Completions
+
+The Homebrew cask includes shell completions for bash, zsh, and fish. These are installed automatically to Homebrew's managed directories.
+
+=== "Zsh"
+
+    Completions should work automatically if you have Homebrew's shell environment configured. Ensure your `~/.zshrc` contains:
+
+    ```bash
+    eval "$(brew shellenv)"
+    ```
+
+    If you're using Oh My Zsh, completions are enabled by default. Otherwise, add to your `~/.zshrc`:
+
+    ```bash
+    autoload -Uz compinit && compinit
+    ```
+
+    Restart your terminal and test with `vesctl <TAB>`.
+
+=== "Bash"
+
+    Install bash-completion if you haven't already:
+
+    ```bash
+    brew install bash-completion@2
+    ```
+
+    Add to your `~/.bash_profile` or `~/.bashrc`:
+
+    ```bash
+    [[ -r "$(brew --prefix)/etc/profile.d/bash_completion.sh" ]] && \
+      . "$(brew --prefix)/etc/profile.d/bash_completion.sh"
+    ```
+
+    Restart your terminal and test with `vesctl <TAB>`.
+
+=== "Fish"
+
+    Completions work automatically if fish was installed via Homebrew.
+
+    Test with `vesctl <TAB>`.
+
+!!! tip "Troubleshooting Completions"
+    If completions don't work after setup:
+
+    1. Ensure you've restarted your terminal
+    2. For zsh, try running `rm -f ~/.zcompdump*` then restart
+    3. Verify completions are installed: `ls $(brew --prefix)/share/zsh/site-functions/_vesctl`
+
 ## Verify Installation
 
 After installation, verify vesctl is working:


### PR DESCRIPTION
## Summary

- Add caveats to `.goreleaser.yaml` to display post-install instructions when users run `brew install --cask vesctl`
- Add detailed shell completion section to Homebrew docs template with tabbed instructions for zsh, bash, and fish
- Include troubleshooting tips for completion issues

## What users will see

After running `brew install --cask vesctl`, users will see:

```
==> Caveats
Shell completions have been installed for bash, zsh, and fish.

For setup instructions, see:
  https://robinmordasiewicz.github.io/vesctl/install/homebrew/#shell-completions

Quick start:
  Zsh: Usually works automatically. Restart your terminal.
  Bash: Run 'brew install bash-completion@2' first.
  Fish: Works automatically.

Test with: vesctl [TAB]
```

## Background

Homebrew casks can bundle shell completions (already configured), but Homebrew deliberately does NOT automatically modify shell config files like `.zshrc` or `.bashrc`. This is a security/robustness decision documented at [docs.brew.sh/Shell-Completion](https://docs.brew.sh/Shell-Completion).

The caveats provide a helpful bridge - informing users that completions are available and directing them to documentation for setup.

## Test plan

- [ ] Verify GoReleaser config is valid (`goreleaser check`)
- [ ] Verify caveats appear correctly in generated cask after next release
- [ ] Verify documentation renders correctly at `/install/homebrew/#shell-completions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)