### PR TITLE
feat: add addon activation commands for subscription management

### DIFF
--- a/cmd/subscription_activate.go
+++ b/cmd/subscription_activate.go
@@ -1,0 +1,201 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	xerrors "github.com/robinmordasiewicz/f5xcctl/pkg/errors"
+	"github.com/robinmordasiewicz/f5xcctl/pkg/subscription"
+)
+
+var (
+	activateAddonName string
+)
+
+var subscriptionActivateCmd = &cobra.Command{
+	Use:   "activate",
+	Short: "Activate an addon service subscription.",
+	Long: `Activate an addon service for the current tenant.
+
+Activation behavior depends on the addon's activation type:
+  - Self-Activation: Activates immediately and the addon becomes available
+  - Partially Managed: Creates a pending request with partial backend processing
+  - Fully Managed: Creates a pending request requiring SRE approval
+
+Use 'f5xcctl subscription addons --filter available' to see which addons can be activated.
+Use 'f5xcctl subscription activation-status' to check pending activation requests.
+
+EXIT CODES:
+  0 - Activation successful or pending request created
+  1 - Generic error (API failure, invalid arguments)
+  9 - Feature not available (access denied, requires upgrade, contact sales)`,
+	Example: `  # Activate bot-defense addon
+  f5xcctl subscription activate --addon bot-defense
+
+  # Activate addon in specific namespace
+  f5xcctl subscription activate --addon api-security -n production
+
+  # Get activation result as JSON
+  f5xcctl subscription activate --addon client-side-defense --output-format json`,
+	RunE: runSubscriptionActivate,
+}
+
+func init() {
+	subscriptionCmd.AddCommand(subscriptionActivateCmd)
+
+	subscriptionActivateCmd.Flags().StringVar(&activateAddonName, "addon", "",
+		"Name of the addon service to activate (required).")
+
+	_ = subscriptionActivateCmd.MarkFlagRequired("addon")
+}
+
+func runSubscriptionActivate(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+	client := GetSubscriptionClient()
+
+	if client == nil {
+		return fmt.Errorf("subscription client not initialized")
+	}
+
+	namespace := GetSubscriptionNamespace()
+
+	// Attempt activation
+	result, err := client.ActivateAddon(ctx, namespace, activateAddonName)
+
+	// Handle activation denied errors with appropriate exit code
+	var deniedErr *subscription.ActivationDeniedError
+	if errors.As(err, &deniedErr) {
+		if outputErr := outputActivationResult(result, GetOutputFormatWithDefault("table")); outputErr != nil {
+			return outputErr
+		}
+		os.Exit(xerrors.ExitFeatureNotAvail) // Exit code 9
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("failed to activate addon: %w", err)
+	}
+
+	// Output result
+	format := GetOutputFormatWithDefault("table")
+	if err := outputActivationResult(result, format); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func outputActivationResult(result *subscription.ActivationResponse, format string) error {
+	if result == nil {
+		return fmt.Errorf("no activation result")
+	}
+
+	switch format {
+	case "json":
+		encoder := json.NewEncoder(os.Stdout)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(result)
+	case "yaml":
+		encoder := yaml.NewEncoder(os.Stdout)
+		encoder.SetIndent(2)
+		return encoder.Encode(result)
+	default:
+		return outputActivationTable(result)
+	}
+}
+
+func outputActivationTable(result *subscription.ActivationResponse) error {
+	// Determine status indicator
+	var statusLabel string
+	if result.IsImmediate {
+		statusLabel = "SUCCESS"
+	} else if result.IsPending {
+		statusLabel = "PENDING"
+	} else if result.AccessStatus != subscription.AccessAllowed && result.AccessStatus != "" {
+		statusLabel = "DENIED"
+	} else {
+		statusLabel = "INFO"
+	}
+
+	fmt.Printf("ACTIVATION RESULT: %s\n", statusLabel)
+	fmt.Println(strings.Repeat("=", 75))
+	fmt.Println()
+
+	// Details
+	fmt.Printf("  %-20s %s\n", "Addon Service:", result.AddonService)
+	if result.Namespace != "" {
+		fmt.Printf("  %-20s %s\n", "Namespace:", result.Namespace)
+	}
+	if result.ActivationType != "" {
+		fmt.Printf("  %-20s %s\n", "Activation Type:",
+			subscription.ActivationTypeDescription(result.ActivationType))
+	}
+	if result.SubscriptionState != "" {
+		fmt.Printf("  %-20s %s\n", "State:",
+			subscription.SubscriptionStateDescription(result.SubscriptionState))
+	}
+	if result.RequestID != "" {
+		fmt.Printf("  %-20s %s\n", "Request ID:", result.RequestID)
+	}
+	fmt.Println()
+
+	// Message with status icon
+	var statusIcon string
+	switch statusLabel {
+	case "SUCCESS":
+		statusIcon = "[OK]"
+	case "PENDING":
+		statusIcon = "[PENDING]"
+	case "DENIED":
+		statusIcon = "[DENIED]"
+	default:
+		statusIcon = "[INFO]"
+	}
+	fmt.Printf("  %s %s\n", statusIcon, result.Message)
+	fmt.Println()
+
+	// Next steps if applicable
+	if result.NextSteps != "" {
+		fmt.Println("NEXT STEPS")
+		fmt.Println(strings.Repeat("-", 75))
+		fmt.Printf("  %s\n", result.NextSteps)
+		fmt.Println()
+	}
+
+	// Guidance for denied access
+	if result.AccessStatus != subscription.AccessAllowed && result.AccessStatus != "" {
+		fmt.Println("GUIDANCE")
+		fmt.Println(strings.Repeat("-", 75))
+		switch result.AccessStatus {
+		case subscription.AccessUpgradeRequired:
+			fmt.Println("  This addon requires a subscription plan upgrade.")
+			fmt.Println("  Options:")
+			fmt.Println("    1. Upgrade via F5 XC Console: Settings > Subscription > Upgrade Plan")
+			fmt.Println("    2. Contact your F5 account manager for plan options")
+		case subscription.AccessContactSales:
+			fmt.Println("  This addon requires contacting F5 sales for enablement.")
+			fmt.Println("  Options:")
+			fmt.Println("    1. Contact F5 sales: https://www.f5.com/company/contact/sales")
+			fmt.Println("    2. Reach out to your F5 account manager")
+		case subscription.AccessDenied:
+			fmt.Println("  Access to this addon is denied by policy.")
+			fmt.Println("  Check your tenant policies or contact your administrator.")
+		case subscription.AccessEOL:
+			fmt.Println("  This addon is end-of-life and cannot be activated.")
+			fmt.Println("  Consider alternative addons or contact F5 support for migration guidance.")
+		case subscription.AccessInternalService:
+			fmt.Println("  This addon is an internal service managed by F5.")
+			fmt.Println("  It cannot be activated through the API.")
+		}
+		fmt.Println()
+	}
+
+	return nil
+}

--- a/cmd/subscription_activation_status.go
+++ b/cmd/subscription_activation_status.go
@@ -1,0 +1,177 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/robinmordasiewicz/f5xcctl/pkg/subscription"
+)
+
+var (
+	activationStatusAddon string // Optional: filter to specific addon
+)
+
+var subscriptionActivationStatusCmd = &cobra.Command{
+	Use:     "activation-status",
+	Aliases: []string{"status", "pending"},
+	Short:   "Check pending addon activation requests.",
+	Long: `Display the status of pending addon activation requests.
+
+Shows all addon services with pending activation requests, including:
+  - Addon service name
+  - Activation type (self, partially managed, fully managed)
+  - Current subscription state
+  - Expected processing time based on activation type
+
+Use this command after 'f5xcctl subscription activate' to monitor
+the progress of managed activation requests.`,
+	Example: `  # Show all pending activation requests
+  f5xcctl subscription activation-status
+
+  # Check status for a specific addon
+  f5xcctl subscription activation-status --addon bot-defense
+
+  # Get status as JSON for automation
+  f5xcctl subscription activation-status --output-format json
+
+  # Check status in a specific namespace
+  f5xcctl subscription activation-status -n production`,
+	RunE: runSubscriptionActivationStatus,
+}
+
+func init() {
+	subscriptionCmd.AddCommand(subscriptionActivationStatusCmd)
+
+	subscriptionActivationStatusCmd.Flags().StringVar(&activationStatusAddon, "addon", "",
+		"Filter to a specific addon service.")
+}
+
+func runSubscriptionActivationStatus(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+	client := GetSubscriptionClient()
+
+	if client == nil {
+		return fmt.Errorf("subscription client not initialized")
+	}
+
+	namespace := GetSubscriptionNamespace()
+	result, err := client.GetPendingActivations(ctx, namespace)
+	if err != nil {
+		return fmt.Errorf("failed to get activation status: %w", err)
+	}
+
+	// Filter to specific addon if requested
+	if activationStatusAddon != "" {
+		var filtered []subscription.PendingActivation
+		for _, p := range result.PendingActivations {
+			if strings.EqualFold(p.AddonService, activationStatusAddon) {
+				filtered = append(filtered, p)
+			}
+		}
+		result.PendingActivations = filtered
+		result.TotalPending = len(filtered)
+	}
+
+	format := GetOutputFormatWithDefault("table")
+	return outputActivationStatus(result, format)
+}
+
+func outputActivationStatus(result *subscription.ActivationStatusResult, format string) error {
+	switch format {
+	case "json":
+		encoder := json.NewEncoder(os.Stdout)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(result)
+	case "yaml":
+		encoder := yaml.NewEncoder(os.Stdout)
+		encoder.SetIndent(2)
+		return encoder.Encode(result)
+	default:
+		return outputActivationStatusTable(result)
+	}
+}
+
+func outputActivationStatusTable(result *subscription.ActivationStatusResult) error {
+	fmt.Println("ADDON ACTIVATION STATUS")
+	fmt.Println(strings.Repeat("=", 85))
+	fmt.Println()
+
+	// Summary
+	fmt.Printf("  Pending Activations: %d\n", result.TotalPending)
+	fmt.Printf("  Active Addons: %d\n", len(result.ActiveAddons))
+	fmt.Println()
+
+	if result.TotalPending == 0 {
+		fmt.Println("  No pending activation requests.")
+		fmt.Println()
+
+		if len(result.ActiveAddons) > 0 {
+			fmt.Println("ACTIVE ADDONS")
+			fmt.Println(strings.Repeat("-", 85))
+			for _, addon := range result.ActiveAddons {
+				fmt.Printf("  [ACTIVE] %s\n", addon)
+			}
+			fmt.Println()
+		}
+
+		fmt.Println("HINTS")
+		fmt.Println(strings.Repeat("-", 85))
+		fmt.Println("  Use 'f5xcctl subscription addons --filter available' to see activatable addons")
+		fmt.Println("  Use 'f5xcctl subscription activate --addon <name>' to activate an addon")
+		fmt.Println()
+		return nil
+	}
+
+	// Pending activations table
+	fmt.Println("PENDING ACTIVATIONS")
+	fmt.Println(strings.Repeat("-", 85))
+	fmt.Printf("  %-25s %-25s %-18s %-15s\n", "ADDON", "TYPE", "STATE", "MESSAGE")
+	fmt.Println("  " + strings.Repeat("-", 83))
+
+	for _, p := range result.PendingActivations {
+		name := p.AddonService
+		if len(name) > 24 {
+			name = name[:21] + "..."
+		}
+
+		typeDesc := subscription.ActivationTypeDescription(p.ActivationType)
+		if len(typeDesc) > 24 {
+			typeDesc = typeDesc[:21] + "..."
+		}
+
+		stateDesc := subscription.SubscriptionStateDescription(p.SubscriptionState)
+		if len(stateDesc) > 17 {
+			stateDesc = stateDesc[:14] + "..."
+		}
+
+		message := p.Message
+		if len(message) > 14 {
+			message = message[:11] + "..."
+		}
+
+		fmt.Printf("  %-25s %-25s %-18s %-15s\n", name, typeDesc, stateDesc, message)
+	}
+	fmt.Println()
+
+	// Expectations based on activation type
+	fmt.Println("EXPECTED PROCESSING TIMES")
+	fmt.Println(strings.Repeat("-", 85))
+	fmt.Println("  Self-Activation:           Usually immediate, up to a few minutes")
+	fmt.Println("  Partially Managed:         Minutes to hours, depends on backend processing")
+	fmt.Println("  Fully Managed:             Up to 24 hours, requires SRE approval")
+	fmt.Println()
+
+	fmt.Println("HINTS")
+	fmt.Println(strings.Repeat("-", 85))
+	fmt.Println("  Run this command again to check for status updates")
+	fmt.Println("  Use --output-format json for automation scripts")
+	fmt.Println()
+
+	return nil
+}


