### PR TITLE
feat: add JSON/YAML schema validation to pre-commit

### DIFF
--- a/.github/workflows/compatibility-tests.yml
+++ b/.github/workflows/compatibility-tests.yml
@@ -9,7 +9,7 @@ on:
       with_api:
         description: 'Run API-dependent tests'
         required: false
-        default: 'false'
+        default: false
         type: boolean
       phase:
         description: 'Specific phase to run (1-9 or all)'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,12 +11,12 @@ on:
       force_regenerate:
         description: 'Force documentation regeneration (ignore spec hash)'
         required: false
-        default: 'false'
+        default: false
         type: boolean
       test_homebrew:
         description: 'Test Homebrew installation and update docs'
         required: false
-        default: 'false'
+        default: false
         type: boolean
   push:
     branches: [main]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,3 +66,14 @@ repos:
         name: Lint Markdown files
         args: ['--fix']
         exclude: '^docs/commands/'  # Exclude auto-generated docs
+
+  # JSON/YAML Schema validation
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.34.0
+    hooks:
+      - id: check-github-workflows
+        name: Validate GitHub Workflows
+      - id: check-jsonschema
+        name: Validate GoReleaser config
+        files: ^\.goreleaser\.ya?ml$
+        args: ['--schemafile', 'https://goreleaser.com/static/schema.json']


### PR DESCRIPTION
## Summary

Add schema validation hooks to pre-commit configuration for catching configuration errors before commit.

### Changes
- Add `check-github-workflows` hook for GitHub Actions workflow validation
- Add `check-jsonschema` hook for GoReleaser config validation using official schema
- Fix workflow input type bugs where boolean defaults were incorrectly specified as strings

### Files Modified
- `.pre-commit-config.yaml` - Added schema validation hooks
- `.github/workflows/compatibility-tests.yml` - Fixed `default: 'false'` → `default: false`
- `.github/workflows/docs.yml` - Fixed two instances of string booleans to actual booleans

### Validation
All hooks pass:
```
Validate GitHub Workflows................................................Passed
Validate GoReleaser config...............................................Passed
```

## Test Plan
- [x] Pre-commit hooks pass locally
- [x] GoReleaser schema URL verified (official schema at goreleaser.com)
- [x] Workflow boolean types fixed and validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)