### PR TITLE
fix: increase num_predict from 300 to 500 tokens

### DIFF
--- a/scripts/generate-llm-descriptions.go
+++ b/scripts/generate-llm-descriptions.go
@@ -457,7 +457,7 @@ func callOllama(prompt string) (string, error) {
 		Stream: false,
 		Options: map[string]interface{}{
 			"temperature": 0.1, // Low for consistency
-			"num_predict": 300, // Allow sufficient length for complete descriptions
+			"num_predict": 500, // Allow sufficient length for complete descriptions
 		},
 	}
 


### PR DESCRIPTION
## Summary
Further increases the `num_predict` parameter from 300 to 500 tokens to ensure LLM-generated descriptions are not truncated.

## Problem
User reported that descriptions still appear truncated in the GitHub Action output.

## Solution
Increase token limit to 500 to provide ample room for complete descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)