### PR TITLE
fix: allow shell completions to work without authentication

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,10 +59,12 @@ var rootCmd = &cobra.Command{
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		// Skip client initialization for non-API commands
 		skipCommands := map[string]bool{
-			"version":    true,
-			"completion": true,
-			"help":       true,
-			"vesctl":     true, // Root command itself
+			"version":          true,
+			"completion":       true,
+			"__complete":       true, // Cobra's shell completion handler
+			"__completeNoDesc": true, // Cobra's shell completion handler (no descriptions)
+			"help":             true,
+			"vesctl":           true, // Root command itself
 		}
 		if skipCommands[cmd.Name()] {
 			return nil


### PR DESCRIPTION
## Summary
- Fixed shell completions not working when VES_API_TOKEN is not set
- Added `__complete` and `__completeNoDesc` to the skipCommands list in PersistentPreRunE
- These are Cobra's hidden commands used for runtime shell completion generation

## Root Cause
Cobra's shell completion system invokes the CLI with hidden `__complete` or `__completeNoDesc` commands to generate completions dynamically. These commands were not in the skip list, so PersistentPreRunE was requiring authentication even for tab completion.

## Test plan
- [x] `vesctl __complete ""` now returns subcommands without authentication errors
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)