### PR TITLE
chore: restore completions/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,5 +74,5 @@ vesctl.windows-*
 *.linux-*
 *.windows-*
 
-# Generated shell completions are now bundled in releases
-# completions/ - NOT gitignored so GoReleaser can include them
+# Generated shell completions (created during release build)
+completions/


### PR DESCRIPTION
## Summary
Restore `completions/` to `.gitignore` to keep the repository clean.

## Context
- The completions directory is generated during the release build by `scripts/completions.sh`
- It should not be committed to the repository
- PR #131 removed it from gitignore based on a mistaken theory that GoReleaser was respecting gitignore
- The actual fix for completions bundling was PR #132 (preserving files during macOS binary repackaging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)