### PR TITLE
fix: add optional GITHUB_TOKEN support to install.sh for CI environments

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -630,7 +630,8 @@ jobs:
           fi
 
           # Run the install script and capture output
-          VES_NO_SUDO=1 VES_INSTALL_DIR=$HOME/.local/bin sh /tmp/install.sh > install-output.txt 2>&1
+          # Pass GITHUB_TOKEN to avoid API rate limits in CI
+          GITHUB_TOKEN=${{ github.token }} VES_NO_SUDO=1 VES_INSTALL_DIR=$HOME/.local/bin sh /tmp/install.sh > install-output.txt 2>&1
           INSTALL_EXIT_CODE=$?
 
           echo "Install output captured:"


### PR DESCRIPTION
## Summary
- Add optional GITHUB_TOKEN support to `http_get` function in install.sh
- When token is set, use authenticated GitHub API requests (5,000/hour limit)
- When token is NOT set, script works exactly as before for anonymous users
- Update docs.yml workflow to pass `github.token` to install script

## Problem
The Documentation workflow was failing because `install.sh` was hitting GitHub API rate limits (60 requests/hour for unauthenticated requests) in CI environments.

## Solution
Add optional GITHUB_TOKEN authentication to the install script's HTTP functions. The token is:
- **Optional**: Anonymous users can still run the script exactly as before
- **Backward compatible**: No changes needed for existing usage
- **CI-friendly**: Workflows can pass `${{ github.token }}` to avoid rate limits

## Test plan
- [ ] PR checks pass
- [ ] Merge and trigger Documentation workflow manually
- [ ] Verify "Test install script" step passes without rate limit errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)