### PR TITLE
fix: correct subscription nav paths to use index.md subdirectories

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -589,12 +589,12 @@ nav:
         - Run: commands/site/azure_vnet/run.md
     - Subscription:
       - Overview: commands/subscription/index.md
-      - Activate: commands/subscription/activate.md
-      - Activation Status: commands/subscription/activation-status.md
-      - Addons: commands/subscription/addons.md
-      - Quota: commands/subscription/quota.md
-      - Show: commands/subscription/show.md
-      - Validate: commands/subscription/validate.md
+      - Activate: commands/subscription/activate/index.md
+      - Activation Status: commands/subscription/activation-status/index.md
+      - Addons: commands/subscription/addons/index.md
+      - Quota: commands/subscription/quota/index.md
+      - Show: commands/subscription/show/index.md
+      - Validate: commands/subscription/validate/index.md
     - Version: commands/version/index.md
   - Guides:
     - guides/index.md


### PR DESCRIPTION
## Summary

Fix the subscription navigation paths in mkdocs.yml to use the correct directory structure.

### Problem
The documentation generator creates files in subdirectory format:
- `commands/subscription/activate/index.md`

But the nav referenced flat format:
- `commands/subscription/activate.md`

This caused the documentation build to fail with 6 warnings in strict mode.

### Fix
Updated all subscription nav entries to use the correct `/index.md` subdirectory pattern.

## Test Plan
- [ ] Documentation builds successfully
- [ ] Subscription navigation renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)