### PR TITLE
chore: add .playwright-mcp/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ vesctl.windows-*
 
 # Generated shell completions (created during release build)
 completions/
+
+# MCP tool state directories
+.playwright-mcp/


### PR DESCRIPTION
## Summary
Add MCP tool state directories to gitignore.

## Changes
- Add `.playwright-mcp/` to gitignore under new "MCP tool state directories" section

The `.playwright-mcp/` directory is created by the Playwright MCP server for browser
automation state and should not be committed to version control.

## Test plan
- [x] `.gitignore` updated
- [x] No code changes, CI validation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)