### PR TITLE
fix: improve LLM description generator error handling and CI reliability

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,27 +105,63 @@ jobs:
       - name: Start Ollama Server
         if: steps.cache-descriptions.outputs.cache-hit != 'true'
         run: |
-          ollama serve &
-          for i in {1..30}; do
+          # Kill any existing Ollama processes to avoid "address already in use" error
+          pkill ollama || true
+          sleep 2
+
+          # Start Ollama server in background
+          nohup ollama serve > /tmp/ollama.log 2>&1 &
+          OLLAMA_PID=$!
+          echo "OLLAMA_PID=$OLLAMA_PID" >> $GITHUB_ENV
+
+          # Wait for Ollama to be ready with better error handling
+          echo "Waiting for Ollama server to start..."
+          for i in {1..60}; do
             if curl -s http://localhost:11434/api/tags > /dev/null 2>&1; then
-              echo "Ollama server is ready"
-              break
+              echo "✅ Ollama server is ready (attempt $i)"
+              exit 0
             fi
-            echo "Waiting for Ollama server... ($i/30)"
+            if [ $((i % 10)) -eq 0 ]; then
+              echo "Still waiting for Ollama server... ($i/60)"
+              echo "--- Ollama log tail ---"
+              tail -5 /tmp/ollama.log 2>/dev/null || true
+              echo "---"
+            fi
             sleep 2
           done
+
+          echo "::error::Ollama server failed to start within 120 seconds"
+          echo "--- Full Ollama log ---"
+          cat /tmp/ollama.log
+          exit 1
 
       - name: Pull Model
         if: steps.cache-descriptions.outputs.cache-hit != 'true'
         run: |
           echo "Pulling model deepseek-r1:1.5b..."
-          ollama pull "deepseek-r1:1.5b"
+          if ! ollama pull "deepseek-r1:1.5b"; then
+            echo "::error::Failed to pull Ollama model deepseek-r1:1.5b"
+            exit 1
+          fi
+          echo "✅ Model pulled successfully"
 
       - name: Generate LLM Descriptions
         if: steps.cache-descriptions.outputs.cache-hit != 'true'
         run: |
           echo "Cache miss - generating LLM descriptions..."
-          make generate-schemas-with-llm
+          # Run with CI mode for GitHub Actions annotations and longer timeout
+          go run scripts/generate-llm-descriptions.go \
+            -ci \
+            -v \
+            -timeout 180s \
+            -max-retries 3 \
+            -fail-threshold 0.2 \
+            -workers 4 \
+            -specs docs/specifications/api \
+            -output pkg/types/descriptions_generated.json
+
+          # Regenerate schemas with new descriptions
+          go run scripts/generate-schemas.go -v -update-resources -use-llm-descriptions
 
       - name: Use cached descriptions
         if: steps.cache-descriptions.outputs.cache-hit == 'true'
@@ -142,14 +178,40 @@ jobs:
       - name: Commit changes if any
         run: |
           if git diff --quiet pkg/types/; then
-            echo "No changes to descriptions"
+            echo "✅ No changes to descriptions - schemas are up to date"
           else
             echo "Committing updated descriptions..."
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add pkg/types/descriptions_generated.json pkg/types/schemas_generated.go pkg/types/resources_generated.go
-            git commit -m "chore: regenerate resource descriptions with LLM [skip ci]" || true
-            git push || true
+
+            # Commit the changes
+            if ! git commit -m "chore: regenerate resource descriptions with LLM [skip ci]"; then
+              echo "::warning::No changes to commit (files may be unchanged)"
+              exit 0
+            fi
+
+            # Push with retry logic for branch protection race conditions
+            MAX_RETRIES=3
+            for i in $(seq 1 $MAX_RETRIES); do
+              echo "Push attempt $i/$MAX_RETRIES..."
+              if git push; then
+                echo "✅ Changes pushed successfully"
+                exit 0
+              fi
+
+              if [ $i -lt $MAX_RETRIES ]; then
+                echo "::warning::Push failed, pulling latest and retrying..."
+                git pull --rebase
+                sleep 2
+              fi
+            done
+
+            # If all retries fail, warn but don't fail the job
+            # The descriptions are still generated and cached
+            echo "::warning::Could not push description updates after $MAX_RETRIES attempts"
+            echo "::warning::This may happen due to branch protection rules or concurrent updates"
+            echo "::warning::The descriptions are still cached and will be used in future builds"
           fi
 
   goreleaser:


### PR DESCRIPTION
## Summary
- Fixed error handling in LLM description generator to properly fail when there are issues
- Added retry logic with exponential backoff for Ollama timeout errors
- Fixed Ollama startup race condition in release.yml
- Added proper GitHub Actions annotations for errors

## Changes

### scripts/generate-llm-descriptions.go
- Add `--ci` flag for GitHub Actions annotation format (`::error::`, `::warning::`)
- Add `--fail-threshold` flag (default 0.2) to fail when error rate exceeds threshold
- Add `--max-retries` flag (default 3) for configurable retry attempts on timeouts
- Increase default timeout from 60s to 120s
- Always log errors (not just in verbose mode)
- Exit with error code 1 if no resources are processed
- Exit with error code 1 if error rate exceeds threshold
- Add `isTimeoutError()` helper for timeout detection
- Add exponential backoff retry logic (2s, 4s, 8s...)

### .github/workflows/release.yml
- Fix Ollama startup race condition by killing existing processes first
- Increase wait timeout from 60s to 120s for Ollama startup
- Add diagnostic output when Ollama fails to start
- Add `::error::` annotations for failures
- Remove silent failure (`|| true`) from commit/push step
- Add retry logic for git push with rebase
- Reduce workers from 8 to 4 for CI stability
- Use new `--ci` flag for proper error reporting

### Makefile
- Add `LLM_TIMEOUT`, `LLM_MAX_RETRIES`, `LLM_FAIL_THRESHOLD` variables
- Pass new flags to generate-llm-descriptions.go

## Test plan
- [x] Script compiles without errors
- [x] `--help` shows new flags
- [x] `--dry-run` mode works correctly
- [x] CI mode (`--ci`) produces `::error::` annotations
- [x] Script fails with exit code 1 when Ollama unavailable
- [x] Unit tests pass
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)