### PR TITLE
fix: preserve completions when repackaging signed macOS binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,9 +250,10 @@ jobs:
               --team-id "$APPLE_TEAM_ID" \
               --wait
 
-            # Repackage as tar.gz (matching original format)
+            # Repackage as tar.gz (preserving all original files including completions)
             cd $RUNNER_TEMP/sign_${ARCH}
-            tar -czf $RUNNER_TEMP/${ASSET_NAME} vesctl
+            # Use * to get all files without ./ prefix, preserving original archive structure
+            tar -czf $RUNNER_TEMP/${ASSET_NAME} *
             cd -
 
             # Upload signed binary to release (replace unsigned)
@@ -330,6 +331,9 @@ jobs:
             end
 
             binary "vesctl"
+            bash_completion "completions/vesctl.bash"
+            zsh_completion "completions/vesctl.zsh"
+            fish_completion "completions/vesctl.fish"
 
             on_macos do
               on_intel do


### PR DESCRIPTION
## Summary
- Fix macOS signing job to preserve all files when repackaging archives
- Add completion stanzas to Homebrew cask template

## Problem
The macOS signing job in the release workflow was only including the signed `vesctl` binary when repackaging. This stripped:
- README.md
- LICENSE
- completions/vesctl.bash
- completions/vesctl.zsh  
- completions/vesctl.fish

The Homebrew cask template was also missing the completion stanzas.

## Solution
1. Change repackaging from `tar -czf ... vesctl` to `tar -czf ... *` to include all files
2. Add `bash_completion`, `zsh_completion`, `fish_completion` stanzas to cask template

## Test Plan
- [ ] Merge this PR
- [ ] Wait for new release to be created
- [ ] Download release archive and verify completions are included:
  ```bash
  tar -tzf vesctl_X.Y.Z_darwin_arm64.tar.gz
  # Should show: vesctl, README.md, completions/vesctl.{bash,zsh,fish}
  ```
- [ ] Run `brew upgrade --cask vesctl`
- [ ] Verify completions work: `vesctl <TAB>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)