### PR TITLE
chore: add .claude/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ completions/
 
 # MCP tool state directories
 .playwright-mcp/
+
+# Claude Code local configuration
+.claude/


### PR DESCRIPTION
## Summary
Add .claude/ directory to .gitignore to prevent committing local Claude Code configuration and custom commands.

## Changes
- Modified `.gitignore` to exclude `.claude/` directory

## Purpose
The .claude/ directory contains user-specific local configuration that should not be tracked in version control.

Closes #207