### PR TITLE
fix: add caveats to Homebrew cask in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -353,7 +353,19 @@ jobs:
               end
             end
 
-            # No zap stanza required
+            caveats <<~EOS
+              Shell completions have been installed for bash, zsh, and fish.
+
+              For setup instructions, see:
+                https://robinmordasiewicz.github.io/vesctl/install/homebrew/#shell-completions
+
+              Quick start:
+                Zsh: Usually works automatically. Restart your terminal.
+                Bash: Run 'brew install bash-completion@2' first.
+                Fish: Works automatically.
+
+              Test with: vesctl [TAB]
+            EOS
           end
           CASKEOF
 


### PR DESCRIPTION
## Summary

The `update-cask` job in the release workflow was overwriting GoReleaser's generated cask with a hardcoded template that was missing the `caveats` stanza.

This PR adds caveats to the workflow's cask template so users see shell completion setup instructions after running `brew install --cask vesctl`.

## Problem

GoReleaser generates a cask with caveats from `.goreleaser.yaml`, but the `update-cask` job (which updates SHA256 hashes after macOS binary signing) replaces the entire cask file with a template that didn't include caveats.

## Solution

Add the caveats block directly to the workflow's heredoc template:

```ruby
caveats <<~EOS
  Shell completions have been installed for bash, zsh, and fish.

  For setup instructions, see:
    https://robinmordasiewicz.github.io/vesctl/install/homebrew/#shell-completions

  Quick start:
    Zsh: Usually works automatically. Restart your terminal.
    Bash: Run 'brew install bash-completion@2' first.
    Fish: Works automatically.

  Test with: vesctl [TAB]
EOS
```

## Test plan

- [ ] Merge this PR
- [ ] Create a new release (or wait for semantic-release)
- [ ] Verify caveats appear when running `brew install --cask vesctl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)