### PR TITLE
fix: set min-width on header source container to prevent overflow

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1225,6 +1225,12 @@ article.md-content__inner.md-typeset {
   max-width: 8rem;
 }
 
+/* Give source container enough width to fit content */
+.md-header__source {
+  min-width: 15rem;
+  flex-shrink: 0;
+}
+
 /* GitHub repository header - single line layout */
 .md-source {
   display: flex !important;


### PR DESCRIPTION
## Summary
- Added `min-width: 15rem` to `.md-header__source` container
- Added `flex-shrink: 0` to prevent container from being squeezed

## Root Cause
The `.md-source` element had `min-width: max-content` (234px) to display the full text without wrapping, but its parent `.md-header__source` container was only allocated 187px by the flexbox layout. This caused 47px of content to overflow beyond the viewport.

## Test plan
- [ ] Verify "robinmordasiewicz/vesctl v4.17.3" displays fully within viewport
- [ ] Test on various viewport widths
- [ ] Verify search box is still usable

🤖 Generated with [Claude Code](https://claude.com/claude-code)