### PR TITLE
fix: reduce Ollama workers to 2 and increase timeout to 180s

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,13 +150,14 @@ jobs:
         run: |
           echo "Cache miss - generating LLM descriptions..."
           # Run with CI mode for GitHub Actions annotations
+          # Use 2 workers to avoid overwhelming Ollama on CI runners
           go run scripts/generate-llm-descriptions.go \
             -ci \
             -v \
-            -timeout 120s \
+            -timeout 180s \
             -max-retries 3 \
             -fail-threshold 0.2 \
-            -workers 4 \
+            -workers 2 \
             -model "mistral:7b-instruct" \
             -specs docs/specifications/api \
             -output pkg/types/descriptions_generated.json


### PR DESCRIPTION
## Summary
- Reduces concurrent Ollama workers from 4 to 2
- Increases per-request timeout from 120s to 180s

## Problem
The previous workflow run (20219821585) failed because 4 concurrent Ollama requests overwhelmed the CI runner. The model warmup and first few resources succeeded, but then requests started timing out repeatedly.

## Solution
Reduce concurrency to 2 workers and increase timeout to 3 minutes. This should provide stable operation on CI runners with limited resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)