### PR TITLE
fix: remove conventional commits requirement from semantic-release

### DIFF
--- a/.semrelrc
+++ b/.semrelrc
@@ -1,8 +1,5 @@
 {
   "branches": ["main"],
   "ci": true,
-  "provider": "github",
-  "changelog": {
-    "generator": "conventionalcommits"
-  }
+  "provider": "github"
 }


### PR DESCRIPTION
## Summary
Remove the conventionalcommits changelog generator requirement from `.semrelrc` to allow any commit to trigger a release.

## Changes
- Modified `.semrelrc` to remove the `changelog.generator` configuration
- This allows semantic-release to work with any commit message format
- Provides more flexibility while maintaining automated release generation

## Testing
This PR itself will test the change by going through the full CI/CD pipeline:
1. Tests will run
2. Semantic-release will attempt to create a new release
3. If successful, GoReleaser will build and publish artifacts
4. Documentation workflow will be triggered
5. All workflows should complete successfully

## Related Issues
- Fixes docs.yml workflow failures due to missing releases
- Addresses requirement that all commits follow conventional format

🤖 Generated with [Claude Code](https://claude.com/claude-code)