### PR TITLE
fix: download GoReleaser binary directly from GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,23 +129,29 @@ jobs:
       - name: Install GoReleaser with retry
         shell: bash
         run: |
+          GORELEASER_VERSION="2.13.1"
           max_retries=5
           base_delay=15
 
           for attempt in $(seq 1 $max_retries); do
-            echo "Attempt $attempt of $max_retries to install GoReleaser..."
+            echo "Attempt $attempt of $max_retries to install GoReleaser v${GORELEASER_VERSION}..."
 
-            # Try to download and install goreleaser
-            if curl -sSL --connect-timeout 30 --max-time 120 \
-                 https://goreleaser.com/static/run 2>/dev/null | bash -s -- --install-only 2>&1; then
+            # Download goreleaser tarball from GitHub releases
+            url="https://github.com/goreleaser/goreleaser/releases/download/v${GORELEASER_VERSION}/goreleaser_Linux_x86_64.tar.gz"
+            if curl -sSL --connect-timeout 30 --max-time 180 -o /tmp/goreleaser.tar.gz "$url" && \
+               tar -xzf /tmp/goreleaser.tar.gz -C /tmp goreleaser && \
+               sudo mv /tmp/goreleaser /usr/local/bin/goreleaser && \
+               chmod +x /usr/local/bin/goreleaser; then
               echo "GoReleaser installed successfully"
               goreleaser --version
+              rm -f /tmp/goreleaser.tar.gz
               exit 0
             fi
 
             if [ $attempt -lt $max_retries ]; then
               delay=$((base_delay * attempt))
               echo "::warning::Failed to install GoReleaser on attempt $attempt, retrying in ${delay}s..."
+              rm -f /tmp/goreleaser.tar.gz /tmp/goreleaser
               sleep $delay
             fi
           done


### PR DESCRIPTION
## Summary
Fix GoReleaser installation in Release workflow by downloading the binary directly from GitHub releases instead of using goreleaser.com/static/run script.

## Root Cause
PR #140 used `bash -s -- --install-only` with the goreleaser.com/static/run script, but this script doesn't support the `--install-only` flag. The script was downloading goreleaser but then failing when trying to pass the flag.

## Solution
Download the tarball directly from GitHub releases:
- `https://github.com/goreleaser/goreleaser/releases/download/v2.13.1/goreleaser_Linux_x86_64.tar.gz`
- Extract to /tmp, move to /usr/local/bin
- Retry logic with exponential backoff (5 attempts)
- Clean up temporary files

## Test plan
- [ ] Release workflow runs successfully
- [ ] GoReleaser installs and creates release
- [ ] Documentation workflow completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)