### PR DESCRIPTION
## Summary

Add commands to activate addon services and monitor pending activation requests.

### New Commands
- `subscription activate --addon <name>` - Activate addon services for the tenant
- `subscription activation-status` - Check pending activation requests (aliases: `status`, `pending`)

### Key Features
- **All activation types supported**: Self-activation (immediate), partially managed, and fully managed
- **Pre-flight validation**: Check addon availability before attempting activation
- **Clear error guidance**: Exit code 9 with actionable messages for denied access scenarios
- **Comprehensive help**: Human-readable help and AI-consumable `--spec` output
- **Multiple output formats**: Table, JSON, YAML support

### Activation Types
| Type | Behavior | Processing Time |
|------|----------|-----------------|
| Self-Activation | Immediate activation | Seconds to minutes |
| Partially Managed | Backend processing | Minutes to hours |
| Fully Managed | SRE approval required | Up to 24 hours |

### Exit Codes
- `0` - Activation successful or pending request created
- `1` - Generic error (API failure, invalid arguments)
- `9` - Feature not available (access denied, requires upgrade, contact sales)

### Files Changed
- New: `cmd/subscription_activate.go` (201 lines)
- New: `cmd/subscription_activation_status.go` (177 lines)
- Modified: `pkg/subscription/client.go` (added ActivateAddon, GetPendingActivations)
- Modified: `pkg/subscription/types.go` (added activation response types, helper methods)

## Test Plan
- [x] `go build` succeeds
- [x] `go vet ./...` passes
- [x] Pre-commit hooks pass
- [x] `f5xcctl subscription activate --help` shows comprehensive help
- [x] `f5xcctl subscription activation-status --help` shows comprehensive help
- [x] `f5xcctl subscription --spec --output-format json` includes new commands and workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)