### PR TITLE
feat: implement case normalization for industry acronyms

### DIFF
--- a/cmd/configuration.go
+++ b/cmd/configuration.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
+	"github.com/robinmordasiewicz/vesctl/pkg/naming"
 	"github.com/robinmordasiewicz/vesctl/pkg/output"
 	"github.com/robinmordasiewicz/vesctl/pkg/types"
 )
@@ -92,7 +93,8 @@ Use --namespace to filter by namespace, or --output-format to control output for
 		rtCopy := rt
 
 		// Build resource-specific Long description
-		longDesc := fmt.Sprintf("List all %s resources in the specified namespace.\n\n", rt.Name)
+		displayName := naming.ToHumanReadable(rt.Name)
+		longDesc := fmt.Sprintf("List all %s resources in the specified namespace.\n\n", displayName)
 		if rt.Description != "" {
 			longDesc += rt.Description + "\n\n"
 		}
@@ -110,7 +112,7 @@ Use --namespace to filter by namespace, or --output-format to control output for
 
 		subCmd := &cobra.Command{
 			Use:     rt.Name,
-			Short:   fmt.Sprintf("List %s", rt.Name),
+			Short:   fmt.Sprintf("List %s", displayName),
 			Long:    longDesc,
 			Example: exampleText,
 			RunE: func(cmd *cobra.Command, args []string) error {
@@ -152,7 +154,8 @@ Use --response-format replace-request to get output suitable for editing and rep
 		rtCopy := rt
 
 		// Build resource-specific Long description
-		longDesc := fmt.Sprintf("Retrieve a specific %s configuration by name.\n\n", rt.Name)
+		displayName := naming.ToHumanReadable(rt.Name)
+		longDesc := fmt.Sprintf("Retrieve a specific %s configuration by name.\n\n", displayName)
 		if rt.Description != "" {
 			longDesc += rt.Description + "\n\n"
 		}
@@ -170,7 +173,7 @@ Use --response-format replace-request to get output suitable for editing and rep
 
 		subCmd := &cobra.Command{
 			Use:     fmt.Sprintf("%s <name>", rt.Name),
-			Short:   fmt.Sprintf("Get %s", rt.Name),
+			Short:   fmt.Sprintf("Get %s", displayName),
 			Long:    longDesc,
 			Example: exampleText,
 			Args:    cobra.ExactArgs(1),
@@ -204,6 +207,7 @@ func buildConfigCreateCmd() *cobra.Command {
 			continue
 		}
 		rtCopy := rt
+		displayName := naming.ToHumanReadable(rt.Name)
 
 		// Build example text
 		exampleText := fmt.Sprintf(`# Create from file
@@ -222,7 +226,7 @@ EOF
 
 		subCmd := &cobra.Command{
 			Use:     rt.Name,
-			Short:   fmt.Sprintf("Create %s", rt.Name),
+			Short:   fmt.Sprintf("Create %s", displayName),
 			Example: exampleText,
 			RunE: func(cmd *cobra.Command, args []string) error {
 				return runConfigCreate(rtCopy, &flags)
@@ -264,9 +268,10 @@ In non-interactive mode (scripts, CI/CD), --yes is required.`,
 			continue
 		}
 		rtCopy := rt
+		displayName := naming.ToHumanReadable(rt.Name)
 
 		// Build resource-specific Long description
-		longDesc := fmt.Sprintf("Delete a %s configuration by name.\n\n", rt.Name)
+		longDesc := fmt.Sprintf("Delete a %s configuration by name.\n\n", displayName)
 		if rt.Description != "" {
 			longDesc += rt.Description + "\n\n"
 		}
@@ -284,7 +289,7 @@ In non-interactive mode (scripts, CI/CD), --yes is required.`,
 
 		subCmd := &cobra.Command{
 			Use:     fmt.Sprintf("%s <name>", rt.Name),
-			Short:   fmt.Sprintf("Delete %s", rt.Name),
+			Short:   fmt.Sprintf("Delete %s", displayName),
 			Long:    longDesc,
 			Example: exampleText,
 			Args:    cobra.ExactArgs(1),
@@ -327,9 +332,10 @@ This is a destructive operation. Use --yes to skip confirmation prompts.`,
 			continue
 		}
 		rtCopy := rt
+		displayName := naming.ToHumanReadable(rt.Name)
 
 		// Build resource-specific Long description
-		longDesc := fmt.Sprintf("Replace an existing %s configuration with new content.\n\n", rt.Name)
+		longDesc := fmt.Sprintf("Replace an existing %s configuration with new content.\n\n", displayName)
 		if rt.Description != "" {
 			longDesc += rt.Description + "\n\n"
 		}
@@ -352,7 +358,7 @@ EOF
 
 		subCmd := &cobra.Command{
 			Use:     rt.Name,
-			Short:   fmt.Sprintf("Replace %s", rt.Name),
+			Short:   fmt.Sprintf("Replace %s", displayName),
 			Long:    longDesc,
 			Example: exampleText,
 			RunE: func(cmd *cobra.Command, args []string) error {
@@ -395,9 +401,10 @@ Use --at-site to query status at a specific site.`,
 			continue
 		}
 		rtCopy := rt
+		displayName := naming.ToHumanReadable(rt.Name)
 
 		// Build resource-specific Long description
-		longDesc := fmt.Sprintf("Display the current status of a %s configuration.\n\n", rt.Name)
+		longDesc := fmt.Sprintf("Display the current status of a %s configuration.\n\n", displayName)
 		if rt.Description != "" {
 			longDesc += rt.Description + "\n\n"
 		}
@@ -415,7 +422,7 @@ Use --at-site to query status at a specific site.`,
 
 		subCmd := &cobra.Command{
 			Use:     fmt.Sprintf("%s <name>", rt.Name),
-			Short:   fmt.Sprintf("Status of %s", rt.Name),
+			Short:   fmt.Sprintf("Status of %s", displayName),
 			Long:    longDesc,
 			Example: exampleText,
 			Args:    cobra.ExactArgs(1),
@@ -458,9 +465,10 @@ Use --mode new to fail if the resource already exists (strict create behavior).`
 			continue
 		}
 		rtCopy := rt
+		displayName := naming.ToHumanReadable(rt.Name)
 
 		// Build resource-specific Long description
-		longDesc := fmt.Sprintf("Create or replace a %s configuration using declarative input.\n\n", rt.Name)
+		longDesc := fmt.Sprintf("Create or replace a %s configuration using declarative input.\n\n", displayName)
 		if rt.Description != "" {
 			longDesc += rt.Description + "\n\n"
 		}
@@ -486,7 +494,7 @@ EOF
 
 		subCmd := &cobra.Command{
 			Use:     rt.Name,
-			Short:   fmt.Sprintf("Apply %s", rt.Name),
+			Short:   fmt.Sprintf("Apply %s", displayName),
 			Long:    longDesc,
 			Example: exampleText,
 			RunE: func(cmd *cobra.Command, args []string) error {
@@ -522,9 +530,10 @@ Note: Patch operation is not yet fully implemented. Use replace for complete upd
 			continue
 		}
 		rtCopy := rt
+		displayName := naming.ToHumanReadable(rt.Name)
 
 		// Build resource-specific Long description
-		longDesc := fmt.Sprintf("Apply a partial update to a %s configuration.\n\n", rt.Name)
+		longDesc := fmt.Sprintf("Apply a partial update to a %s configuration.\n\n", displayName)
 		if rt.Description != "" {
 			longDesc += rt.Description + "\n\n"
 		}
@@ -532,7 +541,7 @@ Note: Patch operation is not yet fully implemented. Use replace for complete upd
 
 		subCmd := &cobra.Command{
 			Use:   rt.Name,
-			Short: fmt.Sprintf("Patch %s", rt.Name),
+			Short: fmt.Sprintf("Patch %s", displayName),
 			Long:  longDesc,
 			RunE: func(cmd *cobra.Command, args []string) error {
 				return runConfigPatch(rtCopy, &flags)
@@ -571,9 +580,10 @@ Use --label-key and --label-value flags (can be repeated for multiple labels).`,
 	// Add resource type subcommands
 	for _, rt := range types.All() {
 		rtCopy := rt
+		displayName := naming.ToHumanReadable(rt.Name)
 
 		// Build resource-specific Long description
-		longDesc := fmt.Sprintf("Add metadata labels to a %s configuration.\n\n", rt.Name)
+		longDesc := fmt.Sprintf("Add metadata labels to a %s configuration.\n\n", displayName)
 		if rt.Description != "" {
 			longDesc += rt.Description + "\n\n"
 		}
@@ -590,7 +600,7 @@ Use --label-key and --label-value flags (can be repeated for multiple labels).`,
 
 		subCmd := &cobra.Command{
 			Use:     fmt.Sprintf("%s <name>", rt.Name),
-			Short:   fmt.Sprintf("Add Labels to %s", rt.Name),
+			Short:   fmt.Sprintf("Add Labels to %s", displayName),
 			Long:    longDesc,
 			Example: exampleText,
 			Args:    cobra.ExactArgs(1),
@@ -630,9 +640,10 @@ Specify the label keys to remove using --label-key flags (can be repeated for mu
 	// Add resource type subcommands
 	for _, rt := range types.All() {
 		rtCopy := rt
+		displayName := naming.ToHumanReadable(rt.Name)
 
 		// Build resource-specific Long description
-		longDesc := fmt.Sprintf("Remove metadata labels from a %s configuration.\n\n", rt.Name)
+		longDesc := fmt.Sprintf("Remove metadata labels from a %s configuration.\n\n", displayName)
 		if rt.Description != "" {
 			longDesc += rt.Description + "\n\n"
 		}
@@ -649,7 +660,7 @@ Specify the label keys to remove using --label-key flags (can be repeated for mu
 
 		subCmd := &cobra.Command{
 			Use:     fmt.Sprintf("%s <name>", rt.Name),
-			Short:   fmt.Sprintf("Remove Labels from %s", rt.Name),
+			Short:   fmt.Sprintf("Remove Labels from %s", displayName),
 			Long:    longDesc,
 			Example: exampleText,
 			Args:    cobra.ExactArgs(1),

--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
+	"github.com/robinmordasiewicz/vesctl/pkg/naming"
 	"github.com/robinmordasiewicz/vesctl/pkg/output"
 	"github.com/robinmordasiewicz/vesctl/pkg/types"
 )
@@ -24,10 +25,11 @@ type resourceFlags struct {
 
 // BuildResourceCommand creates a command group for a resource type
 func BuildResourceCommand(rt *types.ResourceType) *cobra.Command {
+	displayName := naming.ToHumanReadable(rt.Name)
 	cmd := &cobra.Command{
 		Use:   rt.CLIName,
-		Short: rt.Description,
-		Long:  fmt.Sprintf("Manage %s resources in F5 Distributed Cloud.", rt.Description),
+		Short: fmt.Sprintf("Manage %s resources", displayName),
+		Long:  fmt.Sprintf("Manage %s resources in F5 Distributed Cloud.", displayName),
 	}
 
 	// Add subcommands based on supported operations
@@ -56,12 +58,13 @@ func BuildResourceCommand(rt *types.ResourceType) *cobra.Command {
 // buildListCommand creates the list subcommand
 func buildListCommand(rt *types.ResourceType) *cobra.Command {
 	var flags resourceFlags
+	displayName := naming.ToHumanReadable(rt.Name)
 
 	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
-		Short:   fmt.Sprintf("List %s resources", rt.CLIName),
-		Long:    fmt.Sprintf("List all %s resources in the specified namespace.", rt.Description),
+		Short:   fmt.Sprintf("List %s resources", displayName),
+		Long:    fmt.Sprintf("List all %s resources in the specified namespace.", displayName),
 		Example: buildExample(rt, "list", []string{
 			fmt.Sprintf("vesctl %s list --namespace example-namespace", rt.CLIName),
 			fmt.Sprintf("vesctl %s list -n example-namespace -o table", rt.CLIName),
@@ -82,12 +85,13 @@ func buildListCommand(rt *types.ResourceType) *cobra.Command {
 // buildShowCommand creates the show subcommand
 func buildShowCommand(rt *types.ResourceType) *cobra.Command {
 	var flags resourceFlags
+	displayName := naming.ToHumanReadable(rt.Name)
 
 	cmd := &cobra.Command{
 		Use:     "show [name]",
 		Aliases: []string{"get", "describe"},
-		Short:   fmt.Sprintf("Show details of a %s", rt.CLIName),
-		Long:    fmt.Sprintf("Display detailed information about a specific %s.", rt.Description),
+		Short:   fmt.Sprintf("Show details of a %s", displayName),
+		Long:    fmt.Sprintf("Display detailed information about a specific %s.", displayName),
 		Args:    cobra.ExactArgs(1),
 		Example: buildExample(rt, "show", []string{
 			fmt.Sprintf("vesctl %s show example-resource --namespace example-namespace", rt.CLIName),
@@ -110,11 +114,12 @@ func buildShowCommand(rt *types.ResourceType) *cobra.Command {
 // buildCreateCommand creates the create subcommand
 func buildCreateCommand(rt *types.ResourceType) *cobra.Command {
 	var flags resourceFlags
+	displayName := naming.ToHumanReadable(rt.Name)
 
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: fmt.Sprintf("Create a new %s", rt.CLIName),
-		Long:  fmt.Sprintf("Create a new %s from a YAML or JSON file.", rt.Description),
+		Short: fmt.Sprintf("Create a new %s", displayName),
+		Long:  fmt.Sprintf("Create a new %s from a YAML or JSON file.", displayName),
 		Example: buildExample(rt, "create", []string{
 			fmt.Sprintf("vesctl %s create --file resource.yaml", rt.CLIName),
 			fmt.Sprintf("vesctl %s create -f resource.json --namespace example-namespace", rt.CLIName),
@@ -138,12 +143,13 @@ func buildCreateCommand(rt *types.ResourceType) *cobra.Command {
 // buildUpdateCommand creates the update subcommand
 func buildUpdateCommand(rt *types.ResourceType) *cobra.Command {
 	var flags resourceFlags
+	displayName := naming.ToHumanReadable(rt.Name)
 
 	cmd := &cobra.Command{
 		Use:     "update",
 		Aliases: []string{"replace", "apply"},
-		Short:   fmt.Sprintf("Update an existing %s", rt.CLIName),
-		Long:    fmt.Sprintf("Update an existing %s from a YAML or JSON file.", rt.Description),
+		Short:   fmt.Sprintf("Update an existing %s", displayName),
+		Long:    fmt.Sprintf("Update an existing %s from a YAML or JSON file.", displayName),
 		Example: buildExample(rt, "update", []string{
 			fmt.Sprintf("vesctl %s update --file resource.yaml", rt.CLIName),
 			fmt.Sprintf("vesctl %s update -f resource.json", rt.CLIName),
@@ -167,12 +173,13 @@ func buildUpdateCommand(rt *types.ResourceType) *cobra.Command {
 // buildDeleteCommand creates the delete subcommand
 func buildDeleteCommand(rt *types.ResourceType) *cobra.Command {
 	var flags resourceFlags
+	displayName := naming.ToHumanReadable(rt.Name)
 
 	cmd := &cobra.Command{
 		Use:     "delete [name]",
 		Aliases: []string{"rm", "remove"},
-		Short:   fmt.Sprintf("Delete a %s", rt.CLIName),
-		Long:    fmt.Sprintf("Delete a %s resource.", rt.Description),
+		Short:   fmt.Sprintf("Delete a %s", displayName),
+		Long:    fmt.Sprintf("Delete a %s resource.", displayName),
 		Args:    cobra.ExactArgs(1),
 		Example: buildExample(rt, "delete", []string{
 			fmt.Sprintf("vesctl %s delete example-resource --namespace example-namespace", rt.CLIName),
@@ -197,11 +204,12 @@ func buildDeleteCommand(rt *types.ResourceType) *cobra.Command {
 // buildStatusCommand creates the status subcommand
 func buildStatusCommand(rt *types.ResourceType) *cobra.Command {
 	var flags resourceFlags
+	displayName := naming.ToHumanReadable(rt.Name)
 
 	cmd := &cobra.Command{
 		Use:   "status [name]",
-		Short: fmt.Sprintf("Show status of a %s", rt.CLIName),
-		Long:  fmt.Sprintf("Display the operational status of a %s.", rt.Description),
+		Short: fmt.Sprintf("Show status of a %s", displayName),
+		Long:  fmt.Sprintf("Display the operational status of a %s.", displayName),
 		Args:  cobra.ExactArgs(1),
 		Example: buildExample(rt, "status", []string{
 			fmt.Sprintf("vesctl %s status example-resource --namespace example-namespace", rt.CLIName),
@@ -329,7 +337,8 @@ func runCreate(rt *types.ResourceType, flags *resourceFlags) error {
 		return fmt.Errorf("failed to parse response: %w", err)
 	}
 
-	output.PrintInfo(fmt.Sprintf("Created %s successfully", rt.CLIName))
+	displayName := naming.ToHumanReadable(rt.Name)
+	output.PrintInfo(fmt.Sprintf("Created %s successfully", displayName))
 	return output.Print(result, GetOutputFormat())
 }
 
@@ -383,7 +392,8 @@ func runUpdate(rt *types.ResourceType, flags *resourceFlags) error {
 		return fmt.Errorf("failed to parse response: %w", err)
 	}
 
-	output.PrintInfo(fmt.Sprintf("Updated %s '%s' successfully", rt.CLIName, name))
+	displayName := naming.ToHumanReadable(rt.Name)
+	output.PrintInfo(fmt.Sprintf("Updated %s '%s' successfully", displayName, name))
 	return output.Print(result, GetOutputFormat())
 }
 
@@ -394,9 +404,11 @@ func runDelete(rt *types.ResourceType, flags *resourceFlags) error {
 		return fmt.Errorf("client not initialized - check configuration")
 	}
 
+	displayName := naming.ToHumanReadable(rt.Name)
+
 	// Confirm deletion unless --yes is specified
 	if !flags.yes {
-		fmt.Printf("Are you sure you want to delete %s '%s'? [y/N]: ", rt.CLIName, flags.name)
+		fmt.Printf("Are you sure you want to delete %s '%s'? [y/N]: ", displayName, flags.name)
 		var confirm string
 		_, _ = fmt.Scanln(&confirm)
 		if confirm != "y" && confirm != "Y" && confirm != "yes" {
@@ -432,7 +444,7 @@ func runDelete(rt *types.ResourceType, flags *resourceFlags) error {
 			if resp.StatusCode >= 400 {
 				return fmt.Errorf("API error: %s", string(resp.Body))
 			}
-			output.PrintInfo(fmt.Sprintf("Deleted %s '%s' successfully", rt.CLIName, flags.name))
+			output.PrintInfo(fmt.Sprintf("Deleted %s '%s' successfully", displayName, flags.name))
 			return nil
 		}
 	}
@@ -447,7 +459,7 @@ func runDelete(rt *types.ResourceType, flags *resourceFlags) error {
 		return fmt.Errorf("API error: %s", string(resp.Body))
 	}
 
-	output.PrintInfo(fmt.Sprintf("Deleted %s '%s' successfully", rt.CLIName, flags.name))
+	output.PrintInfo(fmt.Sprintf("Deleted %s '%s' successfully", displayName, flags.name))
 	return nil
 }
 

--- a/pkg/naming/acronyms.go
+++ b/pkg/naming/acronyms.go
@@ -1,0 +1,125 @@
+// Package naming provides consistent case conversion and acronym handling
+// for the vesctl CLI tool, ensuring industry-standard acronyms are displayed
+// correctly in documentation, help text, and user-facing output.
+package naming
+
+// UppercaseAcronyms defines acronyms that should always be uppercase.
+// Based on RFC 4949, IEEE standards, and industry style guides (Google, Microsoft, Apple).
+var UppercaseAcronyms = map[string]bool{
+	// Networking protocols
+	"DNS": true, "HTTP": true, "HTTPS": true, "TCP": true, "UDP": true,
+	"TLS": true, "SSL": true, "SSH": true, "FTP": true, "SFTP": true,
+	"SMTP": true, "IMAP": true, "POP": true, "LDAP": true, "DHCP": true,
+	"ARP": true, "ICMP": true, "SNMP": true, "NTP": true, "SIP": true,
+	"RTP": true, "RTSP": true, "QUIC": true, "IP": true, "GRPC": true,
+	// Web/API
+	"API": true, "URL": true, "URI": true, "REST": true, "SOAP": true,
+	"JSON": true, "XML": true, "HTML": true, "CSS": true, "CORS": true,
+	"CDN": true, "WAF": true, "JWT": true, "SAML": true,
+	// Network infrastructure
+	"VPN": true, "NAT": true, "VLAN": true, "BGP": true, "OSPF": true,
+	"QOS": true, "MTU": true, "TTL": true, "ACL": true, "CIDR": true,
+	"VIP": true, "LB": true, "HA": true, "DR": true,
+	// Security
+	"PKI": true, "CA": true, "CSR": true, "CRL": true, "OCSP": true,
+	"PEM": true, "AES": true, "RSA": true, "SHA": true, "MD5": true,
+	"HMAC": true, "MFA": true, "SSO": true, "RBAC": true, "IAM": true,
+	"DDOS": true, "DOS": true, "XSS": true, "CSRF": true, "SQL": true,
+	// Cloud/Infrastructure
+	"AWS": true, "GCP": true, "CPU": true, "RAM": true, "SSD": true,
+	"HDD": true, "GPU": true, "RAID": true, "VM": true, "OS": true,
+	"SLA": true, "RPO": true, "RTO": true, "VPC": true, "VNET": true,
+	"TGW": true, "IKE": true, "ID": true, "SLI": true, "S2S": true,
+	"RE": true, "CE": true, "SPO": true, "SMG": true,
+	"APM": true, "PII": true, "OIDC": true, "K8S": true,
+	// F5-specific
+	"ASM": true, "LTM": true, "GTM": true, "CNE": true, "XC": true,
+	"SSLO": true, "AFM": true, "AVR": true, "ASN": true, "SEC": true,
+	"RPC": true,
+}
+
+// MixedCaseAcronyms defines acronyms with specific mixed-case conventions.
+var MixedCaseAcronyms = map[string]string{
+	"mtls":      "mTLS",
+	"oauth":     "OAuth",
+	"graphql":   "GraphQL",
+	"websocket": "WebSocket",
+	"iscsi":     "iSCSI",
+	"ipv4":      "IPv4",
+	"ipv6":      "IPv6",
+	"macos":     "macOS",
+	"ios":       "iOS",
+	"nosql":     "NoSQL",
+	"bigip":     "BIG-IP",
+	"irule":     "iRule",
+}
+
+// CompoundWords defines compound words for Go type name formatting.
+var CompoundWords = map[string]string{
+	"loadbalancer":  "LoadBalancer",
+	"bigip":         "BigIP",
+	"websocket":     "WebSocket",
+	"fastcgi":       "FastCGI",
+	"originpool":    "OriginPool",
+	"healthcheck":   "HealthCheck",
+	"servicepolicy": "ServicePolicy",
+}
+
+// CompoundWordsHumanReadable defines compound words for documentation purposes.
+var CompoundWordsHumanReadable = map[string]string{
+	"loadbalancer":  "Load Balancer",
+	"bigip":         "BIG-IP",
+	"websocket":     "WebSocket",
+	"fastcgi":       "FastCGI",
+	"originpool":    "Origin Pool",
+	"healthcheck":   "Health Check",
+	"servicepolicy": "Service Policy",
+	"apiendpoint":   "API Endpoint",
+	"apidefinition": "API Definition",
+	"apisecurity":   "API Security",
+}
+
+// IsUppercaseAcronym returns true if the given string is a known uppercase acronym.
+func IsUppercaseAcronym(s string) bool {
+	return UppercaseAcronyms[toUpperASCII(s)]
+}
+
+// GetMixedCaseAcronym returns the correct mixed-case form for known acronyms.
+// Returns empty string if not a mixed-case acronym.
+func GetMixedCaseAcronym(s string) string {
+	return MixedCaseAcronyms[toLowerASCII(s)]
+}
+
+// GetCompoundWordHumanReadable returns the human-readable form of a compound word.
+// Returns empty string if not a known compound word.
+func GetCompoundWordHumanReadable(s string) string {
+	return CompoundWordsHumanReadable[toLowerASCII(s)]
+}
+
+// toUpperASCII converts ASCII string to uppercase without importing strings package.
+func toUpperASCII(s string) string {
+	result := make([]byte, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 'a' && c <= 'z' {
+			result[i] = c - 32
+		} else {
+			result[i] = c
+		}
+	}
+	return string(result)
+}
+
+// toLowerASCII converts ASCII string to lowercase without importing strings package.
+func toLowerASCII(s string) string {
+	result := make([]byte, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 'A' && c <= 'Z' {
+			result[i] = c + 32
+		} else {
+			result[i] = c
+		}
+	}
+	return string(result)
+}

--- a/pkg/naming/naming.go
+++ b/pkg/naming/naming.go
@@ -1,0 +1,192 @@
+// Package naming provides consistent case conversion and acronym handling
+// for the vesctl CLI tool, ensuring industry-standard acronyms are displayed
+// correctly in documentation, help text, and user-facing output.
+package naming
+
+import (
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+// ToHumanReadable converts a snake_case or kebab-case name to human-readable format
+// with proper acronym capitalization and compound word spacing.
+// Examples:
+//   - "http_loadbalancer" -> "HTTP Load Balancer"
+//   - "dns-zone" -> "DNS Zone"
+//   - "bigip_apm" -> "BIG-IP APM"
+//   - "mtls_config" -> "mTLS Config"
+func ToHumanReadable(s string) string {
+	// Normalize separators: replace both underscores and hyphens with spaces
+	s = strings.ReplaceAll(s, "_", " ")
+	s = strings.ReplaceAll(s, "-", " ")
+
+	parts := strings.Fields(s)
+	var result []string
+
+	for _, part := range parts {
+		lower := strings.ToLower(part)
+		upper := strings.ToUpper(part)
+
+		// Check for uppercase acronyms first (e.g., DNS, HTTP, API)
+		if UppercaseAcronyms[upper] {
+			result = append(result, upper)
+		} else if compound, ok := CompoundWordsHumanReadable[lower]; ok {
+			// Handle compound words with spaces (e.g., "loadbalancer" -> "Load Balancer")
+			result = append(result, compound)
+		} else if mixed, ok := MixedCaseAcronyms[lower]; ok {
+			// Handle mixed-case acronyms (e.g., "mtls" -> "mTLS")
+			result = append(result, mixed)
+		} else if len(part) > 0 {
+			// Standard title case: capitalize first letter
+			result = append(result, strings.ToUpper(string(part[0]))+strings.ToLower(part[1:]))
+		}
+	}
+
+	return strings.Join(result, " ")
+}
+
+// ToTitleCase converts a snake_case or dot.separated string to Title Case,
+// preserving acronym capitalization.
+// Example: "http_load_balancer" -> "HTTP Load Balancer"
+func ToTitleCase(s string) string {
+	// Replace underscores and dots with spaces
+	s = strings.ReplaceAll(s, "_", " ")
+	s = strings.ReplaceAll(s, ".", " ")
+	s = strings.ReplaceAll(s, "-", " ")
+
+	words := strings.Fields(s)
+	for i, word := range words {
+		if len(word) > 0 {
+			// Apply standard title case first
+			words[i] = strings.ToUpper(string(word[0])) + strings.ToLower(word[1:])
+		}
+	}
+	result := strings.Join(words, " ")
+
+	// Apply acronym normalization
+	result = NormalizeAcronyms(result)
+
+	return result
+}
+
+// ToTitleCaseFromAnchor converts an anchor name (kebab-case) to Title Case,
+// preserving acronym capitalization.
+// Example: "http-load-balancer" -> "HTTP Load Balancer"
+func ToTitleCaseFromAnchor(anchor string) string {
+	words := strings.Split(anchor, "-")
+	for i, word := range words {
+		upper := strings.ToUpper(word)
+		if UppercaseAcronyms[upper] {
+			words[i] = upper
+		} else if mixed, ok := MixedCaseAcronyms[strings.ToLower(word)]; ok {
+			words[i] = mixed
+		} else if len(word) > 0 {
+			words[i] = strings.ToUpper(string(word[0])) + strings.ToLower(word[1:])
+		}
+	}
+	return strings.Join(words, " ")
+}
+
+// ToSnakeCase converts a CamelCase or PascalCase string to snake_case.
+// Example: "HTTPLoadBalancer" -> "http_load_balancer"
+func ToSnakeCase(s string) string {
+	var result strings.Builder
+	for i, r := range s {
+		if unicode.IsUpper(r) {
+			if i > 0 {
+				// Don't add underscore if previous char was also uppercase (acronym)
+				prev := rune(s[i-1])
+				if !unicode.IsUpper(prev) {
+					result.WriteRune('_')
+				} else if i+1 < len(s) && unicode.IsLower(rune(s[i+1])) {
+					// End of acronym followed by lowercase
+					result.WriteRune('_')
+				}
+			}
+			result.WriteRune(unicode.ToLower(r))
+		} else {
+			result.WriteRune(r)
+		}
+	}
+	return result.String()
+}
+
+// ToKebabCase converts a snake_case or CamelCase string to kebab-case.
+// Example: "http_loadbalancer" -> "http-loadbalancer"
+func ToKebabCase(s string) string {
+	return strings.ToLower(strings.ReplaceAll(s, "_", "-"))
+}
+
+// ToAnchorName converts a name to an anchor-friendly format (kebab-case).
+// Example: "http_load_balancer" -> "http-load-balancer"
+func ToAnchorName(name string) string {
+	return strings.ToLower(strings.ReplaceAll(name, "_", "-"))
+}
+
+// NormalizeAcronyms corrects acronym capitalization in free text.
+// This function is idempotent - running it multiple times produces the same result.
+// Example: "Configure dns settings for the api endpoint" -> "Configure DNS settings for the API endpoint"
+func NormalizeAcronyms(text string) string {
+	wordRegex := regexp.MustCompile(`\b([A-Za-z0-9]+)\b`)
+
+	return wordRegex.ReplaceAllStringFunc(text, func(word string) string {
+		upperWord := strings.ToUpper(word)
+		lowerWord := strings.ToLower(word)
+
+		// Check for mixed-case acronyms first (e.g., mTLS, OAuth)
+		if corrected, ok := MixedCaseAcronyms[lowerWord]; ok {
+			return corrected
+		}
+
+		// Check for uppercase acronyms (e.g., DNS, HTTP, TCP)
+		if UppercaseAcronyms[upperWord] {
+			return upperWord
+		}
+
+		// Return original word unchanged
+		return word
+	})
+}
+
+// ToResourceTypeName converts a snake_case resource name to a Go type name.
+// Example: "http_loadbalancer" -> "HTTPLoadBalancer"
+func ToResourceTypeName(resourceName string) string {
+	parts := strings.Split(resourceName, "_")
+	var result strings.Builder
+
+	for _, part := range parts {
+		lower := strings.ToLower(part)
+		upper := strings.ToUpper(part)
+
+		if UppercaseAcronyms[upper] {
+			result.WriteString(upper)
+		} else if compound, ok := CompoundWords[lower]; ok {
+			result.WriteString(compound)
+		} else {
+			// Title case: capitalize first letter
+			if len(part) > 0 {
+				result.WriteString(strings.ToUpper(string(part[0])) + strings.ToLower(part[1:]))
+			}
+		}
+	}
+
+	return result.String()
+}
+
+// StartsWithVowel checks if a string starts with a vowel (for "a" vs "an" grammar).
+func StartsWithVowel(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	firstChar := strings.ToLower(string(s[0]))
+	return firstChar == "a" || firstChar == "e" || firstChar == "i" || firstChar == "o" || firstChar == "u"
+}
+
+// GetArticle returns "an" if the string starts with a vowel, otherwise "a".
+func GetArticle(s string) string {
+	if StartsWithVowel(s) {
+		return "an"
+	}
+	return "a"
+}

--- a/pkg/naming/naming_test.go
+++ b/pkg/naming/naming_test.go
@@ -1,0 +1,397 @@
+package naming
+
+import (
+	"testing"
+)
+
+func TestToHumanReadable(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		// Basic conversions
+		{"simple word", "certificate", "Certificate"},
+		{"underscore separated", "origin_pool", "Origin Pool"},
+		{"kebab separated", "origin-pool", "Origin Pool"},
+
+		// Uppercase acronyms
+		{"dns zone", "dns_zone", "DNS Zone"},
+		{"http loadbalancer", "http_loadbalancer", "HTTP Load Balancer"},
+		{"api endpoint", "api_endpoint", "API Endpoint"},
+		{"tcp proxy", "tcp_proxy", "TCP Proxy"},
+		{"udp loadbalancer", "udp_loadbalancer", "UDP Load Balancer"},
+		{"tls certificate", "tls_certificate", "TLS Certificate"},
+		{"ssl certificate", "ssl_certificate", "SSL Certificate"},
+		{"jwt token", "jwt_token", "JWT Token"},
+		{"vpn tunnel", "vpn_tunnel", "VPN Tunnel"},
+		{"bgp config", "bgp_config", "BGP Config"},
+		{"vlan config", "vlan_config", "VLAN Config"},
+		{"waf policy", "waf_policy", "WAF Policy"},
+		{"cdn config", "cdn_config", "CDN Config"},
+		{"aws vpc site", "aws_vpc_site", "AWS VPC Site"},
+		{"gcp vpc site", "gcp_vpc_site", "GCP VPC Site"},
+		{"k8s cluster", "k8s_cluster", "K8S Cluster"},
+		{"oidc config", "oidc_config", "OIDC Config"},
+		{"saml config", "saml_config", "SAML Config"},
+		{"ldap config", "ldap_config", "LDAP Config"},
+		{"rbac policy", "rbac_policy", "RBAC Policy"},
+		{"iam policy", "iam_policy", "IAM Policy"},
+		{"rest api", "rest_api", "REST API"},
+		{"json schema", "json_schema", "JSON Schema"},
+		{"xml config", "xml_config", "XML Config"},
+		{"cors policy", "cors_policy", "CORS Policy"},
+
+		// F5-specific acronyms
+		{"bigip apm", "bigip_apm", "BIG-IP APM"},
+		{"bigip ltm", "bigip_ltm", "BIG-IP LTM"},
+		{"bigip gtm", "bigip_gtm", "BIG-IP GTM"},
+		{"bigip asm", "bigip_asm", "BIG-IP ASM"},
+		{"api sec", "api_sec", "API SEC"},
+		{"xc config", "xc_config", "XC Config"},
+
+		// Mixed-case acronyms
+		{"mtls config", "mtls_config", "mTLS Config"},
+		{"oauth provider", "oauth_provider", "OAuth Provider"},
+		{"graphql endpoint", "graphql_endpoint", "GraphQL Endpoint"},
+		{"websocket config", "websocket_config", "WebSocket Config"},
+		{"ipv4 address", "ipv4_address", "IPv4 Address"},
+		{"ipv6 address", "ipv6_address", "IPv6 Address"},
+		{"irule config", "irule_config", "iRule Config"},
+
+		// Compound words
+		{"http loadbalancer", "http_loadbalancer", "HTTP Load Balancer"},
+		{"origin pool", "origin_pool", "Origin Pool"},
+		{"health check", "health_check", "Health Check"},
+		{"service policy", "service_policy", "Service Policy"},
+
+		// Kebab-case inputs
+		{"kebab dns zone", "dns-zone", "DNS Zone"},
+		{"kebab http lb", "http-loadbalancer", "HTTP Load Balancer"},
+		{"kebab api endpoint", "api-endpoint", "API Endpoint"},
+
+		// Complex combinations
+		{"full resource name", "http_loadbalancer_service_policy", "HTTP Load Balancer Service Policy"},
+		{"multiple acronyms", "dns_tcp_udp_config", "DNS TCP UDP Config"},
+		{"api sec api", "api_sec_api_definition", "API SEC API Definition"},
+
+		// Edge cases
+		{"empty string", "", ""},
+		{"single char", "a", "A"},
+		{"already uppercase", "DNS", "DNS"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ToHumanReadable(tt.input)
+			if result != tt.expected {
+				t.Errorf("ToHumanReadable(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestToTitleCase(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"http_load_balancer", "HTTP Load Balancer"},
+		{"dns_zone", "DNS Zone"},
+		{"api_endpoint", "API Endpoint"},
+		{"simple_name", "Simple Name"},
+		{"mtls_config", "mTLS Config"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := ToTitleCase(tt.input)
+			if result != tt.expected {
+				t.Errorf("ToTitleCase(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestToTitleCaseFromAnchor(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"http-load-balancer", "HTTP Load Balancer"},
+		{"dns-zone", "DNS Zone"},
+		{"api-endpoint", "API Endpoint"},
+		{"simple-name", "Simple Name"},
+		{"mtls-config", "mTLS Config"},
+		{"bigip-apm", "BIG-IP APM"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := ToTitleCaseFromAnchor(tt.input)
+			if result != tt.expected {
+				t.Errorf("ToTitleCaseFromAnchor(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestToSnakeCase(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"HTTPLoadBalancer", "http_load_balancer"},
+		{"DNSZone", "dns_zone"},
+		{"APIEndpoint", "api_endpoint"},
+		{"SimpleName", "simple_name"},
+		{"mTLSConfig", "m_tls_config"}, // Note: mTLS becomes m_tls in snake_case
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := ToSnakeCase(tt.input)
+			if result != tt.expected {
+				t.Errorf("ToSnakeCase(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestToKebabCase(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"http_loadbalancer", "http-loadbalancer"},
+		{"dns_zone", "dns-zone"},
+		{"api_endpoint", "api-endpoint"},
+		{"simple_name", "simple-name"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := ToKebabCase(tt.input)
+			if result != tt.expected {
+				t.Errorf("ToKebabCase(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNormalizeAcronyms(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		// Basic acronym correction
+		{"dns lowercase", "Configure dns settings", "Configure DNS settings"},
+		{"api lowercase", "Call the api endpoint", "Call the API endpoint"},
+		{"http lowercase", "Use http protocol", "Use HTTP protocol"},
+		{"multiple acronyms", "Configure dns and api settings for http", "Configure DNS and API settings for HTTP"},
+
+		// Mixed-case acronyms
+		{"mtls", "Enable mtls authentication", "Enable mTLS authentication"},
+		{"oauth", "Use oauth for login", "Use OAuth for login"},
+		{"graphql", "Query graphql endpoint", "Query GraphQL endpoint"},
+		{"ipv4 and ipv6", "Support ipv4 and ipv6", "Support IPv4 and IPv6"},
+
+		// Preserve existing correct casing
+		{"already correct", "DNS is configured", "DNS is configured"},
+		{"mixed correct", "mTLS and HTTP are enabled", "mTLS and HTTP are enabled"},
+
+		// No acronyms
+		{"no acronyms", "This is a simple sentence", "This is a simple sentence"},
+
+		// Idempotency test
+		{"idempotent", "DNS and API", "DNS and API"},
+
+		// Edge cases
+		{"empty string", "", ""},
+		{"single acronym", "dns", "DNS"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NormalizeAcronyms(tt.input)
+			if result != tt.expected {
+				t.Errorf("NormalizeAcronyms(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNormalizeAcronymsIdempotent(t *testing.T) {
+	// Test that running NormalizeAcronyms multiple times produces the same result
+	inputs := []string{
+		"Configure dns settings for the api endpoint",
+		"DNS is already correct",
+		"Enable mtls authentication",
+		"HTTP Load Balancer",
+	}
+
+	for _, input := range inputs {
+		t.Run(input, func(t *testing.T) {
+			first := NormalizeAcronyms(input)
+			second := NormalizeAcronyms(first)
+			third := NormalizeAcronyms(second)
+
+			if first != second || second != third {
+				t.Errorf("NormalizeAcronyms is not idempotent for %q: first=%q, second=%q, third=%q",
+					input, first, second, third)
+			}
+		})
+	}
+}
+
+func TestToResourceTypeName(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"http_loadbalancer", "HTTPLoadBalancer"},
+		{"dns_zone", "DNSZone"},
+		{"api_endpoint", "APIEndpoint"},
+		{"simple_name", "SimpleName"},
+		{"origin_pool", "OriginPool"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := ToResourceTypeName(tt.input)
+			if result != tt.expected {
+				t.Errorf("ToResourceTypeName(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestStartsWithVowel(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{"API", true},
+		{"HTTP", false},
+		{"endpoint", true},
+		{"origin", true},
+		{"DNS", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := StartsWithVowel(tt.input)
+			if result != tt.expected {
+				t.Errorf("StartsWithVowel(%q) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetArticle(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"API", "an"},
+		{"HTTP", "a"},
+		{"endpoint", "an"},
+		{"origin", "an"},
+		{"DNS", "a"},
+		{"certificate", "a"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := GetArticle(tt.input)
+			if result != tt.expected {
+				t.Errorf("GetArticle(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsUppercaseAcronym(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{"dns", true},
+		{"DNS", true},
+		{"Dns", true},
+		{"http", true},
+		{"api", true},
+		{"hello", false},
+		{"world", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := IsUppercaseAcronym(tt.input)
+			if result != tt.expected {
+				t.Errorf("IsUppercaseAcronym(%q) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetMixedCaseAcronym(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"mtls", "mTLS"},
+		{"MTLS", "mTLS"},
+		{"oauth", "OAuth"},
+		{"OAUTH", "OAuth"},
+		{"bigip", "BIG-IP"},
+		{"hello", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := GetMixedCaseAcronym(tt.input)
+			if result != tt.expected {
+				t.Errorf("GetMixedCaseAcronym(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetCompoundWordHumanReadable(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"loadbalancer", "Load Balancer"},
+		{"LOADBALANCER", "Load Balancer"},
+		{"originpool", "Origin Pool"},
+		{"healthcheck", "Health Check"},
+		{"hello", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := GetCompoundWordHumanReadable(tt.input)
+			if result != tt.expected {
+				t.Errorf("GetCompoundWordHumanReadable(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+// Benchmark tests
+func BenchmarkToHumanReadable(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		ToHumanReadable("http_loadbalancer")
+	}
+}
+
+func BenchmarkNormalizeAcronyms(b *testing.B) {
+	text := "Configure dns settings for the api endpoint using http protocol"
+	for i := 0; i < b.N; i++ {
+		NormalizeAcronyms(text)
+	}
+}

--- a/pkg/types/resource.go
+++ b/pkg/types/resource.go
@@ -1,5 +1,7 @@
 package types
 
+import "github.com/robinmordasiewicz/vesctl/pkg/naming"
+
 // ResourceType defines a F5 XC resource type
 type ResourceType struct {
 	// Name is the resource type name (e.g., "http_loadbalancer")
@@ -24,6 +26,12 @@ type ResourceType struct {
 	// DeleteConfig contains custom delete configuration
 	// If nil, standard DELETE method is used
 	DeleteConfig *DeleteConfig
+}
+
+// HumanReadableName returns the human-readable name of the resource type
+// with proper acronym casing (e.g., "http_loadbalancer" -> "HTTP Load Balancer")
+func (r *ResourceType) HumanReadableName() string {
+	return naming.ToHumanReadable(r.Name)
 }
 
 // DeleteConfig defines custom delete behavior for a resource type

--- a/scripts/generate-homebrew-docs.py
+++ b/scripts/generate-homebrew-docs.py
@@ -18,6 +18,8 @@ from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader
 
+from naming import to_human_readable, normalize_acronyms, to_title_case
+
 
 def main():
     parser = argparse.ArgumentParser(
@@ -48,6 +50,11 @@ def main():
         trim_blocks=True,
         lstrip_blocks=True,
     )
+
+    # Register naming filters for consistency across all generators
+    env.filters["to_human_readable"] = to_human_readable
+    env.filters["normalize_acronyms"] = normalize_acronyms
+    env.filters["title_case"] = to_title_case
 
     template = env.get_template("homebrew.md.j2")
 

--- a/scripts/generate-script-docs.py
+++ b/scripts/generate-script-docs.py
@@ -15,6 +15,8 @@ from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader
 
+from naming import to_human_readable, normalize_acronyms, to_title_case
+
 
 def main():
     parser = argparse.ArgumentParser(
@@ -41,6 +43,11 @@ def main():
         trim_blocks=True,
         lstrip_blocks=True,
     )
+
+    # Register naming filters for consistency across all generators
+    env.filters["to_human_readable"] = to_human_readable
+    env.filters["normalize_acronyms"] = normalize_acronyms
+    env.filters["title_case"] = to_title_case
 
     template = env.get_template("script.md.j2")
 

--- a/scripts/generate-source-docs.py
+++ b/scripts/generate-source-docs.py
@@ -20,6 +20,8 @@ from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader
 
+from naming import to_human_readable, normalize_acronyms, to_title_case
+
 
 def clean_output(text):
     """Remove ANSI codes and trim whitespace."""
@@ -58,6 +60,11 @@ def main():
         trim_blocks=True,
         lstrip_blocks=True,
     )
+
+    # Register naming filters for consistency across all generators
+    env.filters["to_human_readable"] = to_human_readable
+    env.filters["normalize_acronyms"] = normalize_acronyms
+    env.filters["title_case"] = to_title_case
 
     template = env.get_template("source.md.j2")
 

--- a/scripts/generate-windows-docs.py
+++ b/scripts/generate-windows-docs.py
@@ -19,6 +19,8 @@ from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader
 
+from naming import to_human_readable, normalize_acronyms, to_title_case
+
 
 def main():
     parser = argparse.ArgumentParser(
@@ -49,6 +51,11 @@ def main():
         trim_blocks=True,
         lstrip_blocks=True,
     )
+
+    # Register naming filters for consistency across all generators
+    env.filters["to_human_readable"] = to_human_readable
+    env.filters["normalize_acronyms"] = normalize_acronyms
+    env.filters["title_case"] = to_title_case
 
     template = env.get_template("windows.md.j2")
 

--- a/scripts/naming.py
+++ b/scripts/naming.py
@@ -1,0 +1,341 @@
+"""
+Naming utilities for consistent case conversion and acronym handling.
+
+This module provides functions to convert resource names to human-readable format
+with proper acronym capitalization, matching the Go pkg/naming package.
+
+Usage:
+    from naming import to_human_readable, normalize_acronyms
+
+    to_human_readable("http_loadbalancer")  # "HTTP Load Balancer"
+    normalize_acronyms("Configure dns settings")  # "Configure DNS settings"
+"""
+
+import re
+from typing import Dict, Set
+
+# UppercaseAcronyms defines acronyms that should always be uppercase.
+# Based on RFC 4949, IEEE standards, and industry style guides.
+UPPERCASE_ACRONYMS: Set[str] = {
+    # Networking protocols
+    "DNS", "HTTP", "HTTPS", "TCP", "UDP",
+    "TLS", "SSL", "SSH", "FTP", "SFTP",
+    "SMTP", "IMAP", "POP", "LDAP", "DHCP",
+    "ARP", "ICMP", "SNMP", "NTP", "SIP",
+    "RTP", "RTSP", "QUIC", "IP", "GRPC",
+    # Web/API
+    "API", "URL", "URI", "REST", "SOAP",
+    "JSON", "XML", "HTML", "CSS", "CORS",
+    "CDN", "WAF", "JWT", "SAML",
+    # Network infrastructure
+    "VPN", "NAT", "VLAN", "BGP", "OSPF",
+    "QOS", "MTU", "TTL", "ACL", "CIDR",
+    "VIP", "LB", "HA", "DR",
+    # Security
+    "PKI", "CA", "CSR", "CRL", "OCSP",
+    "PEM", "AES", "RSA", "SHA", "MD5",
+    "HMAC", "MFA", "SSO", "RBAC", "IAM",
+    "DDOS", "DOS", "XSS", "CSRF", "SQL",
+    # Cloud/Infrastructure
+    "AWS", "GCP", "CPU", "RAM", "SSD",
+    "HDD", "GPU", "RAID", "VM", "OS",
+    "SLA", "RPO", "RTO", "VPC", "VNET",
+    "TGW", "IKE", "ID", "SLI", "S2S",
+    "RE", "CE", "SPO", "SMG",
+    "APM", "PII", "OIDC", "K8S",
+    # F5-specific
+    "ASM", "LTM", "GTM", "CNE", "XC",
+    "SSLO", "AFM", "AVR", "ASN", "SEC",
+    "RPC",
+}
+
+# MixedCaseAcronyms defines acronyms with specific mixed-case conventions.
+MIXED_CASE_ACRONYMS: Dict[str, str] = {
+    "mtls": "mTLS",
+    "oauth": "OAuth",
+    "graphql": "GraphQL",
+    "websocket": "WebSocket",
+    "iscsi": "iSCSI",
+    "ipv4": "IPv4",
+    "ipv6": "IPv6",
+    "macos": "macOS",
+    "ios": "iOS",
+    "nosql": "NoSQL",
+    "bigip": "BIG-IP",
+    "irule": "iRule",
+}
+
+# CompoundWordsHumanReadable defines compound words for documentation purposes.
+COMPOUND_WORDS_HUMAN_READABLE: Dict[str, str] = {
+    "loadbalancer": "Load Balancer",
+    "bigip": "BIG-IP",
+    "websocket": "WebSocket",
+    "fastcgi": "FastCGI",
+    "originpool": "Origin Pool",
+    "healthcheck": "Health Check",
+    "servicepolicy": "Service Policy",
+    "apiendpoint": "API Endpoint",
+    "apidefinition": "API Definition",
+    "apisecurity": "API Security",
+}
+
+# Pre-compiled regex for word boundary matching
+_WORD_REGEX = re.compile(r'\b([A-Za-z0-9]+)\b')
+
+
+def to_human_readable(s: str) -> str:
+    """
+    Convert a snake_case or kebab-case name to human-readable format
+    with proper acronym capitalization and compound word spacing.
+
+    Examples:
+        "http_loadbalancer" -> "HTTP Load Balancer"
+        "dns-zone" -> "DNS Zone"
+        "bigip_apm" -> "BIG-IP APM"
+        "mtls_config" -> "mTLS Config"
+
+    Args:
+        s: Input string in snake_case or kebab-case format
+
+    Returns:
+        Human-readable string with proper capitalization
+    """
+    if not s:
+        return ""
+
+    # Normalize separators: replace both underscores and hyphens with spaces
+    s = s.replace("_", " ").replace("-", " ")
+
+    parts = s.split()
+    result = []
+
+    for part in parts:
+        lower = part.lower()
+        upper = part.upper()
+
+        # Check for uppercase acronyms first (e.g., DNS, HTTP, API)
+        if upper in UPPERCASE_ACRONYMS:
+            result.append(upper)
+        # Handle compound words with spaces (e.g., "loadbalancer" -> "Load Balancer")
+        elif lower in COMPOUND_WORDS_HUMAN_READABLE:
+            result.append(COMPOUND_WORDS_HUMAN_READABLE[lower])
+        # Handle mixed-case acronyms (e.g., "mtls" -> "mTLS")
+        elif lower in MIXED_CASE_ACRONYMS:
+            result.append(MIXED_CASE_ACRONYMS[lower])
+        # Standard title case: capitalize first letter
+        elif part:
+            result.append(part[0].upper() + part[1:].lower())
+
+    return " ".join(result)
+
+
+def to_title_case(s: str) -> str:
+    """
+    Convert a snake_case or dot.separated string to Title Case,
+    preserving acronym capitalization.
+
+    Example: "http_load_balancer" -> "HTTP Load Balancer"
+
+    Args:
+        s: Input string
+
+    Returns:
+        Title case string with proper acronym handling
+    """
+    # Replace underscores, dots, and hyphens with spaces
+    s = s.replace("_", " ").replace(".", " ").replace("-", " ")
+
+    words = s.split()
+    result = []
+    for word in words:
+        if word:
+            # Apply standard title case first
+            result.append(word[0].upper() + word[1:].lower())
+
+    # Apply acronym normalization
+    return normalize_acronyms(" ".join(result))
+
+
+def to_title_case_from_anchor(anchor: str) -> str:
+    """
+    Convert an anchor name (kebab-case) to Title Case,
+    preserving acronym capitalization.
+
+    Example: "http-load-balancer" -> "HTTP Load Balancer"
+
+    Args:
+        anchor: Input string in kebab-case format
+
+    Returns:
+        Title case string with proper acronym handling
+    """
+    words = anchor.split("-")
+    result = []
+
+    for word in words:
+        upper = word.upper()
+        lower = word.lower()
+
+        if upper in UPPERCASE_ACRONYMS:
+            result.append(upper)
+        elif lower in MIXED_CASE_ACRONYMS:
+            result.append(MIXED_CASE_ACRONYMS[lower])
+        elif word:
+            result.append(word[0].upper() + word[1:].lower())
+
+    return " ".join(result)
+
+
+def normalize_acronyms(text: str) -> str:
+    """
+    Correct acronym capitalization in free text.
+    This function is idempotent - running it multiple times produces the same result.
+
+    Example: "Configure dns settings for the api endpoint"
+             -> "Configure DNS settings for the API endpoint"
+
+    Args:
+        text: Input text with potentially incorrect acronym casing
+
+    Returns:
+        Text with corrected acronym capitalization
+    """
+    if not text:
+        return ""
+
+    def replace_word(match):
+        word = match.group(1)
+        upper_word = word.upper()
+        lower_word = word.lower()
+
+        # Check for mixed-case acronyms first (e.g., mTLS, OAuth)
+        if lower_word in MIXED_CASE_ACRONYMS:
+            return MIXED_CASE_ACRONYMS[lower_word]
+
+        # Check for uppercase acronyms (e.g., DNS, HTTP, TCP)
+        if upper_word in UPPERCASE_ACRONYMS:
+            return upper_word
+
+        # Return original word unchanged
+        return word
+
+    return _WORD_REGEX.sub(replace_word, text)
+
+
+def to_kebab_case(s: str) -> str:
+    """
+    Convert a snake_case string to kebab-case.
+
+    Example: "http_loadbalancer" -> "http-loadbalancer"
+
+    Args:
+        s: Input string in snake_case format
+
+    Returns:
+        String in kebab-case format
+    """
+    return s.lower().replace("_", "-")
+
+
+def to_anchor_name(name: str) -> str:
+    """
+    Convert a name to an anchor-friendly format (kebab-case).
+
+    Example: "http_load_balancer" -> "http-load-balancer"
+
+    Args:
+        name: Input name
+
+    Returns:
+        Anchor-friendly string in kebab-case
+    """
+    return name.lower().replace("_", "-")
+
+
+def is_uppercase_acronym(s: str) -> bool:
+    """
+    Check if a string is a known uppercase acronym.
+
+    Args:
+        s: String to check
+
+    Returns:
+        True if the string is a known uppercase acronym
+    """
+    return s.upper() in UPPERCASE_ACRONYMS
+
+
+def get_mixed_case_acronym(s: str) -> str:
+    """
+    Get the correct mixed-case form for known acronyms.
+
+    Args:
+        s: String to check
+
+    Returns:
+        The correct mixed-case form, or empty string if not a mixed-case acronym
+    """
+    return MIXED_CASE_ACRONYMS.get(s.lower(), "")
+
+
+def get_compound_word_human_readable(s: str) -> str:
+    """
+    Get the human-readable form of a compound word.
+
+    Args:
+        s: String to check
+
+    Returns:
+        The human-readable form, or empty string if not a known compound word
+    """
+    return COMPOUND_WORDS_HUMAN_READABLE.get(s.lower(), "")
+
+
+def get_article(s: str) -> str:
+    """
+    Get the appropriate article ("a" or "an") for a string.
+
+    Args:
+        s: String to check
+
+    Returns:
+        "an" if the string starts with a vowel, otherwise "a"
+    """
+    if not s:
+        return "a"
+    first_char = s[0].lower()
+    if first_char in "aeiou":
+        return "an"
+    return "a"
+
+
+# Jinja2 filter aliases for backward compatibility
+underscore_to_space = lambda s: s.replace("_", " ") if s else ""
+title_case = to_title_case
+
+
+if __name__ == "__main__":
+    # Test examples
+    test_cases = [
+        "http_loadbalancer",
+        "dns_zone",
+        "api_endpoint",
+        "bigip_apm",
+        "mtls_config",
+        "aws_vpc_site",
+        "origin_pool",
+        "health_check",
+    ]
+
+    print("Testing to_human_readable:")
+    for tc in test_cases:
+        print(f"  {tc!r} -> {to_human_readable(tc)!r}")
+
+    print("\nTesting normalize_acronyms:")
+    texts = [
+        "Configure dns settings for the api endpoint",
+        "Enable mtls authentication",
+        "Use oauth for login",
+    ]
+    for text in texts:
+        print(f"  {text!r} -> {normalize_acronyms(text)!r}")

--- a/scripts/templates/action_under_resource.md.j2
+++ b/scripts/templates/action_under_resource.md.j2
@@ -51,7 +51,7 @@ api_docs_url: "{{ api_docs_url }}"
 ## Examples
 
 {% if action == 'list' %}
-### List all {{ resource | underscore_to_space }} resources
+### List all {{ resource | to_human_readable }} resources
 
 ```bash
 vesctl {{ group }} {{ action }} {{ resource }}
@@ -69,7 +69,7 @@ vesctl {{ group }} {{ action }} {{ resource }} -n example-namespace
 vesctl {{ group }} {{ action }} {{ resource }} --output-format json
 ```
 {% elif action == 'get' %}
-### Get {{ resource | underscore_to_space }} details
+### Get {{ resource | to_human_readable }} details
 
 ```bash
 vesctl {{ group }} {{ action }} {{ resource }} example-{{ resource | replace('_', '-') }}
@@ -81,13 +81,13 @@ vesctl {{ group }} {{ action }} {{ resource }} example-{{ resource | replace('_'
 vesctl {{ group }} {{ action }} {{ resource }} example-{{ resource | replace('_', '-') }} --output-format yaml
 ```
 {% elif action == 'create' %}
-### Create {{ resource | underscore_to_space }} from file
+### Create {{ resource | to_human_readable }} from file
 
 ```bash
 vesctl {{ group }} {{ action }} {{ resource }} -i {{ resource }}.yaml
 ```
 {% elif action == 'delete' %}
-### Delete {{ resource | underscore_to_space }}
+### Delete {{ resource | to_human_readable }}
 
 ```bash
 vesctl {{ group }} {{ action }} {{ resource }} example-{{ resource | replace('_', '-') }}
@@ -99,37 +99,37 @@ vesctl {{ group }} {{ action }} {{ resource }} example-{{ resource | replace('_'
 vesctl {{ group }} {{ action }} {{ resource }} example-{{ resource | replace('_', '-') }} --yes
 ```
 {% elif action == 'replace' %}
-### Replace {{ resource | underscore_to_space }} from file
+### Replace {{ resource | to_human_readable }} from file
 
 ```bash
 vesctl {{ group }} {{ action }} {{ resource }} -i {{ resource }}.yaml
 ```
 {% elif action == 'apply' %}
-### Apply {{ resource | underscore_to_space }} from file
+### Apply {{ resource | to_human_readable }} from file
 
 ```bash
 vesctl {{ group }} {{ action }} {{ resource }} -i {{ resource }}.yaml
 ```
 {% elif action == 'status' %}
-### Get {{ resource | underscore_to_space }} status
+### Get {{ resource | to_human_readable }} status
 
 ```bash
 vesctl {{ group }} {{ action }} {{ resource }} example-{{ resource | replace('_', '-') }}
 ```
 {% elif action == 'patch' %}
-### Patch {{ resource | underscore_to_space }}
+### Patch {{ resource | to_human_readable }}
 
 ```bash
 vesctl {{ group }} {{ action }} {{ resource }} example-{{ resource | replace('_', '-') }} -i patch.yaml
 ```
 {% elif action == 'add-labels' %}
-### Add labels to {{ resource | underscore_to_space }}
+### Add labels to {{ resource | to_human_readable }}
 
 ```bash
 vesctl {{ group }} {{ action }} {{ resource }} example-{{ resource | replace('_', '-') }} --label-key app --label-value web
 ```
 {% elif action == 'remove-labels' %}
-### Remove labels from {{ resource | underscore_to_space }}
+### Remove labels from {{ resource | to_human_readable }}
 
 ```bash
 vesctl {{ group }} {{ action }} {{ resource }} example-{{ resource | replace('_', '-') }} --label-key app
@@ -144,5 +144,5 @@ vesctl {{ group }} {{ action }} {{ resource }} example-{{ resource | replace('_'
 {% if api_docs_url %}
 ## API Reference
 
-- [{{ resource | title_case }} API Documentation]({{ api_docs_url }})
+- [{{ resource | to_human_readable }} API Documentation]({{ api_docs_url }})
 {% endif %}

--- a/scripts/templates/resource_overview.md.j2
+++ b/scripts/templates/resource_overview.md.j2
@@ -11,7 +11,7 @@ resource_type: "{{ front_matter.resource_type }}"
 
 # vesctl {{ group }} {{ resource }}
 
-> Manage {{ resource | underscore_to_space }} resources in F5 Distributed Cloud
+> Manage {{ resource | to_human_readable }} resources in F5 Distributed Cloud
 
 ## Available Actions
 
@@ -23,7 +23,7 @@ resource_type: "{{ front_matter.resource_type }}"
 
 ## Common Workflows
 
-### Create and verify a {{ resource | underscore_to_space }}
+### Create and verify a {{ resource | to_human_readable }}
 
 ```bash
 # Create from file
@@ -36,7 +36,7 @@ vesctl {{ group }} list {{ resource }}
 vesctl {{ group }} get {{ resource }} <name>
 ```
 
-### Update a {{ resource | underscore_to_space }}
+### Update a {{ resource | to_human_readable }}
 
 ```bash
 # Replace entire resource
@@ -59,7 +59,7 @@ vesctl {{ group }} add-labels {{ resource }} <name> --label-key app --label-valu
 vesctl {{ group }} remove-labels {{ resource }} <name> --label-key app
 ```
 
-### Delete a {{ resource | underscore_to_space }}
+### Delete a {{ resource | to_human_readable }}
 
 ```bash
 vesctl {{ group }} delete {{ resource }} <name>
@@ -70,5 +70,5 @@ vesctl {{ group }} delete {{ resource }} <name> --yes
 
 ## See Also
 
-- [vesctl {{ group }}](../index.md) - {{ group | title_case }} commands
+- [vesctl {{ group }}](../index.md) - {{ group | to_human_readable }} commands
 - [Command Reference](../../index.md)

--- a/scripts/templates/resource_type.md.j2
+++ b/scripts/templates/resource_type.md.j2
@@ -51,7 +51,7 @@ api_docs_url: "{{ api_docs_url }}"
 ## Examples
 
 {% if action == 'list' %}
-### List all {{ resource | underscore_to_space }} resources
+### List all {{ resource | to_human_readable }} resources
 
 ```bash
 vesctl {{ group }} {{ action }} {{ resource }}
@@ -69,7 +69,7 @@ vesctl {{ group }} {{ action }} {{ resource }} -n example-namespace
 vesctl {{ group }} {{ action }} {{ resource }} --output-format json
 ```
 {% elif action == 'get' %}
-### Get {{ resource | underscore_to_space }} details
+### Get {{ resource | to_human_readable }} details
 
 ```bash
 vesctl {{ group }} {{ action }} {{ resource }} example-{{ resource | replace('_', '-') }}
@@ -81,13 +81,13 @@ vesctl {{ group }} {{ action }} {{ resource }} example-{{ resource | replace('_'
 vesctl {{ group }} {{ action }} {{ resource }} example-{{ resource | replace('_', '-') }} --output-format yaml
 ```
 {% elif action == 'create' %}
-### Create {{ resource | underscore_to_space }} from file
+### Create {{ resource | to_human_readable }} from file
 
 ```bash
 vesctl {{ group }} {{ action }} {{ resource }} -i {{ resource }}.yaml
 ```
 {% elif action == 'delete' %}
-### Delete {{ resource | underscore_to_space }}
+### Delete {{ resource | to_human_readable }}
 
 ```bash
 vesctl {{ group }} {{ action }} {{ resource }} example-{{ resource | replace('_', '-') }}
@@ -99,37 +99,37 @@ vesctl {{ group }} {{ action }} {{ resource }} example-{{ resource | replace('_'
 vesctl {{ group }} {{ action }} {{ resource }} example-{{ resource | replace('_', '-') }} --yes
 ```
 {% elif action == 'replace' %}
-### Replace {{ resource | underscore_to_space }} from file
+### Replace {{ resource | to_human_readable }} from file
 
 ```bash
 vesctl {{ group }} {{ action }} {{ resource }} -i {{ resource }}.yaml
 ```
 {% elif action == 'apply' %}
-### Apply {{ resource | underscore_to_space }} from file
+### Apply {{ resource | to_human_readable }} from file
 
 ```bash
 vesctl {{ group }} {{ action }} {{ resource }} -i {{ resource }}.yaml
 ```
 {% elif action == 'status' %}
-### Get {{ resource | underscore_to_space }} status
+### Get {{ resource | to_human_readable }} status
 
 ```bash
 vesctl {{ group }} {{ action }} {{ resource }} example-{{ resource | replace('_', '-') }}
 ```
 {% elif action == 'patch' %}
-### Patch {{ resource | underscore_to_space }}
+### Patch {{ resource | to_human_readable }}
 
 ```bash
 vesctl {{ group }} {{ action }} {{ resource }} example-{{ resource | replace('_', '-') }} -i patch.yaml
 ```
 {% elif action == 'add-labels' %}
-### Add labels to {{ resource | underscore_to_space }}
+### Add labels to {{ resource | to_human_readable }}
 
 ```bash
 vesctl {{ group }} {{ action }} {{ resource }} example-{{ resource | replace('_', '-') }} --label-key app --label-value web
 ```
 {% elif action == 'remove-labels' %}
-### Remove labels from {{ resource | underscore_to_space }}
+### Remove labels from {{ resource | to_human_readable }}
 
 ```bash
 vesctl {{ group }} {{ action }} {{ resource }} example-{{ resource | replace('_', '-') }} --label-key app
@@ -144,5 +144,5 @@ vesctl {{ group }} {{ action }} {{ resource }} example-{{ resource | replace('_'
 {% if api_docs_url %}
 ## API Reference
 
-- [{{ resource | title_case }} API Documentation]({{ api_docs_url }})
+- [{{ resource | to_human_readable }} API Documentation]({{ api_docs_url }})
 {% endif %}

--- a/scripts/templates/resource_unified.md.j2
+++ b/scripts/templates/resource_unified.md.j2
@@ -24,7 +24,7 @@ api_docs:
 
 # vesctl {{ group }} {{ resource }}
 
-> Manage {{ resource | underscore_to_space }} resources in F5 Distributed Cloud
+> Manage {{ resource | to_human_readable }} resources in F5 Distributed Cloud
 
 ## Actions
 
@@ -69,7 +69,7 @@ api_docs:
 {% if action.api_docs_url %}
 #### API Reference
 
-- [{{ resource | title_case }} {{ action.action_name | title_case }} API]({{ action.api_docs_url }})
+- [{{ resource | to_human_readable }} {{ action.action_name | title }} API]({{ action.api_docs_url }})
 {% endif %}
 
 </details>

--- a/scripts/templates/rpc_procedure.md.j2
+++ b/scripts/templates/rpc_procedure.md.j2
@@ -81,7 +81,7 @@ Other procedures in the {{ service }} service:
 {% endif %}
 ## See Also
 
-- [{{ service | underscore_to_space | title }} Service](index.md) - All {{ service }} procedures
+- [{{ service | to_human_readable }} Service](index.md) - All {{ service }} procedures
 - [vesctl request rpc](../index.md) - All RPC commands
 - [vesctl request](../../index.md) - Request commands
 - [Command Reference](../../../index.md)

--- a/scripts/templates/rpc_service.md.j2
+++ b/scripts/templates/rpc_service.md.j2
@@ -11,11 +11,11 @@ rpc_service: "{{ front_matter.rpc_service }}"
 
 # vesctl request rpc {{ service }}
 
-> {{ service | underscore_to_space | title }} service RPC procedures
+> {{ service | to_human_readable }} service RPC procedures
 
 ## Overview
 
-The `{{ service }}` service provides {{ procedures | length }} RPC procedures for interacting with {{ service | underscore_to_space }} functionality in F5 Distributed Cloud.
+The `{{ service }}` service provides {{ procedures | length }} RPC procedures for interacting with {{ service | to_human_readable }} functionality in F5 Distributed Cloud.
 
 ## Available Procedures
 

--- a/scripts/templates/rpc_service_unified.md.j2
+++ b/scripts/templates/rpc_service_unified.md.j2
@@ -11,7 +11,7 @@ procedure_count: {{ procedures | length }}
 
 # vesctl request rpc {{ service }}
 
-> {{ service | underscore_to_space | title }} service RPC procedures
+> {{ service | to_human_readable }} service RPC procedures
 
 ## Procedures
 


### PR DESCRIPTION
## Summary
- Add dictionary-based case normalization for industry acronyms (DNS, HTTP, TCP, BIG-IP, mTLS, etc.)
- Create `pkg/naming/` Go package with transformation functions
- Create `scripts/naming.py` Python port for documentation generation
- Update CLI commands to display human-readable resource names
- Update documentation generators and Jinja2 templates

## Changes
- **pkg/naming/**: New Go package with ToHumanReadable, NormalizeAcronyms, ToTitleCase functions
- **scripts/naming.py**: Python port for Jinja2 template filters
- **cmd/configuration.go, cmd/resource.go**: Use naming functions for CLI help text
- **scripts/generate-*.py**: Register naming filters for all doc generators
- **scripts/templates/*.j2**: Replace .title() with to_human_readable filter

## Test plan
- [ ] Go tests pass (`go test ./pkg/naming/...`)
- [ ] CLI help shows normalized acronyms (`./vesctl configuration list http_loadbalancer --help`)
- [ ] Documentation generates with proper casing
- [ ] CI/CD pipelines complete successfully
- [ ] Web documentation displays correct acronym casing

🤖 Generated with [Claude Code](https://claude.com/claude-code)