### PR TITLE
fix: suppress cache race condition warning in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1048,6 +1048,9 @@ jobs:
 
       - name: Cache generated docs for future builds
         if: needs.generate.result == 'success'
+        # continue-on-error: cache save can fail if another concurrent workflow already saved this key
+        # This is expected when multiple workflows complete simultaneously (race condition)
+        continue-on-error: true
         uses: actions/cache/save@v4
         with:
           path: docs/commands/


### PR DESCRIPTION
## Summary
- Fix cache save race condition warning in docs workflow

## Problem
When multiple Documentation workflows complete simultaneously (e.g., after a release followed by manual retries), they all try to save to the same cache key based on spec hash. The first one succeeds, subsequent ones get:

```
Failed to save: Unable to reserve cache with key f5xcctl-docs-..., another job may be creating this cache.
##[warning]Cache save failed.
```

## Solution
Add `continue-on-error: true` to the cache save step since this warning is harmless - the cache already exists with the correct content from the first successful save.

## Test plan
- [x] Workflow still functions correctly
- [x] Cache is saved on first concurrent run
- [x] Warning no longer fails the workflow on subsequent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)