### PR TITLE
fix: remove completions/ from gitignore for GoReleaser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,5 +74,5 @@ vesctl.windows-*
 *.linux-*
 *.windows-*
 
-# Generated shell completions (created during release)
-completions/
+# Generated shell completions are now bundled in releases
+# completions/ - NOT gitignored so GoReleaser can include them


### PR DESCRIPTION
## Summary
- Remove `completions/` from `.gitignore` so GoReleaser can include generated completion files in release archives

## Problem
Shell completions were not being bundled in release archives despite:
1. `scripts/completions.sh` generating the files correctly (verified in hook logs)
2. `.goreleaser.yaml` having correct `files: [completions/*]` config
3. Local `goreleaser release --snapshot` working perfectly

## Root Cause
GoReleaser appears to respect `.gitignore` when determining which files to include in archives. Since `completions/` was gitignored, the generated files were being skipped in CI releases even though they existed.

## Verification
After merge, the next release should include `completions/` directory in archives:
```bash
tar -tzf vesctl_X.Y.Z_darwin_arm64.tar.gz
# Should show:
# vesctl
# README.md
# completions/vesctl.bash
# completions/vesctl.zsh
# completions/vesctl.fish
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)