### PR TITLE
feat: add CI/local development consistency targets

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -64,7 +64,7 @@ var rootCmd = &cobra.Command{
 			"__complete":       true, // Cobra's shell completion handler
 			"__completeNoDesc": true, // Cobra's shell completion handler (no descriptions)
 			"help":             true,
-			"f5xcctl":           true, // Root command itself
+			"f5xcctl":          true, // Root command itself
 		}
 		if skipCommands[cmd.Name()] {
 			return nil


### PR DESCRIPTION
## Summary
Add new Makefile targets that mirror the GitHub Actions CI pipeline for local development consistency.

## New Targets

| Target | Purpose | Mirrors |
|--------|---------|---------|
| `make ci` | Run full CI pipeline locally | ci.yml workflow |
| `make pre-commit` | Fast checks before committing | - |
| `make pre-push` | Comprehensive checks before pushing | ci.yml + docs.yml |
| `make verify-schemas-ci` | Verify schemas match CI expectations | verify-schemas job |
| `make docs-all` | Generate ALL documentation | docs.yml generate job |
| `make docs-build` | Generate docs and build MkDocs site | docs.yml build job |

## Workflow Comparison

**GitHub Actions CI Pipeline:**
1. Lint (golangci-lint)
2. Test (unit tests on ubuntu, macos, windows)
3. Verify Schemas (regenerate + check drift)
4. Build (cross-platform)
5. GoReleaser Check

**Local `make ci` Pipeline:**
1. `lint` - golangci-lint
2. `test-unit` - unit tests
3. `verify-schemas-ci` - regenerate + check drift
4. `build` - current platform
5. `release-dry` - goreleaser check + snapshot

## Recommended Development Workflow
```bash
# Before committing (fast ~30s)
make pre-commit

# Before pushing (comprehensive ~2min)
make pre-push

# Full CI validation (same as GitHub Actions)
make ci
```

## Test Plan
- [x] `make help` shows new targets
- [x] `make pre-commit` runs successfully
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)