### PR TITLE
fix: add comprehensive vesctl binary path detection in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -517,9 +517,50 @@ jobs:
           # Ensure Homebrew bin is in PATH (ARM and Intel macOS)
           export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
 
-          # Find vesctl location for debugging
-          VESCTL_PATH=$(which vesctl 2>/dev/null || find /opt/homebrew -name vesctl -type f 2>/dev/null | head -1 || echo "")
+          # Debug: Show Caskroom contents
+          echo "=== Caskroom contents ==="
+          ls -la /opt/homebrew/Caskroom/vesctl/ 2>/dev/null || ls -la /usr/local/Caskroom/vesctl/ 2>/dev/null || echo "No Caskroom found"
+
+          # Debug: Show what's in the version directory
+          echo "=== Version directory contents ==="
+          ls -la /opt/homebrew/Caskroom/vesctl/*/ 2>/dev/null || ls -la /usr/local/Caskroom/vesctl/*/ 2>/dev/null || echo "No version directory found"
+
+          # Debug: Show bin directory for symlinks
+          echo "=== Homebrew bin directory (vesctl entries) ==="
+          ls -la /opt/homebrew/bin/vesctl* 2>/dev/null || ls -la /usr/local/bin/vesctl* 2>/dev/null || echo "No vesctl in bin"
+
+          # Find vesctl - check multiple locations including Caskroom
+          VESCTL_PATH=""
+
+          # 1. Try which (if symlink was created)
+          VESCTL_PATH=$(which vesctl 2>/dev/null || true)
+
+          # 2. Try common symlink locations
+          if [ -z "$VESCTL_PATH" ] || [ ! -x "$VESCTL_PATH" ]; then
+            for path in /opt/homebrew/bin/vesctl /usr/local/bin/vesctl; do
+              if [ -x "$path" ]; then
+                VESCTL_PATH="$path"
+                break
+              fi
+            done
+          fi
+
+          # 3. Try Caskroom location directly (ARM Mac)
+          if [ -z "$VESCTL_PATH" ] || [ ! -x "$VESCTL_PATH" ]; then
+            VESCTL_PATH=$(find /opt/homebrew/Caskroom/vesctl -name vesctl -type f 2>/dev/null | head -1 || true)
+          fi
+
+          # 4. Try Caskroom location directly (Intel Mac)
+          if [ -z "$VESCTL_PATH" ] || [ ! -x "$VESCTL_PATH" ]; then
+            VESCTL_PATH=$(find /usr/local/Caskroom/vesctl -name vesctl -type f 2>/dev/null | head -1 || true)
+          fi
+
           echo "vesctl found at: $VESCTL_PATH"
+
+          if [ -z "$VESCTL_PATH" ] || [ ! -x "$VESCTL_PATH" ]; then
+            echo "::error::vesctl binary not found after Homebrew installation"
+            exit 1
+          fi
 
           VERSION_OUTPUT=$("$VESCTL_PATH" version 2>/dev/null || vesctl version)
           echo "Full version output:"


### PR DESCRIPTION
## Summary
- Add debug output to diagnose vesctl binary location after Homebrew cask install
- Search multiple locations: bin directories, Caskroom paths
- Support both ARM (/opt/homebrew) and Intel (/usr/local) macOS

## Problem
The Homebrew cask installation succeeded ("Successfully installed vesctl on attempt 1") but the vesctl binary wasn't being found in the "Capture vesctl version" step, causing workflow failures.

## Root Cause
1. The `binary "vesctl"` stanza in the cask creates a symlink in /opt/homebrew/bin
2. The find command was only searching for files (-type f), potentially missing symlinks
3. The actual binary is in /opt/homebrew/Caskroom/vesctl/<version>/

## Changes
- Add debug output showing Caskroom contents, version directory, and bin directory
- Check multiple paths in order: which, bin directories, Caskroom paths
- Support both ARM Mac (/opt/homebrew) and Intel Mac (/usr/local)
- Add explicit error message if binary not found after all checks

## Test plan
- [ ] Workflow should now show debug output revealing where vesctl is installed
- [ ] Binary should be found in one of the checked locations
- [ ] Version capture should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)