### PR TITLE
feat: add OpenAPI spec transformer for legacy reference normalization

### DIFF
--- a/pkg/openapi/transformer.go
+++ b/pkg/openapi/transformer.go
@@ -1,0 +1,144 @@
+// Package openapi provides utilities for parsing OpenAPI 3.0 specifications
+// and generating example JSON for F5 XC resources.
+package openapi
+
+import (
+	"regexp"
+	"strings"
+)
+
+// TransformConfig holds configuration for spec transformation
+type TransformConfig struct {
+	// VesctlToBinary transforms "vesctl" references to the current binary name
+	VesctlToBinary string
+	// TransformEnvVars transforms VES_* environment variables to F5XC_*
+	TransformEnvVars bool
+}
+
+// DefaultTransformConfig returns the default transformation configuration
+func DefaultTransformConfig() *TransformConfig {
+	return &TransformConfig{
+		VesctlToBinary:   "f5xcctl",
+		TransformEnvVars: true,
+	}
+}
+
+// envVarPattern matches VES_* environment variable patterns
+var envVarPattern = regexp.MustCompile(`\bVES_([A-Z_]+)\b`)
+
+// TransformSpecReferences transforms legacy references in the spec to current branding.
+// This includes:
+// - "vesctl" → "f5xcctl" (or configured binary name)
+// - VES_* environment variables → F5XC_*
+//
+// This function modifies the spec in place.
+func TransformSpecReferences(spec *Spec, config *TransformConfig) {
+	if spec == nil {
+		return
+	}
+	if config == nil {
+		config = DefaultTransformConfig()
+	}
+
+	// Transform info section
+	spec.Info.Title = transformText(spec.Info.Title, config)
+	spec.Info.Description = transformText(spec.Info.Description, config)
+
+	// Transform all schemas
+	for name, schema := range spec.Components.Schemas {
+		transformSchema(schema, config)
+		// Update the map in case we need to track changes
+		spec.Components.Schemas[name] = schema
+	}
+}
+
+// transformSchema recursively transforms text fields in a schema
+func transformSchema(schema *Schema, config *TransformConfig) {
+	if schema == nil {
+		return
+	}
+
+	// Transform description and title
+	schema.Description = transformText(schema.Description, config)
+	schema.Title = transformText(schema.Title, config)
+
+	// Transform F5 XC specific extensions
+	schema.XVesExample = transformText(schema.XVesExample, config)
+	schema.XDisplayName = transformText(schema.XDisplayName, config)
+
+	// Transform nested properties
+	for _, propSchema := range schema.Properties {
+		transformSchema(propSchema, config)
+	}
+
+	// Transform array items
+	if schema.Items != nil {
+		transformSchema(schema.Items, config)
+	}
+}
+
+// transformText applies all text transformations
+func transformText(text string, config *TransformConfig) string {
+	if text == "" {
+		return text
+	}
+
+	// Transform vesctl references
+	if config.VesctlToBinary != "" {
+		// Case-insensitive replacement for various vesctl patterns
+		text = strings.ReplaceAll(text, "vesctl", config.VesctlToBinary)
+		text = strings.ReplaceAll(text, "Vesctl", capitalizeFirst(config.VesctlToBinary))
+		text = strings.ReplaceAll(text, "VESCTL", strings.ToUpper(config.VesctlToBinary))
+	}
+
+	// Transform environment variables
+	if config.TransformEnvVars {
+		text = transformEnvVars(text)
+	}
+
+	return text
+}
+
+// transformEnvVars transforms VES_* environment variables to F5XC_*
+func transformEnvVars(text string) string {
+	return envVarPattern.ReplaceAllStringFunc(text, func(match string) string {
+		// Extract the suffix after VES_
+		suffix := strings.TrimPrefix(match, "VES_")
+		return "F5XC_" + suffix
+	})
+}
+
+// capitalizeFirst returns the string with the first letter capitalized
+func capitalizeFirst(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+// LoadAllSpecsWithTransform loads all OpenAPI specifications from a directory
+// and applies transformations to normalize legacy references.
+func LoadAllSpecsWithTransform(dir string, config *TransformConfig) (map[string]*Spec, error) {
+	specs, err := LoadAllSpecs(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	// Apply transformations to all specs
+	for _, spec := range specs {
+		TransformSpecReferences(spec, config)
+	}
+
+	return specs, nil
+}
+
+// ParseSpecWithTransform parses an OpenAPI specification and applies transformations
+func ParseSpecWithTransform(filePath string, config *TransformConfig) (*Spec, error) {
+	spec, err := ParseSpec(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	TransformSpecReferences(spec, config)
+	return spec, nil
+}

--- a/scripts/generate-examples.go
+++ b/scripts/generate-examples.go
@@ -12,8 +12,8 @@ import (
 	"sort"
 	"text/template"
 
-	"github.com/robinmordasiewicz/vesctl/pkg/openapi"
-	"github.com/robinmordasiewicz/vesctl/pkg/types"
+	"github.com/robinmordasiewicz/f5xcctl/pkg/openapi"
+	"github.com/robinmordasiewicz/f5xcctl/pkg/types"
 )
 
 var (
@@ -49,8 +49,8 @@ func main() {
 		fmt.Println("Loading OpenAPI specifications...")
 	}
 
-	// Load all specs
-	specs, err := openapi.LoadAllSpecs(*specsDir)
+	// Load all specs with transformation to normalize legacy references
+	specs, err := openapi.LoadAllSpecsWithTransform(*specsDir, openapi.DefaultTransformConfig())
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error loading specs: %v\n", err)
 		os.Exit(1)

--- a/scripts/generate-schemas.go
+++ b/scripts/generate-schemas.go
@@ -14,8 +14,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/robinmordasiewicz/vesctl/pkg/openapi"
-	"github.com/robinmordasiewicz/vesctl/pkg/types"
+	"github.com/robinmordasiewicz/f5xcctl/pkg/openapi"
+	"github.com/robinmordasiewicz/f5xcctl/pkg/types"
 )
 
 var (
@@ -57,8 +57,8 @@ func main() {
 		fmt.Println("Loading OpenAPI specifications...")
 	}
 
-	// Load all specs
-	specs, err := openapi.LoadAllSpecs(*specsDir)
+	// Load all specs with transformation to normalize legacy references
+	specs, err := openapi.LoadAllSpecsWithTransform(*specsDir, openapi.DefaultTransformConfig())
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error loading specs: %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
## Summary
- Add pre-processing transformer to normalize legacy references in OpenAPI specs during documentation generation
- Create `pkg/openapi/transformer.go` with `TransformSpecReferences()` function
- Transform "vesctl" → "f5xcctl" in descriptions and examples
- Transform VES_* environment variables → F5XC_*
- Update generation scripts to use `LoadAllSpecsWithTransform()`

## Test plan
- [x] Build successful: `go build -o f5xcctl .`
- [x] Schema generation works: `go run scripts/generate-schemas.go -v`
- [x] Example generation works: `go run scripts/generate-examples.go -v`
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)