### PR TITLE
fix: build local packages before schema generation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,8 +85,10 @@ jobs:
           go-version: "1.24"
           cache: true
 
-      - name: Download dependencies
-        run: go mod download
+      - name: Build local packages
+        run: |
+          go mod tidy
+          go build ./pkg/...
 
       - name: Regenerate schemas
         run: go run scripts/generate-schemas.go -v


### PR DESCRIPTION
## Summary
- Changed CI Verify Schemas job to build local packages explicitly before running schema generator
- Previous `go mod download` wasn't sufficient for `go run` with `//go:build ignore` files
- Uses `go mod tidy && go build ./pkg/...` to ensure packages are recognized

## Test plan
- [ ] CI "Verify Schemas" job should pass

Note: The punycode deprecation warning in golangci-lint output is from the GitHub Action's Node.js runtime, not our code - requires upstream fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)