### PR TITLE
fix: add notarization stapling to macOS binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,6 +231,15 @@ jobs:
               --team-id "$APPLE_TEAM_ID" \
               --wait
 
+            # Staple the notarization ticket to the binary
+            # This embeds the ticket so Gatekeeper can verify locally without contacting Apple
+            echo "Stapling notarization ticket to binary..."
+            xcrun stapler staple "$BINARY_PATH"
+
+            # Verify stapling succeeded
+            xcrun stapler validate "$BINARY_PATH"
+            echo "Stapling complete for $ARCH"
+
             # Repackage as tar.gz (preserving all original files including completions)
             cd $RUNNER_TEMP/sign_${ARCH}
             # Use * to get all files without ./ prefix, preserving original archive structure


### PR DESCRIPTION
## Summary
- Add `xcrun stapler staple` after notarization to embed the ticket in the binary
- Add `xcrun stapler validate` to verify stapling succeeded

## Problem
The macOS binaries were being signed and notarized, but the notarization ticket was not being **stapled** to the binary. Without stapling:

1. Gatekeeper sees the binary is signed ✓
2. Gatekeeper tries to verify notarization by contacting Apple's servers
3. If the lookup fails (caching, network issues, etc.), macOS shows:
   > "Apple could not verify 'vesctl' is free of malware"

## Solution
After notarization completes, staple the ticket to the binary using `xcrun stapler staple`. This embeds the notarization ticket directly in the binary so Gatekeeper can verify locally without contacting Apple.

## Test plan
- [ ] Merge PR and wait for new release
- [ ] Install via `brew reinstall --cask vesctl`
- [ ] Verify binary passes Gatekeeper: `spctl -a -vvv -t execute /opt/homebrew/bin/vesctl`
- [ ] Expected output: "accepted" and "source=Notarized Developer ID"

🤖 Generated with [Claude Code](https://claude.com/claude-code)