### PR TITLE
fix: improve TOC structure by promoting action names to headings

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,6 +70,7 @@ markdown_extensions:
   - md_in_html
   - toc:
       permalink: true
+      toc_depth: 3
 
 extra:
   social:

--- a/scripts/templates/resource_unified.md.j2
+++ b/scripts/templates/resource_unified.md.j2
@@ -29,23 +29,25 @@ api_docs:
 ## Actions
 
 {% for action in actions %}
-<details markdown id="{{ action.action_name }}">
+### {{ action.action_name }}
+
+<details markdown>
 <summary><strong>{{ action.action_name }}</strong> - {{ action.command.short }}</summary>
 
-### Synopsis
+#### Synopsis
 
 ```bash
 {{ action.command.full_command }}{% if action.command.use and '<' in action.command.use %} {{ action.command.use.split()[1:] | join(' ') }}{% endif %} [flags]
 ```
 
 {% if action.command.long and action.command.long != action.command.short %}
-### Description
+#### Description
 
 {{ action.command.long }}
 
 {% endif %}
 {% if action.command.flags %}
-### Flags
+#### Flags
 
 | Flag | Short | Type | Default | Description |
 |------|-------|------|---------|-------------|
@@ -54,7 +56,7 @@ api_docs:
 {% endfor %}
 
 {% endif %}
-### Examples
+#### Examples
 
 {% if action.command.example %}
 ```bash
@@ -65,7 +67,7 @@ api_docs:
 {% endif %}
 
 {% if action.api_docs_url %}
-### API Reference
+#### API Reference
 
 - [{{ resource | title_case }} {{ action.action_name | title_case }} API]({{ action.api_docs_url }})
 {% endif %}


### PR DESCRIPTION
## Summary
- Fix repetitive TOC entries on command documentation pages
- Action names (list, get, create, delete, etc.) are now the main TOC entries
- Subsections (Synopsis, Description, Examples, API Reference) are hidden from TOC

## Problem
The Table of Contents was showing:
- Actions
  - Synopsis, Description, Examples, API Reference (repeated 10x)

## Solution
- Promote action names to H3 headings (visible in TOC)
- Demote subsections to H4 headings (hidden from TOC)
- Set `toc_depth: 3` in mkdocs.yml

## Result
Clean TOC showing:
- Actions
  - list
  - get
  - create
  - delete
  - replace
  - apply
  - patch
  - status
  - add-labels
  - remove-labels

## Test plan
- [x] Local testing with `mkdocs serve`
- [x] Validated TOC structure with Chrome DevTools
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)