### PR TITLE
fix: add retry logic for GoReleaser installation in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,11 +126,36 @@ jobs:
           go-version: "1.24"
           cache: false
 
+      - name: Install GoReleaser with retry
+        shell: bash
+        run: |
+          max_retries=5
+          base_delay=15
+
+          for attempt in $(seq 1 $max_retries); do
+            echo "Attempt $attempt of $max_retries to install GoReleaser..."
+
+            # Try to download and install goreleaser
+            if curl -sSL --connect-timeout 30 --max-time 120 \
+                 https://goreleaser.com/static/run 2>/dev/null | bash -s -- --install-only 2>&1; then
+              echo "GoReleaser installed successfully"
+              goreleaser --version
+              exit 0
+            fi
+
+            if [ $attempt -lt $max_retries ]; then
+              delay=$((base_delay * attempt))
+              echo "::warning::Failed to install GoReleaser on attempt $attempt, retrying in ${delay}s..."
+              sleep $delay
+            fi
+          done
+
+          echo "::error::Failed to install GoReleaser after $max_retries attempts"
+          exit 1
+
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
-        with:
-          version: "~> v2"
-          args: release --clean
+        shell: bash
+        run: goreleaser release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}


### PR DESCRIPTION
## Summary
- Add retry logic for GoReleaser installation in the Release workflow
- Replace goreleaser-action with manual curl-based installation with retries
- 5 retry attempts with progressive delays (15s, 30s, 45s, 60s, 75s)
- Add curl timeouts (30s connect, 120s max)

## Root Cause
The Release workflow failed because GitHub was returning 503 errors when goreleaser-action tried to download GoReleaser from GitHub releases. The built-in retry in goreleaser-action (3 attempts) was not sufficient during prolonged GitHub infrastructure issues.

## Solution
Manual installation with more aggressive retry:
- 5 attempts (vs 3 in goreleaser-action)
- Progressive backoff delays
- Explicit curl timeouts
- Clear logging of retry attempts

This change, combined with PR #139 (Windows download retry), makes both the Release and Documentation workflows resilient to transient GitHub infrastructure issues.

## Test plan
- [ ] Release workflow runs successfully on merge
- [ ] GoReleaser installs and creates release
- [ ] Documentation workflow completes after release

🤖 Generated with [Claude Code](https://claude.com/claude-code)