### PR TITLE
fix: increase header width and add robust retry logic to workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -465,18 +465,35 @@ jobs:
         id: homebrew-install
         run: |
           MAX_RETRIES=5
-          RETRY_DELAY=30
+          BASE_DELAY=10
 
           for i in $(seq 1 $MAX_RETRIES); do
             echo "Attempt $i of $MAX_RETRIES..."
 
-            # Refresh tap
-            brew tap robinmordasiewicz/tap
+            # Clean state before retry (except first attempt)
+            if [ $i -gt 1 ]; then
+              echo "Cleaning up before retry..."
+              brew uninstall --cask vesctl 2>/dev/null || true
+              brew untap robinmordasiewicz/tap 2>/dev/null || true
+            fi
+
+            # Refresh tap with retry
+            echo "Refreshing Homebrew tap..."
+            if ! brew tap robinmordasiewicz/tap; then
+              echo "::warning::Failed to tap, will retry..."
+              if [ $i -lt $MAX_RETRIES ]; then
+                DELAY=$((BASE_DELAY * (2 ** (i - 1))))
+                echo "Waiting ${DELAY}s before retry..."
+                sleep $DELAY
+                continue
+              fi
+            fi
+
             brew update
 
             # Try to install (using cask) and capture output
             if brew install --cask vesctl 2>&1 | tee homebrew-output.txt; then
-              echo "Successfully installed vesctl"
+              echo "Successfully installed vesctl on attempt $i"
               echo "homebrew_success=true" >> $GITHUB_OUTPUT
               exit 0
             fi
@@ -487,8 +504,10 @@ jobs:
               exit 0
             fi
 
-            echo "Waiting ${RETRY_DELAY}s before retry..."
-            sleep $RETRY_DELAY
+            # Exponential backoff: 10s, 20s, 40s, 80s
+            DELAY=$((BASE_DELAY * (2 ** (i - 1))))
+            echo "::warning::Install failed on attempt $i, retrying in ${DELAY}s..."
+            sleep $DELAY
           done
 
       - name: Capture vesctl version

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1227,7 +1227,7 @@ article.md-content__inner.md-typeset {
 
 /* Give source container enough width to fit content */
 .md-header__source {
-  min-width: 15rem;
+  min-width: 17rem;
   flex-shrink: 0;
 }
 


### PR DESCRIPTION
## Summary
- Increase GitHub header container width from 15rem to 17rem to prevent text truncation
- Add exponential backoff and clean state retry logic to Homebrew installation step

## Changes

### Header Fix
- `.md-header__source` min-width: 15rem → 17rem (240px → 272px)
- Content requires ~261px for full "robinmordasiewicz/vesctl v4.17.4" display

### Workflow Improvements
- Exponential backoff: 10s, 20s, 40s, 80s delays between retries
- Clean state before retry: uninstall cask, untap repository
- Handle tap failures with retry instead of immediate failure
- Deterministic recovery from transient network/API failures

## Test plan
- [ ] Verify header displays full repo name and version without truncation
- [ ] Verify workflow handles transient Homebrew failures gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)