### PR TITLE
style: display GitHub repo and version on single line with larger text

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1215,6 +1215,32 @@ article.md-content__inner.md-typeset {
   }
 }
 
+/* GitHub repository header - single line layout with larger text */
+.md-source {
+  display: flex !important;
+  align-items: center !important;
+  gap: 0.5rem;
+}
+
+.md-source__repository {
+  display: flex !important;
+  align-items: center !important;
+  gap: 0.4rem;
+  font-size: 0.8rem !important;
+}
+
+.md-source__facts {
+  display: inline-flex !important;
+  align-items: center !important;
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+.md-source__fact--version {
+  font-size: 0.8rem !important;
+  opacity: 0.8;
+}
+
 /* Hide GitHub stars and forks from header, keep version only */
 .md-source__fact--stars,
 .md-source__fact--forks {


### PR DESCRIPTION
## Summary
- Refactor GitHub repository header to display logo, repo name, and version on a single line
- Increase font size for repository name and version text (0.8rem)
- Use flexbox layout for proper alignment

## Changes
- Update `docs/stylesheets/extra.css` with flexbox layout rules
- Add `display: inline-flex` to `.md-source__facts` to keep version inline
- Increase font sizes for better visibility

## Test plan
- [ ] Verify GitHub header displays on single line after deployment
- [ ] Confirm logo, repo name, and version are properly aligned
- [ ] Check font sizes are larger than previous layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)