### PR TITLE
fix: remove table output truncation from cloudstatus commands

### DIFF
--- a/cmd/cloudstatus_components.go
+++ b/cmd/cloudstatus_components.go
@@ -214,11 +214,7 @@ func runComponentsList(cmd *cobra.Command, args []string) error {
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 		_, _ = fmt.Fprintln(w, "ID\tNAME\tSTATUS\tDESCRIPTION")
 		for _, comp := range filtered {
-			desc := comp.Description
-			if len(desc) > 40 {
-				desc = desc[:37] + "..."
-			}
-			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", comp.ID, comp.Name, comp.Status, desc)
+			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", comp.ID, comp.Name, comp.Status, comp.Description)
 		}
 		return w.Flush()
 	default:

--- a/cmd/cloudstatus_incidents.go
+++ b/cmd/cloudstatus_incidents.go
@@ -283,7 +283,7 @@ func outputIncidents(incidents []cloudstatus.Incident) error {
 		for _, inc := range incidents {
 			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
 				inc.ID,
-				truncate(inc.Name, 40),
+				inc.Name,
 				inc.Status,
 				inc.Impact,
 				inc.StartedAt.Format("2006-01-02 15:04"))
@@ -297,7 +297,7 @@ func outputIncidents(incidents []cloudstatus.Incident) error {
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 		_, _ = fmt.Fprintln(w, "NAME\tSTATUS\tIMPACT")
 		for _, inc := range incidents {
-			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\n", truncate(inc.Name, 50), inc.Status, inc.Impact)
+			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\n", inc.Name, inc.Status, inc.Impact)
 		}
 		return w.Flush()
 	}
@@ -327,13 +327,6 @@ func printIncidentDetails(inc *cloudstatus.Incident) {
 		fmt.Printf("  [%s] %s\n", update.DisplayAt.Format("2006-01-02 15:04:05 MST"), update.Status)
 		fmt.Printf("  %s\n", update.Body)
 	}
-}
-
-func truncate(s string, maxLen int) string {
-	if len(s) <= maxLen {
-		return s
-	}
-	return s[:maxLen-3] + "..."
 }
 
 func parseDuration(s string) (time.Duration, error) {

--- a/cmd/cloudstatus_maintenance.go
+++ b/cmd/cloudstatus_maintenance.go
@@ -203,7 +203,7 @@ func outputMaintenances(maintenances []cloudstatus.ScheduledMaintenance) error {
 		for _, maint := range maintenances {
 			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
 				maint.ID,
-				truncate(maint.Name, 40),
+				maint.Name,
 				maint.Status,
 				maint.ScheduledFor.Format("2006-01-02 15:04 MST"),
 				maint.ScheduledUntil.Format("2006-01-02 15:04 MST"))
@@ -220,7 +220,7 @@ func outputMaintenances(maintenances []cloudstatus.ScheduledMaintenance) error {
 			scheduled := fmt.Sprintf("%s - %s",
 				maint.ScheduledFor.Format("Jan 2 15:04"),
 				maint.ScheduledUntil.Format("Jan 2 15:04 MST"))
-			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\n", truncate(maint.Name, 40), maint.Status, scheduled)
+			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\n", maint.Name, maint.Status, scheduled)
 		}
 		return w.Flush()
 	}


### PR DESCRIPTION
## Summary
- Remove text truncation in cloudstatus table output to display full incident names, maintenance titles, and component descriptions
- The `text/tabwriter` handles column alignment automatically, so truncation is unnecessary
- Deleted the `truncate()` helper function that was limiting output to 40-50 characters

## Changes
- `cmd/cloudstatus_incidents.go`: Remove `truncate()` function and all calls
- `cmd/cloudstatus_maintenance.go`: Remove `truncate()` calls in wide/default formats  
- `cmd/cloudstatus_components.go`: Remove inline description truncation in wide format

## Before
```
NAME                                                STATUS      IMPACT
Informational : New IP ranges for Distributed C...  monitoring  major
```

## After
```
NAME                                                                     STATUS      IMPACT
Informational : New IP ranges for Distributed Cloud Regional Edge sites  monitoring  major
```

## Test plan
- [x] `vesctl cloudstatus incidents active` - verify full names shown
- [x] `vesctl cloudstatus incidents list` - verify full names shown
- [x] `vesctl cloudstatus components list --pop --output-format wide` - verify full descriptions
- [x] Build succeeds
- [x] All pkg tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)