### PR TITLE
feat: add shell completion for cloudstatus commands

### DIFF
--- a/cmd/cloudstatus_completion.go
+++ b/cmd/cloudstatus_completion.go
@@ -1,0 +1,194 @@
+package cmd
+
+import (
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/robinmordasiewicz/vesctl/pkg/cloudstatus"
+)
+
+// Completion client with longer cache TTL for tab completion
+var completionClient *cloudstatus.Client
+
+// getCompletionClient returns a cloudstatus client optimized for tab completion.
+// Uses a 5-minute cache TTL and 3-second timeout to avoid blocking the shell.
+func getCompletionClient() *cloudstatus.Client {
+	if completionClient == nil {
+		completionClient = cloudstatus.NewClient(
+			cloudstatus.WithTimeout(3*time.Second),
+			cloudstatus.WithCache(5*time.Minute),
+		)
+	}
+	return completionClient
+}
+
+// Static completion functions - no API calls required
+
+// completeComponentStatus provides completion for component status values.
+func completeComponentStatus(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return []string{
+		cloudstatus.ComponentOperational + "\tFully operational",
+		cloudstatus.ComponentDegradedPerformance + "\tDegraded performance",
+		cloudstatus.ComponentPartialOutage + "\tPartial outage",
+		cloudstatus.ComponentMajorOutage + "\tMajor outage",
+		cloudstatus.ComponentUnderMaintenance + "\tUnder maintenance",
+	}, cobra.ShellCompDirectiveNoFileComp
+}
+
+// completeIncidentStatus provides completion for incident status values.
+func completeIncidentStatus(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return []string{
+		cloudstatus.IncidentInvestigating + "\tInvestigating the issue",
+		cloudstatus.IncidentIdentified + "\tIssue identified",
+		cloudstatus.IncidentMonitoring + "\tMonitoring the fix",
+		cloudstatus.IncidentResolved + "\tIssue resolved",
+		cloudstatus.IncidentPostmortem + "\tPostmortem in progress",
+	}, cobra.ShellCompDirectiveNoFileComp
+}
+
+// completeIncidentImpact provides completion for incident impact values.
+func completeIncidentImpact(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return []string{
+		cloudstatus.ImpactNone + "\tNo impact",
+		cloudstatus.ImpactMinor + "\tMinor impact",
+		cloudstatus.ImpactMajor + "\tMajor impact",
+		cloudstatus.ImpactCritical + "\tCritical impact",
+	}, cobra.ShellCompDirectiveNoFileComp
+}
+
+// completeMaintenanceStatus provides completion for maintenance status values.
+func completeMaintenanceStatus(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return []string{
+		cloudstatus.MaintenanceScheduled + "\tMaintenance scheduled",
+		cloudstatus.MaintenanceInProgress + "\tMaintenance in progress",
+		cloudstatus.MaintenanceVerifying + "\tVerifying maintenance completion",
+		cloudstatus.MaintenanceCompleted + "\tMaintenance completed",
+	}, cobra.ShellCompDirectiveNoFileComp
+}
+
+// completeRegion provides completion for region values.
+func completeRegion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	completions := make([]string, len(cloudstatus.PredefinedRegions))
+	for i, region := range cloudstatus.PredefinedRegions {
+		completions[i] = region.ID + "\t" + region.DisplayName
+	}
+	return completions, cobra.ShellCompDirectiveNoFileComp
+}
+
+// Dynamic completion functions - require API calls
+
+// completeComponentID provides completion for component IDs.
+func completeComponentID(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	// Only complete first argument
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	client := getCompletionClient()
+	resp, err := client.GetComponents()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	completions := []string{}
+	for _, comp := range resp.Components {
+		// Skip groups - only show actual components
+		if comp.Group {
+			continue
+		}
+		completions = append(completions, comp.ID+"\t"+comp.Name)
+	}
+
+	return completions, cobra.ShellCompDirectiveNoFileComp
+}
+
+// completeIncidentID provides completion for incident IDs.
+func completeIncidentID(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	// Only complete first argument
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	client := getCompletionClient()
+	resp, err := client.GetIncidents()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	completions := []string{}
+	for _, inc := range resp.Incidents {
+		// Truncate name if too long
+		name := inc.Name
+		if len(name) > 50 {
+			name = name[:47] + "..."
+		}
+		completions = append(completions, inc.ID+"\t"+name+" ("+inc.Status+")")
+	}
+
+	return completions, cobra.ShellCompDirectiveNoFileComp
+}
+
+// completeMaintenanceID provides completion for maintenance IDs.
+func completeMaintenanceID(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	// Only complete first argument
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	client := getCompletionClient()
+	resp, err := client.GetMaintenances()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	completions := []string{}
+	for _, maint := range resp.ScheduledMaintenances {
+		// Truncate name if too long
+		name := maint.Name
+		if len(name) > 50 {
+			name = name[:47] + "..."
+		}
+		completions = append(completions, maint.ID+"\t"+name+" ("+maint.Status+")")
+	}
+
+	return completions, cobra.ShellCompDirectiveNoFileComp
+}
+
+// completeWatchComponents provides completion for the watch --components flag.
+// Supports comma-separated values.
+func completeWatchComponents(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	client := getCompletionClient()
+	resp, err := client.GetComponents()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	completions := []string{}
+	for _, comp := range resp.Components {
+		// Skip groups - only show actual components
+		if comp.Group {
+			continue
+		}
+		completions = append(completions, comp.ID+"\t"+comp.Name)
+	}
+
+	// Allow comma-separated values (no space after completion)
+	return completions, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
+}
+
+// completeComponentGroup provides completion for component group filtering.
+func completeComponentGroup(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	client := getCompletionClient()
+	groups, err := client.GetComponentGroups()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	completions := []string{}
+	for _, group := range groups {
+		completions = append(completions, group.ID+"\t"+group.Name)
+	}
+
+	return completions, cobra.ShellCompDirectiveNoFileComp
+}

