### PR TITLE
fix: reduce search box width to prevent GitHub header truncation

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1222,7 +1222,7 @@ article.md-content__inner.md-typeset {
 
 /* Reduce search box width to give more space to source */
 .md-search {
-  max-width: 12rem;
+  max-width: 8rem;
 }
 
 /* GitHub repository header - single line layout */


### PR DESCRIPTION
## Summary
- Reduced search box max-width from 12rem to 8rem
- Frees up ~64px of horizontal space in the header
- Prevents "robinmordasiewicz/vesctl v4.17.2" text from being cut off at the viewport edge

## Test plan
- [ ] Verify full repository name and version displays without truncation
- [ ] Verify search box is still usable at the smaller width
- [ ] Test on different viewport sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)