### PR TITLE
style: hide GitHub stars and forks from documentation header

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1214,3 +1214,9 @@ article.md-content__inner.md-typeset {
     grid-template-columns: 1fr;
   }
 }
+
+/* Hide GitHub stars and forks from header, keep version only */
+.md-source__fact--stars,
+.md-source__fact--forks {
+  display: none !important;
+}


### PR DESCRIPTION
## Summary
- Hide GitHub stars and forks counters from the documentation header
- Keep the version number visible (currently shows v4.17.1 correctly)

## Changes
Add CSS rules to `docs/stylesheets/extra.css` to hide the `.md-source__fact--stars` and `.md-source__fact--forks` elements.

## Before
Header shows: `robinmordasiewicz/vesctl v4.17.1 ☆0 Y0`

## After
Header shows: `robinmordasiewicz/vesctl v4.17.1`

## Test plan
- [ ] Verify stars counter is hidden
- [ ] Verify forks counter is hidden
- [ ] Verify version number still displays
- [ ] Verify repository link still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)