--- a/cmd/cloudstatus_components.go
+++ b/cmd/cloudstatus_components.go
@@ -111,6 +111,11 @@ func init() {
 
 	// Groups flags
 	cloudstatusComponentsGroupsCmd.Flags().BoolVar(&componentsWithComponents, "with-components", false, "Include component count per group.")
+
+	// Register completions
+	_ = cloudstatusComponentsListCmd.RegisterFlagCompletionFunc("status", completeComponentStatus)
+	_ = cloudstatusComponentsListCmd.RegisterFlagCompletionFunc("group", completeComponentGroup)
+	cloudstatusComponentsGetCmd.ValidArgsFunction = completeComponentID
 }
 
 func runComponentsList(cmd *cobra.Command, args []string) error {

--- a/cmd/cloudstatus_incidents.go
+++ b/cmd/cloudstatus_incidents.go
@@ -105,6 +105,12 @@ func init() {
 	cloudstatusIncidentsListCmd.Flags().StringVar(&incidentsImpact, "impact", "", "Filter by impact level (none, minor, major, critical).")
 	cloudstatusIncidentsListCmd.Flags().StringVar(&incidentsSince, "since", "", "Time filter (1h, 1d, 7d, 30d).")
 	cloudstatusIncidentsListCmd.Flags().IntVar(&incidentsLimit, "limit", 0, "Limit number of results.")
+
+	// Register completions
+	_ = cloudstatusIncidentsListCmd.RegisterFlagCompletionFunc("status", completeIncidentStatus)
+	_ = cloudstatusIncidentsListCmd.RegisterFlagCompletionFunc("impact", completeIncidentImpact)
+	cloudstatusIncidentsGetCmd.ValidArgsFunction = completeIncidentID
+	cloudstatusIncidentsUpdatesCmd.ValidArgsFunction = completeIncidentID
 }
 
 func runIncidentsList(cmd *cobra.Command, args []string) error {

--- a/cmd/cloudstatus_maintenance.go
+++ b/cmd/cloudstatus_maintenance.go
@@ -87,6 +87,10 @@ func init() {
 
 	// List flags
 	cloudstatusMaintenanceListCmd.Flags().StringVar(&maintenanceStatus, "status", "", "Filter by status (scheduled, in_progress, verifying, completed).")
+
+	// Register completions
+	_ = cloudstatusMaintenanceListCmd.RegisterFlagCompletionFunc("status", completeMaintenanceStatus)
+	cloudstatusMaintenanceGetCmd.ValidArgsFunction = completeMaintenanceID
 }
 
 func runMaintenanceList(cmd *cobra.Command, args []string) error {

--- a/cmd/cloudstatus_pops.go
+++ b/cmd/cloudstatus_pops.go
@@ -77,6 +77,10 @@ func init() {
 
 	// Status flags
 	cloudstatusPopsStatusCmd.Flags().StringVar(&popsRegion, "region", "", "Filter by region (north-america, south-america, europe, asia, oceania, middle-east).")
+
+	// Register completions
+	_ = cloudstatusPopsListCmd.RegisterFlagCompletionFunc("region", completeRegion)
+	_ = cloudstatusPopsStatusCmd.RegisterFlagCompletionFunc("region", completeRegion)
 }
 
 func runPopsList(cmd *cobra.Command, args []string) error {

--- a/cmd/cloudstatus_watch.go
+++ b/cmd/cloudstatus_watch.go
@@ -56,6 +56,9 @@ func init() {
 	cloudstatusWatchCmd.Flags().StringVar(&watchComponents, "components", "", "Watch specific components (comma-separated names).")
 	cloudstatusWatchCmd.Flags().BoolVar(&watchExitOnChange, "exit-on-change", false, "Exit when status changes.")
 	cloudstatusWatchCmd.Flags().BoolVar(&watchNoClear, "no-clear", false, "Don't clear screen between updates.")
+
+	// Register completions
+	_ = cloudstatusWatchCmd.RegisterFlagCompletionFunc("components", completeWatchComponents)
 }
 
 type watchState struct {


### PR DESCRIPTION
## Summary

Add custom shell completion for the `cloudstatus` command group with both static and dynamic completions.

### Static Completions (instant, offline)

| Flag | Values |
|------|--------|
| `--status` (components) | operational, degraded_performance, partial_outage, major_outage, under_maintenance |
| `--status` (incidents) | investigating, identified, monitoring, resolved, postmortem |
| `--impact` | none, minor, major, critical |
| `--status` (maintenance) | scheduled, in_progress, verifying, completed |
| `--region` | north-america, south-america, europe, asia, oceania, middle-east |

### Dynamic Completions (API-backed)

- 5-minute cache TTL to avoid excessive API calls
- 3-second timeout to prevent blocking shell

| Command | Completes |
|---------|-----------|
| `components get <TAB>` | Component IDs with names |
| `incidents get <TAB>` | Incident IDs with names/status |
| `maintenance get <TAB>` | Maintenance IDs with names/status |
| `watch --components <TAB>` | Component IDs for comma-separated selection |
| `--group <TAB>` | Component group IDs with names |

## Test plan

- [x] Build succeeds
- [x] All static completions return expected values
- [x] Dynamic completions fetch from API correctly
- [x] golangci-lint passes
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)