### PR TITLE
feat: add shell completion for subscription commands

### DIFF
--- a/cmd/subscription_activate.go
+++ b/cmd/subscription_activate.go
@@ -54,6 +54,9 @@ func init() {
 		"Name of the addon service to activate (required).")
 
 	_ = subscriptionActivateCmd.MarkFlagRequired("addon")
+
+	// Register completion for --addon flag (shows available addons)
+	_ = subscriptionActivateCmd.RegisterFlagCompletionFunc("addon", completeAddonName)
 }
 
 func runSubscriptionActivate(cmd *cobra.Command, args []string) error {

--- a/cmd/subscription_activation_status.go
+++ b/cmd/subscription_activation_status.go
@@ -50,6 +50,9 @@ func init() {
 
 	subscriptionActivationStatusCmd.Flags().StringVar(&activationStatusAddon, "addon", "",
 		"Filter to a specific addon service.")
+
+	// Register completion for --addon flag (shows pending and active addons)
+	_ = subscriptionActivationStatusCmd.RegisterFlagCompletionFunc("addon", completePendingAddonName)
 }
 
 func runSubscriptionActivationStatus(cmd *cobra.Command, args []string) error {

--- a/cmd/subscription_addons.go
+++ b/cmd/subscription_addons.go
@@ -59,6 +59,9 @@ func init() {
 
 	subscriptionAddonsCmd.Flags().BoolVar(&addonsShowAll, "all", false, "Show all addon services including denied ones.")
 	subscriptionAddonsCmd.Flags().StringVar(&addonsFilter, "filter", "", "Filter by status: active, available, denied.")
+
+	// Register completion for --filter flag
+	_ = subscriptionAddonsCmd.RegisterFlagCompletionFunc("filter", completeAddonFilter)
 }
 
 func runSubscriptionAddons(cmd *cobra.Command, args []string) error {

--- a/cmd/subscription_completion.go
+++ b/cmd/subscription_completion.go
@@ -1,0 +1,180 @@
+package cmd
+
+import (
+	"context"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/robinmordasiewicz/f5xcctl/pkg/subscription"
+)
+
+// Completion client with caching for subscription completions
+var subscriptionCompletionClient *subscription.Client
+
+// getSubscriptionCompletionClient returns a subscription client optimized for tab completion.
+// Uses a short timeout to avoid blocking the shell.
+func getSubscriptionCompletionClient() *subscription.Client {
+	if subscriptionCompletionClient == nil {
+		subscriptionCompletionClient = GetSubscriptionClient()
+	}
+	return subscriptionCompletionClient
+}
+
+// Static completion functions
+
+// completeAddonFilter provides completion for the --filter flag in subscription addons.
+func completeAddonFilter(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return []string{
+		"active\tShow only active/subscribed addons",
+		"available\tShow addons available for activation",
+		"all\tShow all addon services including denied",
+	}, cobra.ShellCompDirectiveNoFileComp
+}
+
+// Dynamic completion functions
+
+// completeAddonName provides completion for the --addon flag in subscription activate.
+// Fetches available addons from the API with caching.
+func completeAddonName(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	client := getSubscriptionCompletionClient()
+	if client == nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	// Use a short timeout context for completion
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	namespace := GetSubscriptionNamespace()
+	addons, err := client.GetAddonServices(ctx, namespace)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	completions := []string{}
+	for _, addon := range addons {
+		// Only suggest addons that can be activated
+		if addon.CanActivate() {
+			description := addon.DisplayName
+			if description == "" {
+				description = addon.Name
+			}
+			// Add activation type hint
+			if addon.IsSelfActivation() {
+				description += " (instant)"
+			} else if addon.IsManagedActivation() {
+				description += " (managed)"
+			}
+			completions = append(completions, addon.Name+"\t"+description)
+		}
+	}
+
+	return completions, cobra.ShellCompDirectiveNoFileComp
+}
+
+// completePendingAddonName provides completion for addons with pending activation.
+// Used for activation-status --addon flag.
+func completePendingAddonName(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	client := getSubscriptionCompletionClient()
+	if client == nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	// Use a short timeout context for completion
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	namespace := GetSubscriptionNamespace()
+	addons, err := client.GetAddonServices(ctx, namespace)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	completions := []string{}
+	for _, addon := range addons {
+		// Suggest both pending and active addons for status check
+		if addon.IsPending() || addon.State == subscription.StateSubscribed {
+			description := addon.DisplayName
+			if description == "" {
+				description = addon.Name
+			}
+			if addon.IsPending() {
+				description += " (pending)"
+			} else {
+				description += " (active)"
+			}
+			completions = append(completions, addon.Name+"\t"+description)
+		}
+	}
+
+	return completions, cobra.ShellCompDirectiveNoFileComp
+}
+
+// completeResourceType provides completion for --resource-type in subscription validate.
+func completeResourceType(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return []string{
+		"http_loadbalancer\tHTTP Load Balancer",
+		"tcp_loadbalancer\tTCP Load Balancer",
+		"origin_pool\tOrigin Pool",
+		"healthcheck\tHealth Check",
+		"app_firewall\tApplication Firewall (WAF)",
+		"service_policy\tService Policy",
+		"rate_limiter\tRate Limiter",
+		"api_definition\tAPI Definition",
+		"api_group\tAPI Group",
+		"forward_proxy_policy\tForward Proxy Policy",
+		"network_policy\tNetwork Policy",
+		"network_firewall\tNetwork Firewall",
+		"dns_zone\tDNS Zone",
+		"dns_lb_pool\tDNS Load Balancer Pool",
+	}, cobra.ShellCompDirectiveNoFileComp
+}
+
+// completeFeatureName provides completion for --feature in subscription validate.
+func completeFeatureName(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	client := getSubscriptionCompletionClient()
+	if client == nil {
+		// Fall back to common features if no client
+		return []string{
+			"bot-defense\tBot Defense",
+			"api-security\tAPI Security",
+			"client-side-defense\tClient-Side Defense",
+			"malicious-user-detection\tMalicious User Detection",
+			"synthetic-monitoring\tSynthetic Monitoring",
+			"web-app-scanning\tWeb Application Scanning",
+		}, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	// Use a short timeout context for completion
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	namespace := GetSubscriptionNamespace()
+	addons, err := client.GetAddonServices(ctx, namespace)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	completions := []string{}
+	for _, addon := range addons {
+		description := addon.DisplayName
+		if description == "" {
+			description = addon.Name
+		}
+		// Add status hint
+		switch addon.State {
+		case subscription.StateSubscribed:
+			description += " [active]"
+		case subscription.StatePending:
+			description += " [pending]"
+		default:
+			if addon.CanActivate() {
+				description += " [available]"
+			}
+		}
+		completions = append(completions, addon.Name+"\t"+description)
+	}
+
+	return completions, cobra.ShellCompDirectiveNoFileComp
+}

--- a/cmd/subscription_validate.go
+++ b/cmd/subscription_validate.go
@@ -58,6 +58,10 @@ func init() {
 	subscriptionValidateCmd.Flags().StringVar(&validateResourceType, "resource-type", "", "Resource type to validate quota for (e.g., http_loadbalancer, origin_pool).")
 	subscriptionValidateCmd.Flags().IntVar(&validateCount, "count", 1, "Number of resources to create (default: 1).")
 	subscriptionValidateCmd.Flags().StringVar(&validateFeature, "feature", "", "Feature/addon to validate availability (e.g., bot-defense, api-security).")
+
+	// Register completions for validate flags
+	_ = subscriptionValidateCmd.RegisterFlagCompletionFunc("resource-type", completeResourceType)
+	_ = subscriptionValidateCmd.RegisterFlagCompletionFunc("feature", completeFeatureName)
 }
 
 func runSubscriptionValidate(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Summary

Add comprehensive shell tab-completion for subscription command flags, enabling faster command entry and discoverability.

### Completions Added
| Command | Flag | Completion Type |
|---------|------|-----------------|
| `subscription activate` | `--addon` | Dynamic - available addons from API |
| `subscription activation-status` | `--addon` | Dynamic - pending/active addons |
| `subscription addons` | `--filter` | Static - active, available, all |
| `subscription validate` | `--resource-type` | Static - F5 XC resource types |
| `subscription validate` | `--feature` | Dynamic - addon features with status |

### Shell Support
Completions work with all shells via Cobra's built-in completion:
- Bash: `source <(f5xcctl completion bash)`
- Zsh: `source <(f5xcctl completion zsh)`
- Fish: `f5xcctl completion fish | source`

### Implementation Details
- Dynamic completions fetch from API with 3-second timeout
- Completions include descriptions for better discoverability
- Status hints show addon state (active, pending, available)

### Files Changed
- New: `cmd/subscription_completion.go` (completion functions)
- Modified: `cmd/subscription_activate.go` (register --addon completion)
- Modified: `cmd/subscription_activation_status.go` (register --addon completion)
- Modified: `cmd/subscription_addons.go` (register --filter completion)
- Modified: `cmd/subscription_validate.go` (register --resource-type, --feature completions)

## Test Plan
- [x] `go build` succeeds
- [x] `go vet ./...` passes
- [x] Pre-commit hooks pass
- [x] golangci-lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)