### PR TITLE
fix: add go mod download step to CI Verify Schemas job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,9 @@ jobs:
           go-version: "1.24"
           cache: true
 
+      - name: Download dependencies
+        run: go mod download
+
       - name: Regenerate schemas
         run: go run scripts/generate-schemas.go -v
 
@@ -145,19 +148,19 @@ jobs:
           mkdir -p dist
 
           # Linux amd64
-          GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o dist/vesctl-linux-amd64 .
+          GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o dist/f5xcctl-linux-amd64 .
 
           # Linux arm64
-          GOOS=linux GOARCH=arm64 go build -ldflags="-s -w" -o dist/vesctl-linux-arm64 .
+          GOOS=linux GOARCH=arm64 go build -ldflags="-s -w" -o dist/f5xcctl-linux-arm64 .
 
           # macOS amd64
-          GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w" -o dist/vesctl-darwin-amd64 .
+          GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w" -o dist/f5xcctl-darwin-amd64 .
 
           # macOS arm64
-          GOOS=darwin GOARCH=arm64 go build -ldflags="-s -w" -o dist/vesctl-darwin-arm64 .
+          GOOS=darwin GOARCH=arm64 go build -ldflags="-s -w" -o dist/f5xcctl-darwin-arm64 .
 
           # Windows amd64
-          GOOS=windows GOARCH=amd64 go build -ldflags="-s -w" -o dist/vesctl-windows-amd64.exe .
+          GOOS=windows GOARCH=amd64 go build -ldflags="-s -w" -o dist/f5xcctl-windows-amd64.exe .
 
       - name: List built binaries
         run: ls -la dist/


### PR DESCRIPTION
## Summary
- Adds `go mod download` step before running schema generator in CI
- Fixes module resolution error when CI tries to import local packages (pkg/openapi, pkg/types)
- Includes vesctl→f5xcctl binary name updates in Build job that were missed previously

## Test plan
- [ ] CI workflow should pass, specifically the "Verify Schemas" job

🤖 Generated with [Claude Code](https://claude.com/claude-code)