### PR TITLE
fix: staple ZIP archive instead of binary directly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,28 +231,28 @@ jobs:
               --team-id "$APPLE_TEAM_ID" \
               --wait
 
-            # Staple the notarization ticket to the binary
-            # This embeds the ticket so Gatekeeper can verify locally without contacting Apple
-            # Apple's CDN can take significant time to propagate tickets (observed up to 10+ minutes)
-            # Wait 60s initially, then retry up to 8 times with increasing delays
-            echo "Waiting 60s for notarization ticket to propagate to Apple CDN..."
-            sleep 60
+            # Staple the notarization ticket to the ZIP archive
+            # Apple's stapler recursively staples items inside ZIP archives (per Apple docs)
+            # We staple the ZIP, then extract to get the binary with embedded ticket
+            # Apple's CDN can take time to propagate tickets, so we retry with increasing delays
+            echo "Waiting 30s for notarization ticket to propagate to Apple CDN..."
+            sleep 30
 
-            echo "Stapling notarization ticket to binary..."
+            echo "Stapling notarization ticket to ZIP archive..."
             staple_retries=8
-            staple_delay=45
+            staple_delay=30
             for attempt in $(seq 1 $staple_retries); do
-              if xcrun stapler staple "$BINARY_PATH"; then
+              if xcrun stapler staple "$ZIP_PATH"; then
                 echo "Stapling succeeded on attempt $attempt"
                 break
               fi
               if [ $attempt -lt $staple_retries ]; then
                 echo "Stapling attempt $attempt failed, waiting ${staple_delay}s for ticket propagation..."
                 sleep $staple_delay
-                # Increase delay: 45, 60, 90, 120, 150, 180, 240
-                staple_delay=$((staple_delay + 30))
-                if [ $staple_delay -gt 240 ]; then
-                  staple_delay=240
+                # Increase delay: 30, 45, 60, 90, 120, 150, 180
+                staple_delay=$((staple_delay + 15))
+                if [ $staple_delay -gt 180 ]; then
+                  staple_delay=180
                 fi
               else
                 echo "ERROR: Stapling failed after $staple_retries attempts"
@@ -260,9 +260,31 @@ jobs:
               fi
             done
 
-            # Verify stapling succeeded
-            xcrun stapler validate "$BINARY_PATH"
-            echo "Stapling complete for $ARCH"
+            # Verify stapling succeeded on ZIP
+            xcrun stapler validate "$ZIP_PATH"
+            echo "ZIP stapling complete for $ARCH"
+
+            # Extract the stapled binary from the ZIP
+            # The binary inside the stapled ZIP has the notarization ticket embedded
+            echo "Extracting stapled binary from ZIP..."
+            EXTRACT_DIR="$RUNNER_TEMP/stapled_${ARCH}"
+            mkdir -p "$EXTRACT_DIR"
+            ditto -x -k "$ZIP_PATH" "$EXTRACT_DIR"
+
+            # Find and copy the stapled binary back to the signing directory
+            STAPLED_BINARY=$(find "$EXTRACT_DIR" -name "vesctl" -type f)
+            if [ -z "$STAPLED_BINARY" ]; then
+              echo "ERROR: Could not find vesctl binary in extracted ZIP"
+              exit 1
+            fi
+            cp "$STAPLED_BINARY" "$BINARY_PATH"
+
+            # Verify the binary passes Gatekeeper
+            echo "Verifying stapled binary with spctl..."
+            spctl -a -vvv -t execute "$BINARY_PATH" || {
+              echo "WARNING: spctl verification may fail in CI (no GUI), continuing..."
+            }
+            echo "Binary ready for $ARCH"
 
             # Repackage as tar.gz (preserving all original files including completions)
             cd $RUNNER_TEMP/sign_${ARCH}


### PR DESCRIPTION
## Summary
- Staple the ZIP archive instead of the binary directly after notarization
- Extract the stapled binary from the ZIP using ditto
- Use the extracted binary (with embedded ticket) for packaging

## Problem
Previous stapling attempts (PRs #166, #167, #168) all failed with Error 73 (ticket not found) because:
1. We were trying to staple the binary directly
2. But Apple's CDN stores the notarization ticket associated with the ZIP archive that was submitted

Even waiting 17+ minutes with 8 retry attempts didn't help because the ticket was stored for the ZIP, not the extracted binary.

## Solution
According to Apple's documentation, `xcrun stapler staple` on a ZIP archive "recursively looks inside for items it can staple." This change:
1. Staples the ZIP archive (not the binary) after notarization
2. Extracts the binary from the stapled ZIP using `ditto -x -k`
3. Uses the extracted binary (which has the ticket embedded) for packaging

## Test plan
- [ ] Release workflow should complete successfully
- [ ] Download new macOS release and verify with `spctl -a -vvv -t execute`
- [ ] Gatekeeper should not show "Apple could not verify" warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)