### PR TITLE
fix: make navigation collapsible with accordion behavior

### DIFF
--- a/docs/javascripts/sidebar-fix.js
+++ b/docs/javascripts/sidebar-fix.js
@@ -77,4 +77,43 @@ if (!window.__navigationFixInitialized) {
 
   // Also handle browser back/forward
   window.addEventListener('popstate', applyFixes);
+
+  /**
+   * Accordion behavior for navigation
+   * Ensures only one section is expanded at a time within each navigation level
+   */
+  function setupAccordion() {
+    var sidebar = document.querySelector('.md-sidebar--primary');
+    if (!sidebar) return;
+
+    // Listen for toggle changes using event delegation
+    sidebar.addEventListener('change', function(e) {
+      if (!e.target.matches('.md-nav__toggle')) return;
+      if (!e.target.checked) return; // Only act on expansion
+
+      // Find sibling toggles at the same level
+      var parentItem = e.target.closest('.md-nav__item');
+      if (!parentItem) return;
+
+      var parentList = parentItem.parentElement;
+      if (!parentList) return;
+
+      var siblingToggles = parentList.querySelectorAll(':scope > .md-nav__item > .md-nav__toggle');
+
+      // Collapse all siblings except the one being expanded
+      siblingToggles.forEach(function(toggle) {
+        if (toggle !== e.target && toggle.checked) {
+          toggle.checked = false;
+        }
+      });
+    });
+  }
+
+  // Set up accordion behavior
+  setupAccordion();
+
+  // Re-setup accordion after instant navigation
+  if (typeof document$ !== 'undefined') {
+    document$.subscribe(setupAccordion);
+  }
 }

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -470,22 +470,23 @@ html {
 }
 
 /* Navigation Hierarchy - Clear Indentation by Level */
-/* Level 1 items - base indentation */
+/* Level 1 items - all left-justified at same position (parents) */
 .md-sidebar--primary .md-nav[data-md-level="1"] > .md-nav__list > .md-nav__item > .md-nav__link,
 .md-sidebar--primary .md-nav[data-md-level="1"] > .md-nav__list > .md-nav__item > label.md-nav__link {
   padding-left: 0.5rem !important;
+  margin-left: 0 !important;
 }
 
-/* Level 2 items - increased indentation */
+/* Level 2 items - indented under parents (children) */
 .md-sidebar--primary .md-nav[data-md-level="2"] > .md-nav__list > .md-nav__item > .md-nav__link,
 .md-sidebar--primary .md-nav[data-md-level="2"] > .md-nav__list > .md-nav__item > label.md-nav__link {
-  padding-left: 1.25rem !important;
+  padding-left: 1.5rem !important;
 }
 
-/* Level 3 items - maximum indentation */
+/* Level 3 items - further indented (grandchildren) */
 .md-sidebar--primary .md-nav[data-md-level="3"] > .md-nav__list > .md-nav__item > .md-nav__link,
 .md-sidebar--primary .md-nav[data-md-level="3"] > .md-nav__list > .md-nav__item > label.md-nav__link {
-  padding-left: 2rem !important;
+  padding-left: 2.5rem !important;
 }
 
 /* Nested navigation - even more compact */

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,7 +27,6 @@ theme:
     code: JetBrains Mono
   features:
     - navigation.tabs
-    - navigation.sections
     - navigation.indexes
     - navigation.path
     - navigation.top


### PR DESCRIPTION
## Summary
- Remove `navigation.sections` from mkdocs.yml to enable collapsible toggles
- Add accordion JavaScript to ensure only one section is expanded at a time
- Update CSS to ensure all Level 1 parents are left-justified at the same position

## Changes
The navigation now:
- Shows all parents (Api Endpoint, Completion, Configuration, Help, Request, Site, Version) collapsed by default
- Expands children only when parent toggle is clicked
- Collapses previously expanded section when a new section is opened (accordion behavior)
- Parents with children show toggle arrows for expand/collapse
- All parents are perfectly left-justified at the same horizontal position

## Test plan
- [ ] Navigate to /vesctl/commands/ - verify all parents are collapsed
- [ ] Click "Api Endpoint" toggle - verify it expands showing Control, Discover
- [ ] Click "Configuration" toggle - verify it expands AND Api Endpoint collapses
- [ ] Verify parents (Api Endpoint, Completion, Configuration, Help, Request, Site, Version) are all left-justified
- [ ] Test in dark mode - verify same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)