### PR TITLE
fix: add verbose debugging to completions script

### DIFF
--- a/scripts/completions.sh
+++ b/scripts/completions.sh
@@ -2,6 +2,12 @@
 # Generate shell completion files for GoReleaser builds
 set -e
 
+# Output to stderr so GoReleaser captures it
+exec 1>&2
+
+echo "=== Starting completion generation ==="
+echo "Working directory: $(pwd)"
+
 # Clean and create completions directory
 rm -rf completions
 mkdir -p completions
@@ -9,16 +15,40 @@ mkdir -p completions
 # Build binary first to ensure it exists
 # go run . can have issues in CI environments
 echo "Building vesctl for completion generation..."
-go build -o /tmp/vesctl-completions .
+go build -o ./vesctl-completions .
+
+if [ ! -f "./vesctl-completions" ]; then
+    echo "ERROR: Failed to build vesctl-completions binary"
+    exit 1
+fi
+
+echo "Binary built successfully"
 
 # Generate completions for all supported shells using built binary
 for sh in bash zsh fish; do
     echo "Generating ${sh} completions..."
-    /tmp/vesctl-completions completion "${sh}" > "completions/vesctl.${sh}"
+    ./vesctl-completions completion "${sh}" > "completions/vesctl.${sh}"
+
+    if [ ! -s "completions/vesctl.${sh}" ]; then
+        echo "ERROR: Failed to generate ${sh} completions (file empty or missing)"
+        exit 1
+    fi
 done
 
 # Cleanup temp binary
-rm -f /tmp/vesctl-completions
+rm -f ./vesctl-completions
 
-echo "Shell completions generated in completions/"
+echo "=== Completion generation finished ==="
+echo "Generated files:"
 ls -la completions/
+
+# Verify files exist and have content
+for sh in bash zsh fish; do
+    if [ ! -s "completions/vesctl.${sh}" ]; then
+        echo "ERROR: completions/vesctl.${sh} is missing or empty"
+        exit 1
+    fi
+    echo "  completions/vesctl.${sh}: $(wc -c < completions/vesctl.${sh}) bytes"
+done
+
+echo "All completions generated successfully"


### PR DESCRIPTION
## Summary

- Add verbose debugging output to completions script
- Redirect output to stderr so GoReleaser captures it
- Add explicit verification of each step

## Problem

The previous fix (PR #129) didn't result in completions being included in release archives. Local testing with `goreleaser release --snapshot` shows completions ARE being bundled correctly. This PR adds debugging to help identify what's different in CI.

## Changes

- Output to stderr for GoReleaser visibility
- Print working directory
- Verify binary builds successfully
- Verify each completion file exists and has content
- Exit with error if any step fails

## Test Plan

- [ ] Watch release workflow logs for debugging output
- [ ] Verify if completions are in archive

🤖 Generated with [Claude Code](https://claude.com/claude-code)