### PR TITLE
fix: add retry logic for notarization ticket stapling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,8 +233,24 @@ jobs:
 
             # Staple the notarization ticket to the binary
             # This embeds the ticket so Gatekeeper can verify locally without contacting Apple
+            # Retry up to 5 times as the ticket may take time to propagate to Apple's CDN
             echo "Stapling notarization ticket to binary..."
-            xcrun stapler staple "$BINARY_PATH"
+            staple_retries=5
+            staple_delay=30
+            for attempt in $(seq 1 $staple_retries); do
+              if xcrun stapler staple "$BINARY_PATH"; then
+                echo "Stapling succeeded on attempt $attempt"
+                break
+              fi
+              if [ $attempt -lt $staple_retries ]; then
+                echo "Stapling attempt $attempt failed, waiting ${staple_delay}s for ticket propagation..."
+                sleep $staple_delay
+                staple_delay=$((staple_delay * 2))
+              else
+                echo "ERROR: Stapling failed after $staple_retries attempts"
+                exit 1
+              fi
+            done
 
             # Verify stapling succeeded
             xcrun stapler validate "$BINARY_PATH"


### PR DESCRIPTION
## Summary
- Add retry loop with exponential backoff for `xcrun stapler staple`
- Retry up to 5 times (30s, 60s, 120s, 240s delays between attempts)

## Problem
PR #166 added stapling but the first attempt failed with error 73 (ticket not found). This happens because the notarization ticket hasn't fully propagated to Apple's CDN yet after `notarytool submit --wait` completes.

## Solution
Add a retry mechanism that:
1. Attempts to staple the binary
2. If it fails with error 73, waits and retries with exponential backoff
3. Gives up after 5 attempts with a clear error message

## Test plan
- [ ] Merge PR and wait for release
- [ ] Monitor the Sign macOS Binaries job for stapling success
- [ ] If stapling succeeds, reinstall via `brew reinstall --cask vesctl`
- [ ] Verify: `spctl -a -vvv -t execute /opt/homebrew/bin/vesctl` shows "accepted"

🤖 Generated with [Claude Code](https://claude.com/claude-code)