### PR TITLE
fix: increase num_predict from 150 to 300 to prevent truncated descriptions

### DIFF
--- a/scripts/generate-llm-descriptions.go
+++ b/scripts/generate-llm-descriptions.go
@@ -457,7 +457,7 @@ func callOllama(prompt string) (string, error) {
 		Stream: false,
 		Options: map[string]interface{}{
 			"temperature": 0.1, // Low for consistency
-			"num_predict": 150, // Limit output length
+			"num_predict": 300, // Allow sufficient length for complete descriptions
 		},
 	}
 


### PR DESCRIPTION
## Summary
Increases the `num_predict` parameter from 150 to 300 tokens to prevent LLM-generated descriptions from being truncated.

## Problem
With 150 tokens, the mistral:7b-instruct model was truncating descriptions mid-sentence, resulting in incomplete output.

## Solution
Double the token limit to 300, allowing complete, well-formed descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)