### PR TITLE
fix: validate warmup response content and reduce workers for diagnosis

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,14 +149,15 @@ jobs:
         if: steps.cache-descriptions.outputs.cache-hit != 'true'
         run: |
           echo "Cache miss - generating LLM descriptions..."
-          # Run with CI mode for GitHub Actions annotations and longer timeout
+          # Run with CI mode for GitHub Actions annotations
+          # Using 1 worker to diagnose concurrency issues with Ollama
           go run scripts/generate-llm-descriptions.go \
             -ci \
             -v \
-            -timeout 180s \
-            -max-retries 3 \
+            -timeout 300s \
+            -max-retries 5 \
             -fail-threshold 0.2 \
-            -workers 4 \
+            -workers 1 \
             -specs docs/specifications/api \
             -output pkg/types/descriptions_generated.json
 


### PR DESCRIPTION
## Summary
- Fixes Ollama empty response issue in LLM description generator
- Adds warmup response validation to fail early if model isn't working correctly
- Reduces workers to 1 temporarily to diagnose concurrency issues

## Problem
The model warmup was completing in ~2s without validating response content, then all subsequent requests returned empty responses (raw length: 0). The warmup appeared successful but the model wasn't actually generating output.

## Changes
- `warmupModel()` now parses and validates that the response is non-empty
- If warmup returns empty response, fails early with descriptive error
- Added response length and preview logging in verbose mode
- Increased `num_predict` from 10 to 50 for thinking models (deepseek-r1 uses `<think>` tags)
- Reduced workers from 4 to 1 to rule out concurrency issues
- Increased timeout to 300s and max-retries to 5 for single worker

## Test plan
- [ ] Verify warmup validation catches empty responses
- [ ] Monitor release workflow for successful LLM description generation
- [ ] If successful with 1 worker, gradually increase workers to find optimal setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)