### PR TITLE
fix: extend stapling retry delays for Apple CDN propagation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,10 +233,14 @@ jobs:
 
             # Staple the notarization ticket to the binary
             # This embeds the ticket so Gatekeeper can verify locally without contacting Apple
-            # Retry up to 5 times as the ticket may take time to propagate to Apple's CDN
+            # Apple's CDN can take significant time to propagate tickets (observed up to 10+ minutes)
+            # Wait 60s initially, then retry up to 8 times with increasing delays
+            echo "Waiting 60s for notarization ticket to propagate to Apple CDN..."
+            sleep 60
+
             echo "Stapling notarization ticket to binary..."
-            staple_retries=5
-            staple_delay=30
+            staple_retries=8
+            staple_delay=45
             for attempt in $(seq 1 $staple_retries); do
               if xcrun stapler staple "$BINARY_PATH"; then
                 echo "Stapling succeeded on attempt $attempt"
@@ -245,7 +249,11 @@ jobs:
               if [ $attempt -lt $staple_retries ]; then
                 echo "Stapling attempt $attempt failed, waiting ${staple_delay}s for ticket propagation..."
                 sleep $staple_delay
-                staple_delay=$((staple_delay * 2))
+                # Increase delay: 45, 60, 90, 120, 150, 180, 240
+                staple_delay=$((staple_delay + 30))
+                if [ $staple_delay -gt 240 ]; then
+                  staple_delay=240
+                fi
               else
                 echo "ERROR: Stapling failed after $staple_retries attempts"
                 exit 1


### PR DESCRIPTION
## Summary
- Extends retry wait time for macOS notarization ticket stapling
- Previous 5 retries (~7.5min) failed for v4.21.2 due to Apple CDN propagation delay
- New approach: 60s initial wait + 8 retries with increasing delays (~17min total)

## Problem
Release v4.21.2 failed because Apple's CDN hadn't propagated the notarization ticket even after 7.5 minutes of retrying:
```
Stapling attempt 1 failed, waiting 30s...
Stapling attempt 2 failed, waiting 60s...
Stapling attempt 3 failed, waiting 120s...
Stapling attempt 4 failed, waiting 240s...
ERROR: Stapling failed after 5 attempts
```

## Solution
- Add 60s initial wait after notarization completes (gives CDN time to start propagation)
- Increase to 8 retry attempts
- Use linear increasing delays: 45s, 75s, 105s, 135s, 165s, 195s, 225s
- Total wait time if all attempts fail: ~17 minutes

This should accommodate the observed CDN propagation delays.

## Test plan
- [ ] Merge and trigger new release
- [ ] Verify sign-macos job succeeds with stapling
- [ ] Download and verify binary passes `spctl -a -vvv -t execute`

🤖 Generated with [Claude Code](https://claude.com/claude-code)