### PR TITLE
feat: always release on every push to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,31 +44,50 @@ jobs:
         if: steps.changes.outputs.code == 'true'
         run: go test -v -race ./pkg/...
 
-  semantic-release:
-    name: Semantic Release
+  version:
+    name: Bump Version
     runs-on: ubuntu-latest
     needs: test
     outputs:
-      version: ${{ steps.semantic.outputs.version }}
+      version: ${{ steps.bump.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Run go-semantic-release
-        id: semantic
-        uses: go-semantic-release/action@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get latest tag and bump version
+        id: bump
+        run: |
+          # Get latest tag, default to v0.0.0 if none
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          echo "Latest tag: $LATEST_TAG"
+
+          # Extract version numbers
+          VERSION=${LATEST_TAG#v}
+          MAJOR=$(echo $VERSION | cut -d. -f1)
+          MINOR=$(echo $VERSION | cut -d. -f2)
+
+          # Increment minor version
+          NEW_MINOR=$((MINOR + 1))
+          NEW_VERSION="${MAJOR}.${NEW_MINOR}.0"
+
+          echo "New version: v$NEW_VERSION"
+          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Create and push tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "v${{ steps.bump.outputs.version }}" -m "Release v${{ steps.bump.outputs.version }}"
+          git push origin "v${{ steps.bump.outputs.version }}"
 
   goreleaser:
     name: GoReleaser
     runs-on: ubuntu-latest
-    needs: semantic-release
-    if: needs.semantic-release.outputs.version != ''
+    needs: version
     outputs:
-      version: ${{ needs.semantic-release.outputs.version }}
+      version: ${{ needs.version.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Replace semantic-release with auto-increment version strategy to ensure releases happen on every push to main, regardless of commit message type.

### Problem
Currently `go-semantic-release/action@v1` only triggers releases on:
- `feat:` commits
- `fix:` commits  
- `perf:` commits

This means documentation changes, refactors, and other improvements don't create releases.

### Solution
Replace with simple auto-increment minor version strategy:
1. Get latest git tag
2. Increment minor version (e.g., v4.40.0 → v4.41.0)
3. Create and push the new tag
4. GoReleaser proceeds with release

### Changes
- Replace `semantic-release` job with `version` job
- Auto-increment minor version on every push
- Remove conditional release check (`if: outputs.version != ''`)
- Update goreleaser job dependencies

### Benefits
- Every push to main creates a release
- No reliance on conventional commit message parsing
- Simpler and more predictable release process
- Documentation and refactor changes get released

## Test Plan
- [x] Workflow YAML syntax valid
- [ ] CI checks pass
- [ ] After merge: verify new release is created (should be v4.41.0)
- [ ] Verify Homebrew cask is updated
- [ ] Test: `brew reinstall robinmordasiewicz/tap/f5xcctl && f5xcctl version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #226