### PR TITLE
fix: use make generate-schemas in CI instead of direct go run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,13 +85,8 @@ jobs:
           go-version: "1.24"
           cache: true
 
-      - name: Build local packages
-        run: |
-          go mod tidy
-          go build ./pkg/...
-
       - name: Regenerate schemas
-        run: go run scripts/generate-schemas.go -v
+        run: make generate-schemas
 
       - name: Check for uncommitted changes
         run: |


### PR DESCRIPTION
## Summary
- Use `make generate-schemas` in CI instead of direct `go run` command
- The 'go run' with files having '//go:build ignore' and local imports doesn't work reliably with GOTOOLCHAIN=local
- The Makefile handles the build environment properly

## Test plan
- [ ] CI "Verify Schemas" job should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)