### PR TITLE
feat: add global --version flag and hide version/help from docs

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,9 +48,10 @@ var (
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "f5xcctl",
-	Short: "Command-line interface for F5 Distributed Cloud services.",
-	Long:  `Command-line interface for F5 Distributed Cloud services.`,
+	Use:     "f5xcctl",
+	Version: Version, // Enables --version and -v flags
+	Short:   "Command-line interface for F5 Distributed Cloud services.",
+	Long:    `Command-line interface for F5 Distributed Cloud services.`,
 	// Run handles the root command when no subcommand is specified
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Handle --spec flag for root command
@@ -172,6 +173,9 @@ func init() {
 
 	// Register --spec flag for machine-readable CLI specification
 	RegisterSpecFlag(rootCmd)
+
+	// Set custom version template for clean one-liner output (--version, -v)
+	rootCmd.SetVersionTemplate("f5xcctl version {{.Version}}\n")
 
 	// Set custom help template with Environment Variables section
 	rootCmd.SetHelpTemplate(helpTemplateWithEnvVars())

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -42,8 +42,9 @@ func init() {
 }
 
 var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Display f5xcctl version and build information.",
+	Use:    "version",
+	Hidden: true, // Hide from help - users should use --version or -v flag
+	Short:  "Display f5xcctl version and build information.",
 	Long: `Display f5xcctl version and build information.
 
 Shows the current version, git commit hash, build date, Go version,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -418,7 +418,6 @@ nav:
         - Virtual Appliance: commands/configuration/virtual_appliance.md
         - Voltshare: commands/configuration/voltshare.md
         - Workload Flavor: commands/configuration/workload_flavor.md
-    - Help: commands/help/index.md
     - Request:
       - Request Overview: commands/request/index.md
       - Command Sequence: commands/request/command-sequence/index.md
@@ -595,7 +594,6 @@ nav:
       - Quota: commands/subscription/quota/index.md
       - Show: commands/subscription/show/index.md
       - Validate: commands/subscription/validate/index.md
-    - Version: commands/version/index.md
   - Guides:
     - guides/index.md
     - Load Balancers: guides/load-balancer.md


### PR DESCRIPTION
## Summary

Add industry-standard `--version` / `-v` global flag to f5xcctl and clean up documentation navigation for hidden commands.

### Changes
- Add `Version: Version` field to rootCmd enabling `--version` and `-v` flags
- Add `SetVersionTemplate()` for clean one-liner output format
- Hide version subcommand from help (still works when typed)
- Remove Help and Version nav entries from mkdocs.yml

### Behavior

| Command | Output | Visibility |
|---------|--------|------------|
| `f5xcctl --version` | `f5xcctl version 4.42.0` | Shown in help |
| `f5xcctl -v` | `f5xcctl version 4.42.0` | Shown in help |
| `f5xcctl version` | Full multi-line output | Hidden (still works) |

## Test Plan
- [x] Build succeeds
- [x] `--version` flag works
- [x] `-v` shorthand works
- [x] `version` subcommand still works (hidden but functional)
- [x] Help shows `--version` flag but not version subcommand
- [x] mkdocs.yml has no broken nav links to hidden commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #230