### PR TITLE
fix: ensure Homebrew bin directory is in PATH for vesctl

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -514,7 +514,14 @@ jobs:
         if: steps.homebrew-install.outputs.homebrew_success == 'true'
         id: vesctl-version
         run: |
-          VERSION_OUTPUT=$(vesctl version)
+          # Ensure Homebrew bin is in PATH (ARM and Intel macOS)
+          export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+
+          # Find vesctl location for debugging
+          VESCTL_PATH=$(which vesctl 2>/dev/null || find /opt/homebrew -name vesctl -type f 2>/dev/null | head -1 || echo "")
+          echo "vesctl found at: $VESCTL_PATH"
+
+          VERSION_OUTPUT=$("$VESCTL_PATH" version 2>/dev/null || vesctl version)
           echo "Full version output:"
           echo "$VERSION_OUTPUT"
 


### PR DESCRIPTION
## Summary
Fix workflow failure where vesctl command is not found after Homebrew cask installation.

## Problem
After `brew install --cask vesctl`, the binary is installed but the Homebrew bin directory isn't in PATH on macOS runners, causing `vesctl: command not found` error.

## Solution
- Add `/opt/homebrew/bin` and `/usr/local/bin` to PATH explicitly
- Use fallback search with `which` and `find` to locate vesctl
- Log the vesctl location for debugging

## Test plan
- [ ] Workflow completes without "command not found" error
- [ ] vesctl version is captured correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)