### PR TITLE
feat: improve help system with hidden help command, recursive templates, and documentation

### DIFF
--- a/cmd/api_endpoint.go
+++ b/cmd/api_endpoint.go
@@ -34,10 +34,33 @@ var (
 )
 
 var apiEndpointCmd = &cobra.Command{
-	Use:     "api-endpoint",
-	Short:   "Discover and manage API endpoints within F5 XC service mesh.",
-	Long:    `Discover and manage API endpoints within F5 XC service mesh.`,
-	Example: `f5xcctl api-endpoint discover --namespace default`,
+	Use:   "api-endpoint",
+	Short: "Discover and manage API endpoints within F5 XC service mesh.",
+	Long: `Discover and manage API endpoints within F5 XC service mesh.
+
+This command group provides tools for API discovery and security policy
+generation based on service mesh traffic analysis. F5 XC automatically
+discovers API endpoints from observed traffic between services.
+
+WORKFLOW:
+  1. Use 'discover' to find API endpoints between services
+  2. Review discovered endpoints and their communication patterns
+  3. Use 'control' to generate L7 policies based on discoveries
+
+COMMANDS:
+  discover  Find API endpoints in service mesh traffic
+  control   Generate L7 policies from discovered endpoints
+
+AI assistants should run 'discover' first to understand the service mesh
+topology before using 'control' to create security policies.`,
+	Example: `  # Discover API endpoints in a namespace
+  f5xcctl api-endpoint discover --namespace default --app-type my-app
+
+  # Create L7 policies from discovered endpoints
+  f5xcctl api-endpoint control --discover-ns default --app-type my-app
+
+  # Check available commands
+  f5xcctl api-endpoint --help`,
 }
 
 var apiEndpointDiscoverCmd = &cobra.Command{

--- a/cmd/configuration.go
+++ b/cmd/configuration.go
@@ -65,8 +65,47 @@ var configurationCmd = &cobra.Command{
 	Use:     "configuration",
 	Aliases: []string{"cfg", "c"},
 	Short:   "Manage F5 XC configuration objects using CRUD operations.",
-	Long:    `Manage F5 XC configuration objects using CRUD operations.`,
-	Example: `f5xcctl configuration create virtual_host`,
+	Long: `Manage F5 Distributed Cloud configuration objects using CRUD operations.
+
+This is the primary command group for managing F5 XC resources. It supports
+standard create, read, update, and delete operations across all resource types
+in your F5 XC tenant.
+
+OPERATIONS:
+  list           List resources of a type (optionally filtered by namespace)
+  get            Retrieve a specific resource by name
+  create         Create a new resource from YAML/JSON file
+  replace        Replace an existing resource completely
+  apply          Create or update (upsert) a resource
+  delete         Remove a resource by name
+  status         Check the operational status of a resource
+  patch          Partially update a resource
+  add-labels     Add labels to a resource
+  remove-labels  Remove labels from a resource
+
+COMMON RESOURCE TYPES:
+  namespace, http_loadbalancer, origin_pool, healthcheck, app_firewall,
+  service_policy, route, virtual_host, tcp_loadbalancer, dns_zone
+
+AI assistants should use 'f5xcctl configuration list namespace' first to
+discover available namespaces, then explore resources within each namespace.`,
+	Example: `  # List all namespaces
+  f5xcctl configuration list namespace
+
+  # List HTTP load balancers in a namespace
+  f5xcctl configuration list http_loadbalancer -n my-namespace
+
+  # Get a specific resource as YAML
+  f5xcctl configuration get http_loadbalancer -n my-namespace my-lb --output-format yaml
+
+  # Create a resource from file
+  f5xcctl configuration create http_loadbalancer -n my-namespace -i lb-config.yaml
+
+  # Delete a resource (with confirmation)
+  f5xcctl configuration delete http_loadbalancer -n my-namespace my-lb
+
+  # Apply (create or update) a resource
+  f5xcctl configuration apply http_loadbalancer -n my-namespace -i lb-config.yaml`,
 }
 
 func init() {

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -25,7 +25,7 @@ var configureFlags struct {
 
 var configureCmd = &cobra.Command{
 	Use:    "configure",
-	Short:  "Configure CLI settings",
+	Short:  "Configure CLI settings.",
 	Hidden: true, // Hide from help to match original f5xcctl
 	Long: `Configure the F5 Distributed Cloud CLI settings.
 

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -25,7 +25,7 @@ var loginFlags struct {
 
 var loginCmd = &cobra.Command{
 	Use:    "login",
-	Short:  "Log in to F5 Distributed Cloud",
+	Short:  "Log in to F5 Distributed Cloud.",
 	Hidden: true, // Hide from help to match original f5xcctl
 	Long: `Authenticate with F5 Distributed Cloud.
 
@@ -53,7 +53,7 @@ After successful login, you can use all f5xcctl commands to manage your resource
 
 var logoutCmd = &cobra.Command{
 	Use:    "logout",
-	Short:  "Log out from F5 Distributed Cloud",
+	Short:  "Log out from F5 Distributed Cloud.",
 	Hidden: true, // Hide from help to match original f5xcctl
 	Long:   `Clear saved credentials from the configuration file.`,
 	Example: `  # Log out

--- a/cmd/request.go
+++ b/cmd/request.go
@@ -10,8 +10,27 @@ var requestCmd = &cobra.Command{
 	Use:     "request",
 	Aliases: []string{"req", "r"},
 	Short:   "Execute custom API requests to F5 Distributed Cloud.",
-	Long:    `Execute custom API requests to F5 Distributed Cloud.`,
-	Example: `f5xcctl request secrets encrypt --policy-doc temp_policy --public-key pub_key secret`,
+	Long: `Execute custom API requests to F5 Distributed Cloud services.
+
+This command group provides access to specialized F5 XC API operations
+that aren't covered by standard configuration commands. Use these for
+advanced operations like secret encryption, RPC calls, and command sequencing.
+
+AVAILABLE SERVICES:
+  secrets           Encrypt and manage secrets using F5 XC policy-based encryption
+  rpc               Execute raw RPC calls to F5 XC API endpoints
+  command-sequence  Run multiple API operations from a sequence file
+
+AI assistants should use 'f5xcctl request <service> --help' for service-specific
+options and available actions.`,
+	Example: `  # Encrypt a secret using policy-based encryption
+  f5xcctl request secrets encrypt --policy-doc policy.yaml --public-key key.pem secret
+
+  # Execute a command sequence from file
+  f5xcctl request command-sequence -i commands.yaml
+
+  # Check available request services
+  f5xcctl request --help`,
 }
 
 func init() {

--- a/cmd/site.go
+++ b/cmd/site.go
@@ -17,8 +17,38 @@ var siteCmd = &cobra.Command{
 	Use:     "site",
 	Aliases: []string{"s"},
 	Short:   "Deploy and manage F5 XC sites on public cloud providers.",
-	Long:    `Deploy and manage F5 XC sites on public cloud providers.`,
-	Example: `f5xcctl site aws_vpc create`,
+	Long: `Deploy and manage F5 Distributed Cloud Customer Edge (CE) sites.
+
+Sites are deployment points for F5 XC services in your infrastructure.
+This command group supports creating, managing, and monitoring sites
+across multiple cloud providers using Terraform automation.
+
+SITE TYPES:
+  aws_vpc      Deploy CE nodes in AWS Virtual Private Cloud
+  azure_vnet   Deploy CE nodes in Azure Virtual Network
+
+LIFECYCLE:
+  1. Create site configuration in F5 XC console
+  2. Run Terraform to provision cloud infrastructure
+  3. Monitor site status until nodes report ONLINE
+  4. Optionally destroy infrastructure and delete site
+
+AI assistants should use 'f5xcctl site <provider> --help' for provider-specific
+options and 'f5xcctl site <provider> run --help' for Terraform actions.`,
+	Example: `  # Create an AWS VPC site from configuration
+  f5xcctl site aws_vpc create -i aws-site.yaml
+
+  # Delete an AWS VPC site
+  f5xcctl site aws_vpc delete --name example-site
+
+  # Run Terraform to provision AWS infrastructure
+  f5xcctl site aws_vpc run --name example-site --action apply --auto-approve
+
+  # Create an Azure VNet site
+  f5xcctl site azure_vnet create -i azure-site.yaml
+
+  # Check available site commands
+  f5xcctl site aws_vpc --help`,
 }
 
 func init() {

--- a/cmd/spec.go
+++ b/cmd/spec.go
@@ -645,6 +645,7 @@ func extractFlags(flags *pflag.FlagSet) []FlagSpec {
 			Type:        f.Value.Type(),
 			Default:     f.DefValue,
 			Description: f.Usage,
+			Required:    isRequiredFlag(f),
 		}
 
 		flagSpecs = append(flagSpecs, flagSpec)
@@ -656,6 +657,17 @@ func extractFlags(flags *pflag.FlagSet) []FlagSpec {
 	})
 
 	return flagSpecs
+}
+
+// isRequiredFlag checks if a flag is marked as required via Cobra's annotation system.
+// Cobra uses BashCompOneRequiredFlag annotation when MarkFlagRequired() is called.
+func isRequiredFlag(f *pflag.Flag) bool {
+	if f.Annotations == nil {
+		return false
+	}
+	// Cobra sets this annotation when a flag is marked required
+	_, ok := f.Annotations[cobra.BashCompOneRequiredFlag]
+	return ok
 }
 
 // getExitCodes returns the exit code specifications

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -42,10 +42,22 @@ func init() {
 }
 
 var versionCmd = &cobra.Command{
-	Use:     "version",
-	Short:   "Display f5xcctl version and build information.",
-	Long:    `Display f5xcctl version and build information.`,
-	Example: `f5xcctl version`,
+	Use:   "version",
+	Short: "Display f5xcctl version and build information.",
+	Long: `Display f5xcctl version and build information.
+
+Shows the current version, git commit hash, build date, Go version,
+and platform information. Useful for debugging, support requests,
+and verifying installation.
+
+OUTPUT FIELDS:
+  version   Release version (semver format)
+  commit    Git commit hash (7-character short form)
+  built     Build timestamp (ISO 8601 format)
+  go        Go runtime version used to compile
+  platform  Operating system and architecture (e.g., darwin/arm64)`,
+	Example: `  # Show version information
+  f5xcctl version`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Short commit hash (7 chars like GitHub)
 		commit := GitCommit


### PR DESCRIPTION
## Summary

Comprehensive improvements to f5xcctl's help system to provide a more professional CLI experience.

### Changes
- Hide `help` command from Available Commands (still functional when typed)
- Apply custom help template recursively to ALL commands
- Add required flag detection to --spec output
- Expand Long descriptions for site, request, configuration, api-endpoint, version commands
- Fix missing periods in Short descriptions

### Files Changed
- `cmd/root.go` - Help system infrastructure
- `cmd/spec.go` - Required flag detection
- `cmd/site.go`, `cmd/request.go`, `cmd/configuration.go`, `cmd/api_endpoint.go`, `cmd/version.go` - Documentation expansion
- `cmd/login.go`, `cmd/configure.go` - Period fixes

## Test Plan
- [x] Build succeeds
- [x] Help command hidden from listing
- [x] Help command works when typed directly
- [x] Environment Variables section appears on all subcommands
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #228