### PR TITLE
fix: add concurrency control to cancel in-progress release jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
 
+# Cancel in-progress runs when a new run is triggered
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
 


### PR DESCRIPTION
## Summary
Add concurrency control to the Release workflow to automatically cancel in-progress runs when a new run is triggered.

## Changes
```yaml
concurrency:
  group: release-${{ github.ref }}
  cancel-in-progress: true
```

## Why
- LLM description generation takes a long time (~5-10 minutes)
- If multiple commits are pushed quickly, multiple release jobs pile up
- This wastes CI resources and can cause race conditions

## Behavior
- When a new push to `main` triggers the Release workflow
- Any in-progress Release workflow runs are automatically cancelled
- Only the latest run continues to completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)