### PR TITLE
fix: shell completion cache not refreshed after upgrade

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -356,6 +356,11 @@ jobs:
               end
             end
 
+            # Clear zsh completion cache after install/upgrade
+            postflight do
+              system_command "/bin/rm", args: ["-f", "#{Dir.home}/.zcompdump", "#{Dir.home}/.zcompdump-#{Socket.gethostname}-*"]
+            end
+
             caveats <<~EOS
               Shell completions have been installed for bash, zsh, and fish.
 

--- a/docs/install/completions.md
+++ b/docs/install/completions.md
@@ -1,6 +1,6 @@
 # Shell Completion
 
-Enable tab completion for your shell:
+Enable tab completion for your shell.
 
 ## Bash
 
@@ -18,11 +18,11 @@ f5xcctl completion bash > $(brew --prefix)/etc/bash_completion.d/f5xcctl
 ## Zsh
 
 ```bash
-# Enable completion system
+# Enable completion system (if not already enabled)
 echo "autoload -U compinit; compinit" >> ~/.zshrc
 
 # Install completion
-f5xcctl completion zsh > "${fpath[1]}/_vesctl"
+f5xcctl completion zsh > "${fpath[1]}/_f5xcctl"
 ```
 
 ## Fish
@@ -35,4 +35,30 @@ f5xcctl completion fish > ~/.config/fish/completions/f5xcctl.fish
 
 ```powershell
 f5xcctl completion powershell | Out-String | Invoke-Expression
+```
+
+## Troubleshooting
+
+### Completions not working after upgrade
+
+Zsh caches completion functions in `~/.zcompdump*` files. After upgrading f5xcctl, the stale cache may prevent new completions from loading.
+
+**Fix:** Clear the cache and restart your shell:
+
+```bash
+rm -f ~/.zcompdump* && exec zsh
+```
+
+### Completions not loading at all
+
+Ensure the completion system is enabled in your `~/.zshrc`:
+
+```bash
+autoload -Uz compinit && compinit
+```
+
+Then restart your shell or run:
+
+```bash
+source ~/.zshrc
 ```

--- a/install.sh
+++ b/install.sh
@@ -747,6 +747,8 @@ setup_zsh_completion() {
             success "Zsh completion installed to ${ZSH_COMPLETION_DIR}/_f5xcctl"
             # Automatically configure RC file
             add_zsh_completion_config "$ZSH_COMPLETION_DIR" || true
+            # Clear zsh completion cache to ensure new completions are loaded
+            rm -f "${ZDOTDIR:-$HOME}"/.zcompdump* 2>/dev/null
             return 0
         fi
     fi


### PR DESCRIPTION
## Summary

Fix shell completion cache issues that prevent tab completion from working after upgrading f5xcctl.

## Changes
- Fix docs typo: `_vesctl` → `_f5xcctl` in completions.md
- Add troubleshooting section for zsh completion cache issues
- Add cache clearing to install.sh after zsh completion setup
- Add postflight hook to Homebrew cask to clear zcompdump on install/upgrade

## Files Changed
- `.github/workflows/release.yml` - Homebrew cask postflight hook
- `docs/install/completions.md` - Typo fix and troubleshooting section
- `install.sh` - Cache clearing in zsh completion setup

🤖 Generated with Claude Code

Closes #220