### PR TITLE
feat: integrate LLM description generation into release pipeline

### DIFF
--- a/.github/workflows/generate-descriptions.yml
+++ b/.github/workflows/generate-descriptions.yml
@@ -7,6 +7,13 @@ on:
         description: 'Ollama model to use'
         required: false
         default: 'deepseek-r1:1.5b'
+  workflow_call:
+    inputs:
+      model:
+        description: 'Ollama model to use'
+        required: false
+        type: string
+        default: 'deepseek-r1:1.5b'
 
 jobs:
   generate:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,10 +57,80 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  generate-descriptions:
+    name: Generate LLM Descriptions
+    runs-on: ubuntu-latest
+    needs: semantic-release
+    if: needs.semantic-release.outputs.version != ''
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+          cache: true
+
+      - name: Install Ollama
+        run: |
+          curl -fsSL https://ollama.com/install.sh | sh
+
+      - name: Start Ollama Server
+        run: |
+          ollama serve &
+          for i in {1..30}; do
+            if curl -s http://localhost:11434/api/tags > /dev/null 2>&1; then
+              echo "Ollama server is ready"
+              break
+            fi
+            echo "Waiting for Ollama server... ($i/30)"
+            sleep 2
+          done
+
+      - name: Pull Model
+        run: |
+          echo "Pulling model deepseek-r1:1.5b..."
+          ollama pull "deepseek-r1:1.5b"
+
+      - name: Generate LLM Descriptions
+        run: |
+          go run scripts/generate-llm-descriptions.go \
+            -specs docs/specifications/api \
+            -output pkg/types/descriptions_generated.json \
+            -model "deepseek-r1:1.5b" \
+            -ollama-url http://localhost:11434 \
+            -v
+
+      - name: Regenerate Schemas with LLM Descriptions
+        run: |
+          go run scripts/generate-schemas.go -v -update-resources -use-llm-descriptions
+
+      - name: Verify Build
+        run: |
+          make build
+          make test-unit
+
+      - name: Commit changes if any
+        run: |
+          if git diff --quiet pkg/types/; then
+            echo "No changes to descriptions"
+          else
+            echo "Committing updated descriptions..."
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add pkg/types/descriptions_generated.json pkg/types/schemas_generated.go pkg/types/resources_generated.go
+            git commit -m "chore: regenerate resource descriptions with LLM [skip ci]" || true
+            git push || true
+          fi
+
   goreleaser:
     name: GoReleaser
     runs-on: ubuntu-latest
-    needs: semantic-release
+    needs: [semantic-release, generate-descriptions]
     if: needs.semantic-release.outputs.version != ''
     outputs:
       version: ${{ needs.semantic-release.outputs.version }}
@@ -68,6 +138,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          ref: main
           fetch-depth: 0
 
       - name: Set up Go


### PR DESCRIPTION
## Summary

Integrates the LLM description generation into the automated release pipeline so descriptions are regenerated with each new release.

## Changes

### release.yml
- Add new `generate-descriptions` job that runs after `semantic-release` and before `goreleaser`
- Job only runs when a new version will be released (`if: needs.semantic-release.outputs.version != ''`)
- Installs Ollama, pulls deepseek-r1:1.5b model, generates descriptions
- Commits any changes with `[skip ci]` to avoid retriggering the release cycle
- `goreleaser` now depends on both `semantic-release` and `generate-descriptions`
- Checkout uses `ref: main` to pick up any committed description changes

### generate-descriptions.yml
- Add `workflow_call` trigger for reusability from other workflows

## Release Pipeline Flow

```
push to main
    ↓
  test
    ↓
semantic-release → determines version
    ↓
generate-descriptions → regenerates with LLM (if version != '')
    ↓
goreleaser → builds with updated descriptions
    ↓
sign-macos → signs macOS binaries
```

## Test Plan

- [x] Workflow syntax is valid
- [ ] CI checks pass
- [ ] Next release includes regenerated descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)