### PR TITLE
fix: build explicit binary before generating shell completions

### DIFF
--- a/scripts/completions.sh
+++ b/scripts/completions.sh
@@ -6,11 +6,19 @@ set -e
 rm -rf completions
 mkdir -p completions
 
-# Generate completions for all supported shells
+# Build binary first to ensure it exists
+# go run . can have issues in CI environments
+echo "Building vesctl for completion generation..."
+go build -o /tmp/vesctl-completions .
+
+# Generate completions for all supported shells using built binary
 for sh in bash zsh fish; do
     echo "Generating ${sh} completions..."
-    go run . completion "${sh}" > "completions/vesctl.${sh}"
+    /tmp/vesctl-completions completion "${sh}" > "completions/vesctl.${sh}"
 done
+
+# Cleanup temp binary
+rm -f /tmp/vesctl-completions
 
 echo "Shell completions generated in completions/"
 ls -la completions/


### PR DESCRIPTION
## Summary

- Fix completions.sh to build explicit binary before generating completions
- The previous `go run . completion` approach had issues in CI environments
- Completions are now properly generated and included in release archives

## Problem

Shell completions were not being included in release archives, causing the Homebrew cask installation to fail to provide tab completions despite the caveats message claiming they were installed.

## Solution

Changed `scripts/completions.sh` to:
1. Build an explicit binary (`/tmp/vesctl-completions`)
2. Use that binary to generate completions for bash, zsh, and fish
3. Clean up the temporary binary after generation

## Test Plan

- [x] Ran `./scripts/completions.sh` locally - generates all three completion files
- [ ] After merge, verify release archive contains `completions/` directory
- [ ] Test `brew upgrade --cask vesctl` and verify completions work

🤖 Generated with [Claude Code](https://claude.com/claude-code)