### PR TITLE
docs: add subscription commands to navigation menu

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -587,6 +587,14 @@ nav:
         - Delete: commands/site/azure_vnet/delete.md
         - Replace: commands/site/azure_vnet/replace.md
         - Run: commands/site/azure_vnet/run.md
+    - Subscription:
+      - Overview: commands/subscription/index.md
+      - Activate: commands/subscription/activate.md
+      - Activation Status: commands/subscription/activation-status.md
+      - Addons: commands/subscription/addons.md
+      - Quota: commands/subscription/quota.md
+      - Show: commands/subscription/show.md
+      - Validate: commands/subscription/validate.md
     - Version: commands/version/index.md
   - Guides:
     - guides/index.md


### PR DESCRIPTION
## Summary

Add the Subscription command section to the left navigation menu in mkdocs.yml so that subscription subcommands appear as navigable subpages.

### Changes
- Add Subscription nav section to mkdocs.yml with entries for all 6 subcommands:
  - activate
  - activation-status
  - addons
  - quota
  - show
  - validate

## Test Plan
- [ ] Documentation builds successfully
- [ ] Subscription section appears in left navigation menu
- [ ] All 6 subcommands are navigable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #217