### PR TITLE
fix(docs): update navigation for v5.0.0 domain-based command structure

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,327 +97,1321 @@ nav:
     - Authentication: install/authentication.md
   - Commands:
     - Overview: commands/index.md
+    - Ai Intelligence:
+      - Ai Intelligence Overview: commands/ai_intelligence/index.md
+      - Add Labels: commands/ai_intelligence/add-labels/index.md
+      - Apply: commands/ai_intelligence/apply/index.md
+      - Create: commands/ai_intelligence/create/index.md
+      - Delete: commands/ai_intelligence/delete/index.md
+      - Get: commands/ai_intelligence/get/index.md
+      - List: commands/ai_intelligence/list/index.md
+      - Patch: commands/ai_intelligence/patch/index.md
+      - Remove Labels: commands/ai_intelligence/remove-labels/index.md
+      - Replace: commands/ai_intelligence/replace/index.md
+      - Status: commands/ai_intelligence/status/index.md
     - API Endpoint:
       - API Endpoint Overview: commands/api-endpoint/index.md
       - Control: commands/api-endpoint/control/index.md
       - Discover: commands/api-endpoint/discover/index.md
-    - Completion: commands/completion/index.md
-    - Cloud Status:
-      - Overview: commands/cloudstatus/index.md
-      - Status: commands/cloudstatus/status.md
-      - Summary: commands/cloudstatus/summary.md
-      - Watch: commands/cloudstatus/watch.md
+    - API Security:
+      - API Security Overview: commands/api_security/index.md
+      - Add Labels:
+        - Add Labels Overview: commands/api_security/add-labels/index.md
+        - App API Group: commands/api_security/add-labels/app_api_group.md
+        - Sensitive Data Policy: commands/api_security/add-labels/sensitive_data_policy.md
+      - Apply:
+        - Apply Overview: commands/api_security/apply/index.md
+        - App API Group: commands/api_security/apply/app_api_group.md
+        - Sensitive Data Policy: commands/api_security/apply/sensitive_data_policy.md
+      - Create:
+        - Create Overview: commands/api_security/create/index.md
+        - App API Group: commands/api_security/create/app_api_group.md
+        - Sensitive Data Policy: commands/api_security/create/sensitive_data_policy.md
+      - Delete:
+        - Delete Overview: commands/api_security/delete/index.md
+        - App API Group: commands/api_security/delete/app_api_group.md
+        - Sensitive Data Policy: commands/api_security/delete/sensitive_data_policy.md
+      - Get:
+        - Get Overview: commands/api_security/get/index.md
+        - App API Group: commands/api_security/get/app_api_group.md
+        - Sensitive Data Policy: commands/api_security/get/sensitive_data_policy.md
+      - List:
+        - List Overview: commands/api_security/list/index.md
+        - App API Group: commands/api_security/list/app_api_group.md
+        - Sensitive Data Policy: commands/api_security/list/sensitive_data_policy.md
+      - Patch:
+        - Patch Overview: commands/api_security/patch/index.md
+        - App API Group: commands/api_security/patch/app_api_group.md
+        - Sensitive Data Policy: commands/api_security/patch/sensitive_data_policy.md
+      - Remove Labels:
+        - Remove Labels Overview: commands/api_security/remove-labels/index.md
+        - App API Group: commands/api_security/remove-labels/app_api_group.md
+        - Sensitive Data Policy: commands/api_security/remove-labels/sensitive_data_policy.md
+      - Replace:
+        - Replace Overview: commands/api_security/replace/index.md
+        - App API Group: commands/api_security/replace/app_api_group.md
+        - Sensitive Data Policy: commands/api_security/replace/sensitive_data_policy.md
+      - Status:
+        - Status Overview: commands/api_security/status/index.md
+        - App API Group: commands/api_security/status/app_api_group.md
+        - Sensitive Data Policy: commands/api_security/status/sensitive_data_policy.md
+    - Applications:
+      - Applications Overview: commands/applications/index.md
+      - Add Labels:
+        - Add Labels Overview: commands/applications/add-labels/index.md
+        - App Setting: commands/applications/add-labels/app_setting.md
+        - App Type: commands/applications/add-labels/app_type.md
+        - Workload: commands/applications/add-labels/workload.md
+        - Workload Flavor: commands/applications/add-labels/workload_flavor.md
+      - Apply:
+        - Apply Overview: commands/applications/apply/index.md
+        - App Setting: commands/applications/apply/app_setting.md
+        - App Type: commands/applications/apply/app_type.md
+        - Workload: commands/applications/apply/workload.md
+        - Workload Flavor: commands/applications/apply/workload_flavor.md
+      - Create:
+        - Create Overview: commands/applications/create/index.md
+        - App Setting: commands/applications/create/app_setting.md
+        - App Type: commands/applications/create/app_type.md
+        - Workload: commands/applications/create/workload.md
+        - Workload Flavor: commands/applications/create/workload_flavor.md
+      - Delete:
+        - Delete Overview: commands/applications/delete/index.md
+        - App Setting: commands/applications/delete/app_setting.md
+        - App Type: commands/applications/delete/app_type.md
+        - Workload: commands/applications/delete/workload.md
+        - Workload Flavor: commands/applications/delete/workload_flavor.md
+      - Get:
+        - Get Overview: commands/applications/get/index.md
+        - App Setting: commands/applications/get/app_setting.md
+        - App Type: commands/applications/get/app_type.md
+        - Workload: commands/applications/get/workload.md
+        - Workload Flavor: commands/applications/get/workload_flavor.md
+      - List:
+        - List Overview: commands/applications/list/index.md
+        - App Setting: commands/applications/list/app_setting.md
+        - App Type: commands/applications/list/app_type.md
+        - Workload: commands/applications/list/workload.md
+        - Workload Flavor: commands/applications/list/workload_flavor.md
+      - Patch:
+        - Patch Overview: commands/applications/patch/index.md
+        - App Setting: commands/applications/patch/app_setting.md
+        - App Type: commands/applications/patch/app_type.md
+        - Workload: commands/applications/patch/workload.md
+        - Workload Flavor: commands/applications/patch/workload_flavor.md
+      - Remove Labels:
+        - Remove Labels Overview: commands/applications/remove-labels/index.md
+        - App Setting: commands/applications/remove-labels/app_setting.md
+        - App Type: commands/applications/remove-labels/app_type.md
+        - Workload: commands/applications/remove-labels/workload.md
+        - Workload Flavor: commands/applications/remove-labels/workload_flavor.md
+      - Replace:
+        - Replace Overview: commands/applications/replace/index.md
+        - App Setting: commands/applications/replace/app_setting.md
+        - App Type: commands/applications/replace/app_type.md
+        - Workload: commands/applications/replace/workload.md
+        - Workload Flavor: commands/applications/replace/workload_flavor.md
+      - Status:
+        - Status Overview: commands/applications/status/index.md
+        - App Setting: commands/applications/status/app_setting.md
+        - App Type: commands/applications/status/app_type.md
+        - Workload: commands/applications/status/workload.md
+        - Workload Flavor: commands/applications/status/workload_flavor.md
+    - BIG-IP:
+      - BIG-IP Overview: commands/bigip/index.md
+      - Add Labels:
+        - Add Labels Overview: commands/bigip/add-labels/index.md
+        - BIG-IP APM: commands/bigip/add-labels/bigip_apm.md
+        - BIG-IP iRule: commands/bigip/add-labels/bigip_irule.md
+      - Apply:
+        - Apply Overview: commands/bigip/apply/index.md
+        - BIG-IP APM: commands/bigip/apply/bigip_apm.md
+        - BIG-IP iRule: commands/bigip/apply/bigip_irule.md
+      - Create:
+        - Create Overview: commands/bigip/create/index.md
+        - BIG-IP APM: commands/bigip/create/bigip_apm.md
+        - BIG-IP iRule: commands/bigip/create/bigip_irule.md
+      - Delete:
+        - Delete Overview: commands/bigip/delete/index.md
+        - BIG-IP APM: commands/bigip/delete/bigip_apm.md
+        - BIG-IP iRule: commands/bigip/delete/bigip_irule.md
+      - Get:
+        - Get Overview: commands/bigip/get/index.md
+        - BIG-IP APM: commands/bigip/get/bigip_apm.md
+        - BIG-IP iRule: commands/bigip/get/bigip_irule.md
+      - List:
+        - List Overview: commands/bigip/list/index.md
+        - BIG-IP APM: commands/bigip/list/bigip_apm.md
+        - BIG-IP iRule: commands/bigip/list/bigip_irule.md
+      - Patch:
+        - Patch Overview: commands/bigip/patch/index.md
+        - BIG-IP APM: commands/bigip/patch/bigip_apm.md
+        - BIG-IP iRule: commands/bigip/patch/bigip_irule.md
+      - Remove Labels:
+        - Remove Labels Overview: commands/bigip/remove-labels/index.md
+        - BIG-IP APM: commands/bigip/remove-labels/bigip_apm.md
+        - BIG-IP iRule: commands/bigip/remove-labels/bigip_irule.md
+      - Replace:
+        - Replace Overview: commands/bigip/replace/index.md
+        - BIG-IP APM: commands/bigip/replace/bigip_apm.md
+        - BIG-IP iRule: commands/bigip/replace/bigip_irule.md
+      - Status:
+        - Status Overview: commands/bigip/status/index.md
+        - BIG-IP APM: commands/bigip/status/bigip_apm.md
+        - BIG-IP iRule: commands/bigip/status/bigip_irule.md
+    - Billing:
+      - Billing Overview: commands/billing/index.md
+      - Add Labels:
+        - Add Labels Overview: commands/billing/add-labels/index.md
+        - Quota: commands/billing/add-labels/quota.md
+      - Apply: commands/billing/apply/index.md
+      - Create: commands/billing/create/index.md
+      - Delete: commands/billing/delete/index.md
+      - Get:
+        - Get Overview: commands/billing/get/index.md
+        - Quota: commands/billing/get/quota.md
+      - List:
+        - List Overview: commands/billing/list/index.md
+        - Quota: commands/billing/list/quota.md
+      - Patch: commands/billing/patch/index.md
+      - Remove Labels:
+        - Remove Labels Overview: commands/billing/remove-labels/index.md
+        - Quota: commands/billing/remove-labels/quota.md
+      - Replace: commands/billing/replace/index.md
+      - Status:
+        - Status Overview: commands/billing/status/index.md
+        - Quota: commands/billing/status/quota.md
+    - CDN:
+      - CDN Overview: commands/cdn/index.md
+      - Add Labels:
+        - Add Labels Overview: commands/cdn/add-labels/index.md
+        - CDN Cache Rule: commands/cdn/add-labels/cdn_cache_rule.md
+        - CDN Load Balancer: commands/cdn/add-labels/cdn_loadbalancer.md
+      - Apply:
+        - Apply Overview: commands/cdn/apply/index.md
+        - CDN Cache Rule: commands/cdn/apply/cdn_cache_rule.md
+        - CDN Load Balancer: commands/cdn/apply/cdn_loadbalancer.md
+      - Create:
+        - Create Overview: commands/cdn/create/index.md
+        - CDN Cache Rule: commands/cdn/create/cdn_cache_rule.md
+        - CDN Load Balancer: commands/cdn/create/cdn_loadbalancer.md
+      - Delete:
+        - Delete Overview: commands/cdn/delete/index.md
+        - CDN Cache Rule: commands/cdn/delete/cdn_cache_rule.md
+        - CDN Load Balancer: commands/cdn/delete/cdn_loadbalancer.md
+      - Get:
+        - Get Overview: commands/cdn/get/index.md
+        - CDN Cache Rule: commands/cdn/get/cdn_cache_rule.md
+        - CDN Load Balancer: commands/cdn/get/cdn_loadbalancer.md
+      - List:
+        - List Overview: commands/cdn/list/index.md
+        - CDN Cache Rule: commands/cdn/list/cdn_cache_rule.md
+        - CDN Load Balancer: commands/cdn/list/cdn_loadbalancer.md
+      - Patch:
+        - Patch Overview: commands/cdn/patch/index.md
+        - CDN Cache Rule: commands/cdn/patch/cdn_cache_rule.md
+        - CDN Load Balancer: commands/cdn/patch/cdn_loadbalancer.md
+      - Remove Labels:
+        - Remove Labels Overview: commands/cdn/remove-labels/index.md
+        - CDN Cache Rule: commands/cdn/remove-labels/cdn_cache_rule.md
+        - CDN Load Balancer: commands/cdn/remove-labels/cdn_loadbalancer.md
+      - Replace:
+        - Replace Overview: commands/cdn/replace/index.md
+        - CDN Cache Rule: commands/cdn/replace/cdn_cache_rule.md
+        - CDN Load Balancer: commands/cdn/replace/cdn_loadbalancer.md
+      - Status:
+        - Status Overview: commands/cdn/status/index.md
+        - CDN Cache Rule: commands/cdn/status/cdn_cache_rule.md
+        - CDN Load Balancer: commands/cdn/status/cdn_loadbalancer.md
+    - Cloudstatus:
+      - Cloudstatus Overview: commands/cloudstatus/index.md
       - Components:
-        - Overview: commands/cloudstatus/components/index.md
+        - Components Overview: commands/cloudstatus/components/index.md
         - Get: commands/cloudstatus/components/get.md
         - Groups: commands/cloudstatus/components/groups.md
         - List: commands/cloudstatus/components/list.md
       - Incidents:
-        - Overview: commands/cloudstatus/incidents/index.md
+        - Incidents Overview: commands/cloudstatus/incidents/index.md
         - Active: commands/cloudstatus/incidents/active.md
         - Get: commands/cloudstatus/incidents/get.md
         - List: commands/cloudstatus/incidents/list.md
         - Updates: commands/cloudstatus/incidents/updates.md
       - Maintenance:
-        - Overview: commands/cloudstatus/maintenance/index.md
+        - Maintenance Overview: commands/cloudstatus/maintenance/index.md
         - Active: commands/cloudstatus/maintenance/active.md
         - Get: commands/cloudstatus/maintenance/get.md
         - List: commands/cloudstatus/maintenance/list.md
         - Upcoming: commands/cloudstatus/maintenance/upcoming.md
-      - PoPs:
-        - Overview: commands/cloudstatus/pops/index.md
+      - Pops:
+        - Pops Overview: commands/cloudstatus/pops/index.md
         - List: commands/cloudstatus/pops/list.md
         - Status: commands/cloudstatus/pops/status.md
-    - Configuration:
-      - Configuration Overview: commands/configuration/index.md
-      - AI/ML:
-        - Ai Assistant: commands/configuration/ai_assistant.md
-      - API Security:
-        - API Definition: commands/configuration/api_definition.md
-        - API SEC API Crawler: commands/configuration/api_sec_api_crawler.md
-        - API SEC API Discovery: commands/configuration/api_sec_api_discovery.md
-        - API SEC API Testing: commands/configuration/api_sec_api_testing.md
-        - API SEC Code Base Integration: commands/configuration/api_sec_code_base_integration.md
-        - API SEC Rule Suggestion: commands/configuration/api_sec_rule_suggestion.md
-        - App API Group: commands/configuration/app_api_group.md
-      - Authentication:
-        - API Credential: commands/configuration/api_credential.md
-        - Cloud Credentials: commands/configuration/cloud_credentials.md
-        - Discovery: commands/configuration/discovery.md
-        - Secret Management: commands/configuration/secret_management.md
-        - Secret Management Access: commands/configuration/secret_management_access.md
-        - Secret Policy: commands/configuration/secret_policy.md
-        - Secret Policy Rule: commands/configuration/secret_policy_rule.md
-        - Token: commands/configuration/token.md
-      - BIG-IP Integration:
-        - BIG-IP APM: commands/configuration/bigip_apm.md
-        - BIG-IP iRule: commands/configuration/bigip_irule.md
-        - BIG-IP Virtual Server: commands/configuration/bigip_virtual_server.md
-      - Bot Defense:
-        - Bot Defense App Infrastructure: commands/configuration/bot_defense_app_infrastructure.md
-      - Certificates:
-        - Certificate: commands/configuration/certificate.md
-        - Certificate Chain: commands/configuration/certificate_chain.md
-        - CRL: commands/configuration/crl.md
-        - Trusted CA List: commands/configuration/trusted_ca_list.md
-      - DNS:
-        - DNS Compliance Checks: commands/configuration/dns_compliance_checks.md
-        - DNS Domain: commands/configuration/dns_domain.md
-        - DNS LB Health Check: commands/configuration/dns_lb_health_check.md
-        - DNS LB Pool: commands/configuration/dns_lb_pool.md
-        - DNS Load Balancer: commands/configuration/dns_load_balancer.md
-        - DNS Zone: commands/configuration/dns_zone.md
-        - DNS Zone Rrset: commands/configuration/dns_zone_rrset.md
-        - DNS Zone Subscription: commands/configuration/dns_zone_subscription.md
-      - Infrastructure Protection:
-        - Infraprotect: commands/configuration/infraprotect.md
-        - Infraprotect ASN: commands/configuration/infraprotect_asn.md
-        - Infraprotect ASN Prefix: commands/configuration/infraprotect_asn_prefix.md
-        - Infraprotect Deny List Rule: commands/configuration/infraprotect_deny_list_rule.md
-        - Infraprotect Firewall Rule: commands/configuration/infraprotect_firewall_rule.md
-        - Infraprotect Firewall Rule Group: commands/configuration/infraprotect_firewall_rule_group.md
-        - Infraprotect Firewall Ruleset: commands/configuration/infraprotect_firewall_ruleset.md
-        - Infraprotect Information: commands/configuration/infraprotect_information.md
-        - Infraprotect Internet Prefix Advertisement: commands/configuration/infraprotect_internet_prefix_advertisement.md
-        - Infraprotect Tunnel: commands/configuration/infraprotect_tunnel.md
-      - Integrations:
-        - External Connector: commands/configuration/external_connector.md
-        - Third Party Application: commands/configuration/third_party_application.md
-      - Kubernetes:
-        - K8S Cluster: commands/configuration/k8s_cluster.md
-        - K8S Cluster Role: commands/configuration/k8s_cluster_role.md
-        - K8S Cluster Role Binding: commands/configuration/k8s_cluster_role_binding.md
-        - K8S Pod Security Admission: commands/configuration/k8s_pod_security_admission.md
-        - K8S Pod Security Policy: commands/configuration/k8s_pod_security_policy.md
-        - Virtual K8S: commands/configuration/virtual_k8s.md
-        - Workload: commands/configuration/workload.md
-      - Load Balancing:
-        - CDN Load Balancer: commands/configuration/cdn_loadbalancer.md
-        - Cluster: commands/configuration/cluster.md
-        - Endpoint: commands/configuration/endpoint.md
-        - Health Check: commands/configuration/healthcheck.md
-        - HTTP Load Balancer: commands/configuration/http_loadbalancer.md
-        - Origin Pool: commands/configuration/origin_pool.md
-        - Route: commands/configuration/route.md
-        - TCP Load Balancer: commands/configuration/tcp_loadbalancer.md
-        - UDP Load Balancer: commands/configuration/udp_loadbalancer.md
-        - Virtual Host: commands/configuration/virtual_host.md
-      - Monitoring:
-        - Alert: commands/configuration/alert.md
-        - Alert Policy: commands/configuration/alert_policy.md
-        - Alert Receiver: commands/configuration/alert_receiver.md
-        - Global Log Receiver: commands/configuration/global_log_receiver.md
-        - Log: commands/configuration/log.md
-        - Log Receiver: commands/configuration/log_receiver.md
-        - Report: commands/configuration/report.md
-        - Report Config: commands/configuration/report_config.md
-        - Shape Brmalerts Alert Template: commands/configuration/shape_brmalerts_alert_template.md
-        - Synthetic Monitor: commands/configuration/synthetic_monitor.md
-      - Networking:
-        - BGP: commands/configuration/bgp.md
-        - BGP ASN Set: commands/configuration/bgp_asn_set.md
-        - BGP Routing Policy: commands/configuration/bgp_routing_policy.md
-        - Forward Proxy Policy: commands/configuration/forward_proxy_policy.md
-        - Network Connector: commands/configuration/network_connector.md
-        - Network Firewall: commands/configuration/network_firewall.md
-        - Network Interface: commands/configuration/network_interface.md
-        - Network Policy: commands/configuration/network_policy.md
-        - Network Policy Rule: commands/configuration/network_policy_rule.md
-        - Network Policy Set: commands/configuration/network_policy_set.md
-        - Network Policy View: commands/configuration/network_policy_view.md
-        - Operate BGP: commands/configuration/operate_bgp.md
-        - Policy Based Routing: commands/configuration/policy_based_routing.md
-        - Proxy: commands/configuration/proxy.md
-        - Segment: commands/configuration/segment.md
-        - Segment Connection: commands/configuration/segment_connection.md
-        - Srv6 Network Slice: commands/configuration/srv6_network_slice.md
-        - Tunnel: commands/configuration/tunnel.md
-        - Virtual Network: commands/configuration/virtual_network.md
-      - Organization:
-        - Contact: commands/configuration/contact.md
-        - Namespace: commands/configuration/namespace.md
-        - Namespace Role: commands/configuration/namespace_role.md
-        - RBAC Policy: commands/configuration/rbac_policy.md
-        - Role: commands/configuration/role.md
-        - Tenant: commands/configuration/tenant.md
-        - Tenant Configuration: commands/configuration/tenant_configuration.md
-        - Tenant Management: commands/configuration/tenant_management.md
-        - Tenant Management Allowed Tenant: commands/configuration/tenant_management_allowed_tenant.md
-        - Tenant Management Child Tenant: commands/configuration/tenant_management_child_tenant.md
-        - Tenant Management Child Tenant Manager: commands/configuration/tenant_management_child_tenant_manager.md
-        - Tenant Management Managed Tenant: commands/configuration/tenant_management_managed_tenant.md
-        - Tenant Management Tenant Profile: commands/configuration/tenant_management_tenant_profile.md
-        - User: commands/configuration/user.md
-        - User Group: commands/configuration/user_group.md
-        - User Identification: commands/configuration/user_identification.md
-        - User Setting: commands/configuration/user_setting.md
-        - Was User Token: commands/configuration/was_user_token.md
-      - Security:
-        - Advertise Policy: commands/configuration/advertise_policy.md
-        - App Firewall: commands/configuration/app_firewall.md
-        - Enhanced Firewall Policy: commands/configuration/enhanced_firewall_policy.md
-        - Malicious User Mitigation: commands/configuration/malicious_user_mitigation.md
-        - NAT Policy: commands/configuration/nat_policy.md
-        - Rate Limiter: commands/configuration/rate_limiter.md
-        - Rate Limiter Policy: commands/configuration/rate_limiter_policy.md
-        - Sensitive Data Policy: commands/configuration/sensitive_data_policy.md
-        - Service Policy: commands/configuration/service_policy.md
-        - Service Policy Rule: commands/configuration/service_policy_rule.md
-        - Service Policy Set: commands/configuration/service_policy_set.md
-        - Shape Bot Defense Bot Allowlist Policy: commands/configuration/shape_bot_defense_bot_allowlist_policy.md
-        - Shape Bot Defense Bot Endpoint Policy: commands/configuration/shape_bot_defense_bot_endpoint_policy.md
-        - Shape Bot Defense Bot Network Policy: commands/configuration/shape_bot_defense_bot_network_policy.md
-        - Shape Brmalerts Alert Gen Policy: commands/configuration/shape_brmalerts_alert_gen_policy.md
-        - Usb Policy: commands/configuration/usb_policy.md
-        - Voltshare Admin Policy: commands/configuration/voltshare_admin_policy.md
-        - WAF: commands/configuration/waf.md
-        - WAF Exclusion Policy: commands/configuration/waf_exclusion_policy.md
-        - WAF Signatures Changelog: commands/configuration/waf_signatures_changelog.md
-      - Shape Services:
-        - Shape Bot Defense Bot Infrastructure: commands/configuration/shape_bot_defense_bot_infrastructure.md
-        - Shape Bot Defense Instance: commands/configuration/shape_bot_defense_instance.md
-        - Shape Bot Defense Mobile Base Config: commands/configuration/shape_bot_defense_mobile_base_config.md
-        - Shape Bot Defense Mobile Sdk: commands/configuration/shape_bot_defense_mobile_sdk.md
-        - Shape Bot Defense Protected Application: commands/configuration/shape_bot_defense_protected_application.md
-        - Shape Bot Defense Reporting: commands/configuration/shape_bot_defense_reporting.md
-        - Shape Bot Detection Rule: commands/configuration/shape_bot_detection_rule.md
-        - Shape Bot Detection Update: commands/configuration/shape_bot_detection_update.md
-        - Shape Client Side Defense: commands/configuration/shape_client_side_defense.md
-        - Shape Client Side Defense Allowed Domain: commands/configuration/shape_client_side_defense_allowed_domain.md
-        - Shape Client Side Defense Mitigated Domain: commands/configuration/shape_client_side_defense_mitigated_domain.md
-        - Shape Client Side Defense Protected Domain: commands/configuration/shape_client_side_defense_protected_domain.md
-        - Shape Data Delivery: commands/configuration/shape_data_delivery.md
-        - Shape Data Delivery Receiver: commands/configuration/shape_data_delivery_receiver.md
-        - Shape Device ID: commands/configuration/shape_device_id.md
-        - Shape Recognize: commands/configuration/shape_recognize.md
-        - Shape Safe: commands/configuration/shape_safe.md
-        - Shape Safeap: commands/configuration/shape_safeap.md
-      - Sites:
-        - AWS TGW Site: commands/configuration/aws_tgw_site.md
-        - AWS VPC Site: commands/configuration/aws_vpc_site.md
-        - Azure VNET Site: commands/configuration/azure_vnet_site.md
-        - Fleet: commands/configuration/fleet.md
-        - GCP VPC Site: commands/configuration/gcp_vpc_site.md
-        - Graph Site: commands/configuration/graph_site.md
-        - Securemesh Site: commands/configuration/securemesh_site.md
-        - Securemesh Site V2: commands/configuration/securemesh_site_v2.md
-        - Status At Site: commands/configuration/status_at_site.md
-        - Virtual Site: commands/configuration/virtual_site.md
-        - Voltstack Site: commands/configuration/voltstack_site.md
-      - Subscriptions:
-        - Ai Data Bfdp Subscription: commands/configuration/ai_data_bfdp_subscription.md
-        - Billing Payment Method: commands/configuration/billing_payment_method.md
-        - Billing Plan Transition: commands/configuration/billing_plan_transition.md
-        - Malware Protection Subscription: commands/configuration/malware_protection_subscription.md
-        - Nginx One Subscription: commands/configuration/nginx_one_subscription.md
-        - Observability Subscription: commands/configuration/observability_subscription.md
-        - Pbac Addon Subscription: commands/configuration/pbac_addon_subscription.md
-        - Shape Bot Defense Subscription: commands/configuration/shape_bot_defense_subscription.md
-        - Shape Client Side Defense Subscription: commands/configuration/shape_client_side_defense_subscription.md
-        - Shape Data Delivery Subscription: commands/configuration/shape_data_delivery_subscription.md
-        - Shape Mobile App Shield Subscription: commands/configuration/shape_mobile_app_shield_subscription.md
-        - Shape Mobile Integrator Subscription: commands/configuration/shape_mobile_integrator_subscription.md
-        - Subscription: commands/configuration/subscription.md
-      - VPN:
-        - IKE Phase1 Profile: commands/configuration/ike_phase1_profile.md
-        - IKE Phase2 Profile: commands/configuration/ike_phase2_profile.md
-      - General:
-        - Address Allocator: commands/configuration/address_allocator.md
-        - Ai Data Bfdp: commands/configuration/ai_data_bfdp.md
-        - API Group: commands/configuration/api_group.md
-        - API Group Element: commands/configuration/api_group_element.md
-        - App Security: commands/configuration/app_security.md
-        - App Setting: commands/configuration/app_setting.md
-        - App Type: commands/configuration/app_type.md
-        - Authentication: commands/configuration/authentication.md
-        - Bigcne Data Group: commands/configuration/bigcne_data_group.md
-        - Bigcne iRule: commands/configuration/bigcne_irule.md
-        - CDN Cache Rule: commands/configuration/cdn_cache_rule.md
-        - Certified Hardware: commands/configuration/certified_hardware.md
-        - Cloud Connect: commands/configuration/cloud_connect.md
-        - Cloud Elastic IP: commands/configuration/cloud_elastic_ip.md
-        - Cloud Link: commands/configuration/cloud_link.md
-        - Cloud Region: commands/configuration/cloud_region.md
-        - Cminstance: commands/configuration/cminstance.md
-        - Container Registry: commands/configuration/container_registry.md
-        - Customer Support: commands/configuration/customer_support.md
-        - Data Privacy Geo Config: commands/configuration/data_privacy_geo_config.md
-        - Data Privacy Lma Region: commands/configuration/data_privacy_lma_region.md
-        - Data Type: commands/configuration/data_type.md
-        - Dc Cluster Group: commands/configuration/dc_cluster_group.md
-        - Discovered Service: commands/configuration/discovered_service.md
-        - Fast ACL: commands/configuration/fast_acl.md
-        - Fast ACL Rule: commands/configuration/fast_acl_rule.md
-        - Filter Set: commands/configuration/filter_set.md
-        - Flow: commands/configuration/flow.md
-        - Flow Anomaly: commands/configuration/flow_anomaly.md
-        - Forwarding Class: commands/configuration/forwarding_class.md
-        - Geo Location Set: commands/configuration/geo_location_set.md
-        - Gia: commands/configuration/gia.md
-        - Graph Connectivity: commands/configuration/graph_connectivity.md
-        - Graph L3l4: commands/configuration/graph_l3l4.md
-        - Graph Service: commands/configuration/graph_service.md
-        - Ike1: commands/configuration/ike1.md
-        - Ike2: commands/configuration/ike2.md
-        - Implicit Label: commands/configuration/implicit_label.md
-        - IP Prefix Set: commands/configuration/ip_prefix_set.md
-        - Known Label: commands/configuration/known_label.md
-        - Known Label Key: commands/configuration/known_label_key.md
-        - Maintenance Status: commands/configuration/maintenance_status.md
-        - Marketplace AWS Account: commands/configuration/marketplace_aws_account.md
-        - Marketplace XC Saas: commands/configuration/marketplace_xc_saas.md
-        - Module Management: commands/configuration/module_management.md
-        - Nfv Service: commands/configuration/nfv_service.md
-        - Nginx One Nginx Csg: commands/configuration/nginx_one_nginx_csg.md
-        - Nginx One Nginx Instance: commands/configuration/nginx_one_nginx_instance.md
-        - Nginx One Nginx Server: commands/configuration/nginx_one_nginx_server.md
-        - Nginx One Nginx Service Discovery: commands/configuration/nginx_one_nginx_service_discovery.md
-        - OIDC Provider: commands/configuration/oidc_provider.md
-        - Operate CRL: commands/configuration/operate_crl.md
-        - Operate Debug: commands/configuration/operate_debug.md
-        - Operate DHCP: commands/configuration/operate_dhcp.md
-        - Operate Flow: commands/configuration/operate_flow.md
-        - Operate Lte: commands/configuration/operate_lte.md
-        - Operate Ping: commands/configuration/operate_ping.md
-        - Operate Route: commands/configuration/operate_route.md
-        - Operate Tcpdump: commands/configuration/operate_tcpdump.md
-        - Operate Traceroute: commands/configuration/operate_traceroute.md
-        - Operate Usb: commands/configuration/operate_usb.md
-        - Operate Wifi: commands/configuration/operate_wifi.md
-        - Pbac Addon Service: commands/configuration/pbac_addon_service.md
-        - Pbac Catalog: commands/configuration/pbac_catalog.md
-        - Pbac Navigation Tile: commands/configuration/pbac_navigation_tile.md
-        - Pbac Plan: commands/configuration/pbac_plan.md
-        - Policer: commands/configuration/policer.md
-        - Protocol Inspection: commands/configuration/protocol_inspection.md
-        - Protocol Policer: commands/configuration/protocol_policer.md
-        - Public IP: commands/configuration/public_ip.md
-        - Quota: commands/configuration/quota.md
-        - Registration: commands/configuration/registration.md
-        - Scim: commands/configuration/scim.md
-        - Signup: commands/configuration/signup.md
-        - Site: commands/configuration/site.md
-        - Site Mesh Group: commands/configuration/site_mesh_group.md
-        - Stored Object: commands/configuration/stored_object.md
-        - Subnet: commands/configuration/subnet.md
-        - Synthetic Monitor DNS: commands/configuration/synthetic_monitor_dns.md
-        - Synthetic Monitor HTTP: commands/configuration/synthetic_monitor_http.md
-        - Ticket Management Ticket Tracking System: commands/configuration/ticket_management_ticket_tracking_system.md
-        - Topology: commands/configuration/topology.md
-        - Tpm API Key: commands/configuration/tpm_api_key.md
-        - Tpm Category: commands/configuration/tpm_category.md
-        - Tpm Manager: commands/configuration/tpm_manager.md
-        - Tpm Provision: commands/configuration/tpm_provision.md
-        - Ui Static Component: commands/configuration/ui_static_component.md
-        - Upgrade Status: commands/configuration/upgrade_status.md
-        - Usage: commands/configuration/usage.md
-        - Usage Invoice: commands/configuration/usage_invoice.md
-        - Usage Plan: commands/configuration/usage_plan.md
-        - Views Terraform Parameters: commands/configuration/views_terraform_parameters.md
-        - Views View Internal: commands/configuration/views_view_internal.md
-        - Virtual Appliance: commands/configuration/virtual_appliance.md
-        - Voltshare: commands/configuration/voltshare.md
-        - Workload Flavor: commands/configuration/workload_flavor.md
+      - Status: commands/cloudstatus/status.md
+      - Summary: commands/cloudstatus/summary.md
+      - Watch: commands/cloudstatus/watch.md
+    - Completion: commands/completion/index.md
+    - Config:
+      - Config Overview: commands/config/index.md
+      - Add Labels:
+        - Add Labels Overview: commands/config/add-labels/index.md
+        - Known Label: commands/config/add-labels/known_label.md
+        - Known Label Key: commands/config/add-labels/known_label_key.md
+      - Apply:
+        - Apply Overview: commands/config/apply/index.md
+        - Known Label: commands/config/apply/known_label.md
+        - Known Label Key: commands/config/apply/known_label_key.md
+      - Create:
+        - Create Overview: commands/config/create/index.md
+        - Known Label: commands/config/create/known_label.md
+        - Known Label Key: commands/config/create/known_label_key.md
+      - Delete:
+        - Delete Overview: commands/config/delete/index.md
+        - Known Label: commands/config/delete/known_label.md
+        - Known Label Key: commands/config/delete/known_label_key.md
+      - Get:
+        - Get Overview: commands/config/get/index.md
+        - Known Label: commands/config/get/known_label.md
+        - Known Label Key: commands/config/get/known_label_key.md
+      - List:
+        - List Overview: commands/config/list/index.md
+        - Known Label: commands/config/list/known_label.md
+        - Known Label Key: commands/config/list/known_label_key.md
+      - Patch:
+        - Patch Overview: commands/config/patch/index.md
+        - Known Label: commands/config/patch/known_label.md
+        - Known Label Key: commands/config/patch/known_label_key.md
+      - Remove Labels:
+        - Remove Labels Overview: commands/config/remove-labels/index.md
+        - Known Label: commands/config/remove-labels/known_label.md
+        - Known Label Key: commands/config/remove-labels/known_label_key.md
+      - Replace:
+        - Replace Overview: commands/config/replace/index.md
+        - Known Label: commands/config/replace/known_label.md
+        - Known Label Key: commands/config/replace/known_label_key.md
+      - Status:
+        - Status Overview: commands/config/status/index.md
+        - Known Label: commands/config/status/known_label.md
+        - Known Label Key: commands/config/status/known_label_key.md
+    - Identity:
+      - Identity Overview: commands/identity/index.md
+      - Add Labels:
+        - Add Labels Overview: commands/identity/add-labels/index.md
+        - API Credential: commands/identity/add-labels/api_credential.md
+        - Authentication: commands/identity/add-labels/authentication.md
+        - Certificate: commands/identity/add-labels/certificate.md
+        - Certificate Chain: commands/identity/add-labels/certificate_chain.md
+        - Contact: commands/identity/add-labels/contact.md
+        - K8S Cluster Role: commands/identity/add-labels/k8s_cluster_role.md
+        - K8S Cluster Role Binding: commands/identity/add-labels/k8s_cluster_role_binding.md
+        - Namespace: commands/identity/add-labels/namespace.md
+        - Role: commands/identity/add-labels/role.md
+        - Token: commands/identity/add-labels/token.md
+        - User Identification: commands/identity/add-labels/user_identification.md
+      - Apply:
+        - Apply Overview: commands/identity/apply/index.md
+        - API Credential: commands/identity/apply/api_credential.md
+        - Authentication: commands/identity/apply/authentication.md
+        - Certificate: commands/identity/apply/certificate.md
+        - Certificate Chain: commands/identity/apply/certificate_chain.md
+        - Contact: commands/identity/apply/contact.md
+        - K8S Cluster Role: commands/identity/apply/k8s_cluster_role.md
+        - K8S Cluster Role Binding: commands/identity/apply/k8s_cluster_role_binding.md
+        - Namespace: commands/identity/apply/namespace.md
+        - Role: commands/identity/apply/role.md
+        - Token: commands/identity/apply/token.md
+        - User Identification: commands/identity/apply/user_identification.md
+      - Create:
+        - Create Overview: commands/identity/create/index.md
+        - API Credential: commands/identity/create/api_credential.md
+        - Authentication: commands/identity/create/authentication.md
+        - Certificate: commands/identity/create/certificate.md
+        - Certificate Chain: commands/identity/create/certificate_chain.md
+        - Contact: commands/identity/create/contact.md
+        - K8S Cluster Role: commands/identity/create/k8s_cluster_role.md
+        - K8S Cluster Role Binding: commands/identity/create/k8s_cluster_role_binding.md
+        - Namespace: commands/identity/create/namespace.md
+        - Role: commands/identity/create/role.md
+        - Token: commands/identity/create/token.md
+        - User Identification: commands/identity/create/user_identification.md
+      - Delete:
+        - Delete Overview: commands/identity/delete/index.md
+        - API Credential: commands/identity/delete/api_credential.md
+        - Authentication: commands/identity/delete/authentication.md
+        - Certificate: commands/identity/delete/certificate.md
+        - Certificate Chain: commands/identity/delete/certificate_chain.md
+        - Contact: commands/identity/delete/contact.md
+        - K8S Cluster Role: commands/identity/delete/k8s_cluster_role.md
+        - K8S Cluster Role Binding: commands/identity/delete/k8s_cluster_role_binding.md
+        - Namespace: commands/identity/delete/namespace.md
+        - Role: commands/identity/delete/role.md
+        - Token: commands/identity/delete/token.md
+        - User Identification: commands/identity/delete/user_identification.md
+      - Get:
+        - Get Overview: commands/identity/get/index.md
+        - API Credential: commands/identity/get/api_credential.md
+        - Authentication: commands/identity/get/authentication.md
+        - Certificate: commands/identity/get/certificate.md
+        - Certificate Chain: commands/identity/get/certificate_chain.md
+        - Contact: commands/identity/get/contact.md
+        - K8S Cluster Role: commands/identity/get/k8s_cluster_role.md
+        - K8S Cluster Role Binding: commands/identity/get/k8s_cluster_role_binding.md
+        - Namespace: commands/identity/get/namespace.md
+        - Role: commands/identity/get/role.md
+        - Token: commands/identity/get/token.md
+        - User Identification: commands/identity/get/user_identification.md
+      - List:
+        - List Overview: commands/identity/list/index.md
+        - API Credential: commands/identity/list/api_credential.md
+        - Authentication: commands/identity/list/authentication.md
+        - Certificate: commands/identity/list/certificate.md
+        - Certificate Chain: commands/identity/list/certificate_chain.md
+        - Contact: commands/identity/list/contact.md
+        - K8S Cluster Role: commands/identity/list/k8s_cluster_role.md
+        - K8S Cluster Role Binding: commands/identity/list/k8s_cluster_role_binding.md
+        - Namespace: commands/identity/list/namespace.md
+        - Role: commands/identity/list/role.md
+        - Token: commands/identity/list/token.md
+        - User Identification: commands/identity/list/user_identification.md
+      - Patch:
+        - Patch Overview: commands/identity/patch/index.md
+        - API Credential: commands/identity/patch/api_credential.md
+        - Authentication: commands/identity/patch/authentication.md
+        - Certificate: commands/identity/patch/certificate.md
+        - Certificate Chain: commands/identity/patch/certificate_chain.md
+        - Contact: commands/identity/patch/contact.md
+        - K8S Cluster Role: commands/identity/patch/k8s_cluster_role.md
+        - K8S Cluster Role Binding: commands/identity/patch/k8s_cluster_role_binding.md
+        - Namespace: commands/identity/patch/namespace.md
+        - Role: commands/identity/patch/role.md
+        - Token: commands/identity/patch/token.md
+        - User Identification: commands/identity/patch/user_identification.md
+      - Remove Labels:
+        - Remove Labels Overview: commands/identity/remove-labels/index.md
+        - API Credential: commands/identity/remove-labels/api_credential.md
+        - Authentication: commands/identity/remove-labels/authentication.md
+        - Certificate: commands/identity/remove-labels/certificate.md
+        - Certificate Chain: commands/identity/remove-labels/certificate_chain.md
+        - Contact: commands/identity/remove-labels/contact.md
+        - K8S Cluster Role: commands/identity/remove-labels/k8s_cluster_role.md
+        - K8S Cluster Role Binding: commands/identity/remove-labels/k8s_cluster_role_binding.md
+        - Namespace: commands/identity/remove-labels/namespace.md
+        - Role: commands/identity/remove-labels/role.md
+        - Token: commands/identity/remove-labels/token.md
+        - User Identification: commands/identity/remove-labels/user_identification.md
+      - Replace:
+        - Replace Overview: commands/identity/replace/index.md
+        - API Credential: commands/identity/replace/api_credential.md
+        - Authentication: commands/identity/replace/authentication.md
+        - Certificate: commands/identity/replace/certificate.md
+        - Certificate Chain: commands/identity/replace/certificate_chain.md
+        - Contact: commands/identity/replace/contact.md
+        - K8S Cluster Role: commands/identity/replace/k8s_cluster_role.md
+        - K8S Cluster Role Binding: commands/identity/replace/k8s_cluster_role_binding.md
+        - Namespace: commands/identity/replace/namespace.md
+        - Role: commands/identity/replace/role.md
+        - Token: commands/identity/replace/token.md
+        - User Identification: commands/identity/replace/user_identification.md
+      - Status:
+        - Status Overview: commands/identity/status/index.md
+        - API Credential: commands/identity/status/api_credential.md
+        - Authentication: commands/identity/status/authentication.md
+        - Certificate: commands/identity/status/certificate.md
+        - Certificate Chain: commands/identity/status/certificate_chain.md
+        - Contact: commands/identity/status/contact.md
+        - K8S Cluster Role: commands/identity/status/k8s_cluster_role.md
+        - K8S Cluster Role Binding: commands/identity/status/k8s_cluster_role_binding.md
+        - Namespace: commands/identity/status/namespace.md
+        - Role: commands/identity/status/role.md
+        - Token: commands/identity/status/token.md
+        - User Identification: commands/identity/status/user_identification.md
+    - Infrastructure:
+      - Infrastructure Overview: commands/infrastructure/index.md
+      - Add Labels:
+        - Add Labels Overview: commands/infrastructure/add-labels/index.md
+        - AWS TGW Site: commands/infrastructure/add-labels/aws_tgw_site.md
+        - AWS VPC Site: commands/infrastructure/add-labels/aws_vpc_site.md
+        - Azure VNET Site: commands/infrastructure/add-labels/azure_vnet_site.md
+        - Cloud Credentials: commands/infrastructure/add-labels/cloud_credentials.md
+        - GCP VPC Site: commands/infrastructure/add-labels/gcp_vpc_site.md
+        - K8S Cluster: commands/infrastructure/add-labels/k8s_cluster.md
+        - K8S Pod Security Admission: commands/infrastructure/add-labels/k8s_pod_security_admission.md
+        - K8S Pod Security Policy: commands/infrastructure/add-labels/k8s_pod_security_policy.md
+        - Registration: commands/infrastructure/add-labels/registration.md
+        - Securemesh Site: commands/infrastructure/add-labels/securemesh_site.md
+        - Securemesh Site V2: commands/infrastructure/add-labels/securemesh_site_v2.md
+        - Usb Policy: commands/infrastructure/add-labels/usb_policy.md
+        - Virtual K8S: commands/infrastructure/add-labels/virtual_k8s.md
+        - Voltstack Site: commands/infrastructure/add-labels/voltstack_site.md
+      - Apply:
+        - Apply Overview: commands/infrastructure/apply/index.md
+        - AWS TGW Site: commands/infrastructure/apply/aws_tgw_site.md
+        - AWS VPC Site: commands/infrastructure/apply/aws_vpc_site.md
+        - Azure VNET Site: commands/infrastructure/apply/azure_vnet_site.md
+        - Cloud Credentials: commands/infrastructure/apply/cloud_credentials.md
+        - GCP VPC Site: commands/infrastructure/apply/gcp_vpc_site.md
+        - K8S Cluster: commands/infrastructure/apply/k8s_cluster.md
+        - K8S Pod Security Admission: commands/infrastructure/apply/k8s_pod_security_admission.md
+        - K8S Pod Security Policy: commands/infrastructure/apply/k8s_pod_security_policy.md
+        - Registration: commands/infrastructure/apply/registration.md
+        - Securemesh Site: commands/infrastructure/apply/securemesh_site.md
+        - Securemesh Site V2: commands/infrastructure/apply/securemesh_site_v2.md
+        - Usb Policy: commands/infrastructure/apply/usb_policy.md
+        - Virtual K8S: commands/infrastructure/apply/virtual_k8s.md
+        - Voltstack Site: commands/infrastructure/apply/voltstack_site.md
+      - Create:
+        - Create Overview: commands/infrastructure/create/index.md
+        - AWS TGW Site: commands/infrastructure/create/aws_tgw_site.md
+        - AWS VPC Site: commands/infrastructure/create/aws_vpc_site.md
+        - Azure VNET Site: commands/infrastructure/create/azure_vnet_site.md
+        - Cloud Credentials: commands/infrastructure/create/cloud_credentials.md
+        - GCP VPC Site: commands/infrastructure/create/gcp_vpc_site.md
+        - K8S Cluster: commands/infrastructure/create/k8s_cluster.md
+        - K8S Pod Security Admission: commands/infrastructure/create/k8s_pod_security_admission.md
+        - K8S Pod Security Policy: commands/infrastructure/create/k8s_pod_security_policy.md
+        - Registration: commands/infrastructure/create/registration.md
+        - Securemesh Site: commands/infrastructure/create/securemesh_site.md
+        - Securemesh Site V2: commands/infrastructure/create/securemesh_site_v2.md
+        - Usb Policy: commands/infrastructure/create/usb_policy.md
+        - Virtual K8S: commands/infrastructure/create/virtual_k8s.md
+        - Voltstack Site: commands/infrastructure/create/voltstack_site.md
+      - Delete:
+        - Delete Overview: commands/infrastructure/delete/index.md
+        - AWS TGW Site: commands/infrastructure/delete/aws_tgw_site.md
+        - AWS VPC Site: commands/infrastructure/delete/aws_vpc_site.md
+        - Azure VNET Site: commands/infrastructure/delete/azure_vnet_site.md
+        - Cloud Credentials: commands/infrastructure/delete/cloud_credentials.md
+        - GCP VPC Site: commands/infrastructure/delete/gcp_vpc_site.md
+        - K8S Cluster: commands/infrastructure/delete/k8s_cluster.md
+        - K8S Pod Security Admission: commands/infrastructure/delete/k8s_pod_security_admission.md
+        - K8S Pod Security Policy: commands/infrastructure/delete/k8s_pod_security_policy.md
+        - Registration: commands/infrastructure/delete/registration.md
+        - Securemesh Site: commands/infrastructure/delete/securemesh_site.md
+        - Securemesh Site V2: commands/infrastructure/delete/securemesh_site_v2.md
+        - Usb Policy: commands/infrastructure/delete/usb_policy.md
+        - Virtual K8S: commands/infrastructure/delete/virtual_k8s.md
+        - Voltstack Site: commands/infrastructure/delete/voltstack_site.md
+      - Get:
+        - Get Overview: commands/infrastructure/get/index.md
+        - AWS TGW Site: commands/infrastructure/get/aws_tgw_site.md
+        - AWS VPC Site: commands/infrastructure/get/aws_vpc_site.md
+        - Azure VNET Site: commands/infrastructure/get/azure_vnet_site.md
+        - Cloud Credentials: commands/infrastructure/get/cloud_credentials.md
+        - GCP VPC Site: commands/infrastructure/get/gcp_vpc_site.md
+        - K8S Cluster: commands/infrastructure/get/k8s_cluster.md
+        - K8S Pod Security Admission: commands/infrastructure/get/k8s_pod_security_admission.md
+        - K8S Pod Security Policy: commands/infrastructure/get/k8s_pod_security_policy.md
+        - Registration: commands/infrastructure/get/registration.md
+        - Securemesh Site: commands/infrastructure/get/securemesh_site.md
+        - Securemesh Site V2: commands/infrastructure/get/securemesh_site_v2.md
+        - Usb Policy: commands/infrastructure/get/usb_policy.md
+        - Virtual K8S: commands/infrastructure/get/virtual_k8s.md
+        - Voltstack Site: commands/infrastructure/get/voltstack_site.md
+      - List:
+        - List Overview: commands/infrastructure/list/index.md
+        - AWS TGW Site: commands/infrastructure/list/aws_tgw_site.md
+        - AWS VPC Site: commands/infrastructure/list/aws_vpc_site.md
+        - Azure VNET Site: commands/infrastructure/list/azure_vnet_site.md
+        - Cloud Credentials: commands/infrastructure/list/cloud_credentials.md
+        - GCP VPC Site: commands/infrastructure/list/gcp_vpc_site.md
+        - K8S Cluster: commands/infrastructure/list/k8s_cluster.md
+        - K8S Pod Security Admission: commands/infrastructure/list/k8s_pod_security_admission.md
+        - K8S Pod Security Policy: commands/infrastructure/list/k8s_pod_security_policy.md
+        - Registration: commands/infrastructure/list/registration.md
+        - Securemesh Site: commands/infrastructure/list/securemesh_site.md
+        - Securemesh Site V2: commands/infrastructure/list/securemesh_site_v2.md
+        - Usb Policy: commands/infrastructure/list/usb_policy.md
+        - Virtual K8S: commands/infrastructure/list/virtual_k8s.md
+        - Voltstack Site: commands/infrastructure/list/voltstack_site.md
+      - Patch:
+        - Patch Overview: commands/infrastructure/patch/index.md
+        - AWS TGW Site: commands/infrastructure/patch/aws_tgw_site.md
+        - AWS VPC Site: commands/infrastructure/patch/aws_vpc_site.md
+        - Azure VNET Site: commands/infrastructure/patch/azure_vnet_site.md
+        - Cloud Credentials: commands/infrastructure/patch/cloud_credentials.md
+        - GCP VPC Site: commands/infrastructure/patch/gcp_vpc_site.md
+        - K8S Cluster: commands/infrastructure/patch/k8s_cluster.md
+        - K8S Pod Security Admission: commands/infrastructure/patch/k8s_pod_security_admission.md
+        - K8S Pod Security Policy: commands/infrastructure/patch/k8s_pod_security_policy.md
+        - Registration: commands/infrastructure/patch/registration.md
+        - Securemesh Site: commands/infrastructure/patch/securemesh_site.md
+        - Securemesh Site V2: commands/infrastructure/patch/securemesh_site_v2.md
+        - Usb Policy: commands/infrastructure/patch/usb_policy.md
+        - Virtual K8S: commands/infrastructure/patch/virtual_k8s.md
+        - Voltstack Site: commands/infrastructure/patch/voltstack_site.md
+      - Remove Labels:
+        - Remove Labels Overview: commands/infrastructure/remove-labels/index.md
+        - AWS TGW Site: commands/infrastructure/remove-labels/aws_tgw_site.md
+        - AWS VPC Site: commands/infrastructure/remove-labels/aws_vpc_site.md
+        - Azure VNET Site: commands/infrastructure/remove-labels/azure_vnet_site.md
+        - Cloud Credentials: commands/infrastructure/remove-labels/cloud_credentials.md
+        - GCP VPC Site: commands/infrastructure/remove-labels/gcp_vpc_site.md
+        - K8S Cluster: commands/infrastructure/remove-labels/k8s_cluster.md
+        - K8S Pod Security Admission: commands/infrastructure/remove-labels/k8s_pod_security_admission.md
+        - K8S Pod Security Policy: commands/infrastructure/remove-labels/k8s_pod_security_policy.md
+        - Registration: commands/infrastructure/remove-labels/registration.md
+        - Securemesh Site: commands/infrastructure/remove-labels/securemesh_site.md
+        - Securemesh Site V2: commands/infrastructure/remove-labels/securemesh_site_v2.md
+        - Usb Policy: commands/infrastructure/remove-labels/usb_policy.md
+        - Virtual K8S: commands/infrastructure/remove-labels/virtual_k8s.md
+        - Voltstack Site: commands/infrastructure/remove-labels/voltstack_site.md
+      - Replace:
+        - Replace Overview: commands/infrastructure/replace/index.md
+        - AWS TGW Site: commands/infrastructure/replace/aws_tgw_site.md
+        - AWS VPC Site: commands/infrastructure/replace/aws_vpc_site.md
+        - Azure VNET Site: commands/infrastructure/replace/azure_vnet_site.md
+        - Cloud Credentials: commands/infrastructure/replace/cloud_credentials.md
+        - GCP VPC Site: commands/infrastructure/replace/gcp_vpc_site.md
+        - K8S Cluster: commands/infrastructure/replace/k8s_cluster.md
+        - K8S Pod Security Admission: commands/infrastructure/replace/k8s_pod_security_admission.md
+        - K8S Pod Security Policy: commands/infrastructure/replace/k8s_pod_security_policy.md
+        - Registration: commands/infrastructure/replace/registration.md
+        - Securemesh Site: commands/infrastructure/replace/securemesh_site.md
+        - Securemesh Site V2: commands/infrastructure/replace/securemesh_site_v2.md
+        - Usb Policy: commands/infrastructure/replace/usb_policy.md
+        - Virtual K8S: commands/infrastructure/replace/virtual_k8s.md
+        - Voltstack Site: commands/infrastructure/replace/voltstack_site.md
+      - Status:
+        - Status Overview: commands/infrastructure/status/index.md
+        - AWS TGW Site: commands/infrastructure/status/aws_tgw_site.md
+        - AWS VPC Site: commands/infrastructure/status/aws_vpc_site.md
+        - Azure VNET Site: commands/infrastructure/status/azure_vnet_site.md
+        - Cloud Credentials: commands/infrastructure/status/cloud_credentials.md
+        - GCP VPC Site: commands/infrastructure/status/gcp_vpc_site.md
+        - K8S Cluster: commands/infrastructure/status/k8s_cluster.md
+        - K8S Pod Security Admission: commands/infrastructure/status/k8s_pod_security_admission.md
+        - K8S Pod Security Policy: commands/infrastructure/status/k8s_pod_security_policy.md
+        - Registration: commands/infrastructure/status/registration.md
+        - Securemesh Site: commands/infrastructure/status/securemesh_site.md
+        - Securemesh Site V2: commands/infrastructure/status/securemesh_site_v2.md
+        - Usb Policy: commands/infrastructure/status/usb_policy.md
+        - Virtual K8S: commands/infrastructure/status/virtual_k8s.md
+        - Voltstack Site: commands/infrastructure/status/voltstack_site.md
+    - Infrastructure Protection:
+      - Infrastructure Protection Overview: commands/infrastructure_protection/index.md
+      - Add Labels:
+        - Add Labels Overview: commands/infrastructure_protection/add-labels/index.md
+        - Infraprotect ASN: commands/infrastructure_protection/add-labels/infraprotect_asn.md
+        - Infraprotect ASN Prefix: commands/infrastructure_protection/add-labels/infraprotect_asn_prefix.md
+        - Infraprotect Deny List Rule: commands/infrastructure_protection/add-labels/infraprotect_deny_list_rule.md
+        - Infraprotect Firewall Rule: commands/infrastructure_protection/add-labels/infraprotect_firewall_rule.md
+        - Infraprotect Firewall Rule Group: commands/infrastructure_protection/add-labels/infraprotect_firewall_rule_group.md
+        - Infraprotect Internet Prefix Advertisement: commands/infrastructure_protection/add-labels/infraprotect_internet_prefix_advertisement.md
+        - Infraprotect Tunnel: commands/infrastructure_protection/add-labels/infraprotect_tunnel.md
+      - Apply:
+        - Apply Overview: commands/infrastructure_protection/apply/index.md
+        - Infraprotect ASN: commands/infrastructure_protection/apply/infraprotect_asn.md
+        - Infraprotect ASN Prefix: commands/infrastructure_protection/apply/infraprotect_asn_prefix.md
+        - Infraprotect Deny List Rule: commands/infrastructure_protection/apply/infraprotect_deny_list_rule.md
+        - Infraprotect Firewall Rule: commands/infrastructure_protection/apply/infraprotect_firewall_rule.md
+        - Infraprotect Firewall Rule Group: commands/infrastructure_protection/apply/infraprotect_firewall_rule_group.md
+        - Infraprotect Internet Prefix Advertisement: commands/infrastructure_protection/apply/infraprotect_internet_prefix_advertisement.md
+        - Infraprotect Tunnel: commands/infrastructure_protection/apply/infraprotect_tunnel.md
+      - Create:
+        - Create Overview: commands/infrastructure_protection/create/index.md
+        - Infraprotect ASN: commands/infrastructure_protection/create/infraprotect_asn.md
+        - Infraprotect ASN Prefix: commands/infrastructure_protection/create/infraprotect_asn_prefix.md
+        - Infraprotect Deny List Rule: commands/infrastructure_protection/create/infraprotect_deny_list_rule.md
+        - Infraprotect Firewall Rule: commands/infrastructure_protection/create/infraprotect_firewall_rule.md
+        - Infraprotect Firewall Rule Group: commands/infrastructure_protection/create/infraprotect_firewall_rule_group.md
+        - Infraprotect Internet Prefix Advertisement: commands/infrastructure_protection/create/infraprotect_internet_prefix_advertisement.md
+        - Infraprotect Tunnel: commands/infrastructure_protection/create/infraprotect_tunnel.md
+      - Delete:
+        - Delete Overview: commands/infrastructure_protection/delete/index.md
+        - Infraprotect ASN: commands/infrastructure_protection/delete/infraprotect_asn.md
+        - Infraprotect ASN Prefix: commands/infrastructure_protection/delete/infraprotect_asn_prefix.md
+        - Infraprotect Deny List Rule: commands/infrastructure_protection/delete/infraprotect_deny_list_rule.md
+        - Infraprotect Firewall Rule: commands/infrastructure_protection/delete/infraprotect_firewall_rule.md
+        - Infraprotect Firewall Rule Group: commands/infrastructure_protection/delete/infraprotect_firewall_rule_group.md
+        - Infraprotect Internet Prefix Advertisement: commands/infrastructure_protection/delete/infraprotect_internet_prefix_advertisement.md
+        - Infraprotect Tunnel: commands/infrastructure_protection/delete/infraprotect_tunnel.md
+      - Get:
+        - Get Overview: commands/infrastructure_protection/get/index.md
+        - Infraprotect ASN: commands/infrastructure_protection/get/infraprotect_asn.md
+        - Infraprotect ASN Prefix: commands/infrastructure_protection/get/infraprotect_asn_prefix.md
+        - Infraprotect Deny List Rule: commands/infrastructure_protection/get/infraprotect_deny_list_rule.md
+        - Infraprotect Firewall Rule: commands/infrastructure_protection/get/infraprotect_firewall_rule.md
+        - Infraprotect Firewall Rule Group: commands/infrastructure_protection/get/infraprotect_firewall_rule_group.md
+        - Infraprotect Internet Prefix Advertisement: commands/infrastructure_protection/get/infraprotect_internet_prefix_advertisement.md
+        - Infraprotect Tunnel: commands/infrastructure_protection/get/infraprotect_tunnel.md
+      - List:
+        - List Overview: commands/infrastructure_protection/list/index.md
+        - Infraprotect ASN: commands/infrastructure_protection/list/infraprotect_asn.md
+        - Infraprotect ASN Prefix: commands/infrastructure_protection/list/infraprotect_asn_prefix.md
+        - Infraprotect Deny List Rule: commands/infrastructure_protection/list/infraprotect_deny_list_rule.md
+        - Infraprotect Firewall Rule: commands/infrastructure_protection/list/infraprotect_firewall_rule.md
+        - Infraprotect Firewall Rule Group: commands/infrastructure_protection/list/infraprotect_firewall_rule_group.md
+        - Infraprotect Internet Prefix Advertisement: commands/infrastructure_protection/list/infraprotect_internet_prefix_advertisement.md
+        - Infraprotect Tunnel: commands/infrastructure_protection/list/infraprotect_tunnel.md
+      - Patch:
+        - Patch Overview: commands/infrastructure_protection/patch/index.md
+        - Infraprotect ASN: commands/infrastructure_protection/patch/infraprotect_asn.md
+        - Infraprotect ASN Prefix: commands/infrastructure_protection/patch/infraprotect_asn_prefix.md
+        - Infraprotect Deny List Rule: commands/infrastructure_protection/patch/infraprotect_deny_list_rule.md
+        - Infraprotect Firewall Rule: commands/infrastructure_protection/patch/infraprotect_firewall_rule.md
+        - Infraprotect Firewall Rule Group: commands/infrastructure_protection/patch/infraprotect_firewall_rule_group.md
+        - Infraprotect Internet Prefix Advertisement: commands/infrastructure_protection/patch/infraprotect_internet_prefix_advertisement.md
+        - Infraprotect Tunnel: commands/infrastructure_protection/patch/infraprotect_tunnel.md
+      - Remove Labels:
+        - Remove Labels Overview: commands/infrastructure_protection/remove-labels/index.md
+        - Infraprotect ASN: commands/infrastructure_protection/remove-labels/infraprotect_asn.md
+        - Infraprotect ASN Prefix: commands/infrastructure_protection/remove-labels/infraprotect_asn_prefix.md
+        - Infraprotect Deny List Rule: commands/infrastructure_protection/remove-labels/infraprotect_deny_list_rule.md
+        - Infraprotect Firewall Rule: commands/infrastructure_protection/remove-labels/infraprotect_firewall_rule.md
+        - Infraprotect Firewall Rule Group: commands/infrastructure_protection/remove-labels/infraprotect_firewall_rule_group.md
+        - Infraprotect Internet Prefix Advertisement: commands/infrastructure_protection/remove-labels/infraprotect_internet_prefix_advertisement.md
+        - Infraprotect Tunnel: commands/infrastructure_protection/remove-labels/infraprotect_tunnel.md
+      - Replace:
+        - Replace Overview: commands/infrastructure_protection/replace/index.md
+        - Infraprotect ASN: commands/infrastructure_protection/replace/infraprotect_asn.md
+        - Infraprotect ASN Prefix: commands/infrastructure_protection/replace/infraprotect_asn_prefix.md
+        - Infraprotect Deny List Rule: commands/infrastructure_protection/replace/infraprotect_deny_list_rule.md
+        - Infraprotect Firewall Rule: commands/infrastructure_protection/replace/infraprotect_firewall_rule.md
+        - Infraprotect Firewall Rule Group: commands/infrastructure_protection/replace/infraprotect_firewall_rule_group.md
+        - Infraprotect Internet Prefix Advertisement: commands/infrastructure_protection/replace/infraprotect_internet_prefix_advertisement.md
+        - Infraprotect Tunnel: commands/infrastructure_protection/replace/infraprotect_tunnel.md
+      - Status:
+        - Status Overview: commands/infrastructure_protection/status/index.md
+        - Infraprotect ASN: commands/infrastructure_protection/status/infraprotect_asn.md
+        - Infraprotect ASN Prefix: commands/infrastructure_protection/status/infraprotect_asn_prefix.md
+        - Infraprotect Deny List Rule: commands/infrastructure_protection/status/infraprotect_deny_list_rule.md
+        - Infraprotect Firewall Rule: commands/infrastructure_protection/status/infraprotect_firewall_rule.md
+        - Infraprotect Firewall Rule Group: commands/infrastructure_protection/status/infraprotect_firewall_rule_group.md
+        - Infraprotect Internet Prefix Advertisement: commands/infrastructure_protection/status/infraprotect_internet_prefix_advertisement.md
+        - Infraprotect Tunnel: commands/infrastructure_protection/status/infraprotect_tunnel.md
+    - Integrations:
+      - Integrations Overview: commands/integrations/index.md
+      - Add Labels:
+        - Add Labels Overview: commands/integrations/add-labels/index.md
+        - Cminstance: commands/integrations/add-labels/cminstance.md
+        - Tpm API Key: commands/integrations/add-labels/tpm_api_key.md
+        - Tpm Category: commands/integrations/add-labels/tpm_category.md
+        - Tpm Manager: commands/integrations/add-labels/tpm_manager.md
+      - Apply:
+        - Apply Overview: commands/integrations/apply/index.md
+        - Cminstance: commands/integrations/apply/cminstance.md
+        - Tpm API Key: commands/integrations/apply/tpm_api_key.md
+        - Tpm Category: commands/integrations/apply/tpm_category.md
+        - Tpm Manager: commands/integrations/apply/tpm_manager.md
+      - Create:
+        - Create Overview: commands/integrations/create/index.md
+        - Cminstance: commands/integrations/create/cminstance.md
+        - Tpm API Key: commands/integrations/create/tpm_api_key.md
+        - Tpm Category: commands/integrations/create/tpm_category.md
+        - Tpm Manager: commands/integrations/create/tpm_manager.md
+      - Delete:
+        - Delete Overview: commands/integrations/delete/index.md
+        - Cminstance: commands/integrations/delete/cminstance.md
+      - Get:
+        - Get Overview: commands/integrations/get/index.md
+        - Cminstance: commands/integrations/get/cminstance.md
+        - Tpm API Key: commands/integrations/get/tpm_api_key.md
+        - Tpm Category: commands/integrations/get/tpm_category.md
+        - Tpm Manager: commands/integrations/get/tpm_manager.md
+      - List:
+        - List Overview: commands/integrations/list/index.md
+        - Cminstance: commands/integrations/list/cminstance.md
+        - Tpm API Key: commands/integrations/list/tpm_api_key.md
+        - Tpm Category: commands/integrations/list/tpm_category.md
+        - Tpm Manager: commands/integrations/list/tpm_manager.md
+      - Patch:
+        - Patch Overview: commands/integrations/patch/index.md
+        - Cminstance: commands/integrations/patch/cminstance.md
+        - Tpm API Key: commands/integrations/patch/tpm_api_key.md
+        - Tpm Category: commands/integrations/patch/tpm_category.md
+      - Remove Labels:
+        - Remove Labels Overview: commands/integrations/remove-labels/index.md
+        - Cminstance: commands/integrations/remove-labels/cminstance.md
+        - Tpm API Key: commands/integrations/remove-labels/tpm_api_key.md
+        - Tpm Category: commands/integrations/remove-labels/tpm_category.md
+        - Tpm Manager: commands/integrations/remove-labels/tpm_manager.md
+      - Replace:
+        - Replace Overview: commands/integrations/replace/index.md
+        - Cminstance: commands/integrations/replace/cminstance.md
+        - Tpm API Key: commands/integrations/replace/tpm_api_key.md
+        - Tpm Category: commands/integrations/replace/tpm_category.md
+      - Status:
+        - Status Overview: commands/integrations/status/index.md
+        - Cminstance: commands/integrations/status/cminstance.md
+    - Load Balancer:
+      - Load Balancer Overview: commands/load_balancer/index.md
+      - Add Labels:
+        - Add Labels Overview: commands/load_balancer/add-labels/index.md
+        - Forward Proxy Policy: commands/load_balancer/add-labels/forward_proxy_policy.md
+        - Health Check: commands/load_balancer/add-labels/healthcheck.md
+        - HTTP Load Balancer: commands/load_balancer/add-labels/http_loadbalancer.md
+        - Origin Pool: commands/load_balancer/add-labels/origin_pool.md
+        - Proxy: commands/load_balancer/add-labels/proxy.md
+        - TCP Load Balancer: commands/load_balancer/add-labels/tcp_loadbalancer.md
+        - UDP Load Balancer: commands/load_balancer/add-labels/udp_loadbalancer.md
+      - Apply:
+        - Apply Overview: commands/load_balancer/apply/index.md
+        - Forward Proxy Policy: commands/load_balancer/apply/forward_proxy_policy.md
+        - Health Check: commands/load_balancer/apply/healthcheck.md
+        - HTTP Load Balancer: commands/load_balancer/apply/http_loadbalancer.md
+        - Origin Pool: commands/load_balancer/apply/origin_pool.md
+        - Proxy: commands/load_balancer/apply/proxy.md
+        - TCP Load Balancer: commands/load_balancer/apply/tcp_loadbalancer.md
+        - UDP Load Balancer: commands/load_balancer/apply/udp_loadbalancer.md
+      - Create:
+        - Create Overview: commands/load_balancer/create/index.md
+        - Forward Proxy Policy: commands/load_balancer/create/forward_proxy_policy.md
+        - Health Check: commands/load_balancer/create/healthcheck.md
+        - HTTP Load Balancer: commands/load_balancer/create/http_loadbalancer.md
+        - Origin Pool: commands/load_balancer/create/origin_pool.md
+        - Proxy: commands/load_balancer/create/proxy.md
+        - TCP Load Balancer: commands/load_balancer/create/tcp_loadbalancer.md
+        - UDP Load Balancer: commands/load_balancer/create/udp_loadbalancer.md
+      - Delete:
+        - Delete Overview: commands/load_balancer/delete/index.md
+        - Forward Proxy Policy: commands/load_balancer/delete/forward_proxy_policy.md
+        - Health Check: commands/load_balancer/delete/healthcheck.md
+        - HTTP Load Balancer: commands/load_balancer/delete/http_loadbalancer.md
+        - Origin Pool: commands/load_balancer/delete/origin_pool.md
+        - Proxy: commands/load_balancer/delete/proxy.md
+        - TCP Load Balancer: commands/load_balancer/delete/tcp_loadbalancer.md
+        - UDP Load Balancer: commands/load_balancer/delete/udp_loadbalancer.md
+      - Get:
+        - Get Overview: commands/load_balancer/get/index.md
+        - Forward Proxy Policy: commands/load_balancer/get/forward_proxy_policy.md
+        - Health Check: commands/load_balancer/get/healthcheck.md
+        - HTTP Load Balancer: commands/load_balancer/get/http_loadbalancer.md
+        - Origin Pool: commands/load_balancer/get/origin_pool.md
+        - Proxy: commands/load_balancer/get/proxy.md
+        - TCP Load Balancer: commands/load_balancer/get/tcp_loadbalancer.md
+        - UDP Load Balancer: commands/load_balancer/get/udp_loadbalancer.md
+      - List:
+        - List Overview: commands/load_balancer/list/index.md
+        - Forward Proxy Policy: commands/load_balancer/list/forward_proxy_policy.md
+        - Health Check: commands/load_balancer/list/healthcheck.md
+        - HTTP Load Balancer: commands/load_balancer/list/http_loadbalancer.md
+        - Origin Pool: commands/load_balancer/list/origin_pool.md
+        - Proxy: commands/load_balancer/list/proxy.md
+        - TCP Load Balancer: commands/load_balancer/list/tcp_loadbalancer.md
+        - UDP Load Balancer: commands/load_balancer/list/udp_loadbalancer.md
+      - Patch:
+        - Patch Overview: commands/load_balancer/patch/index.md
+        - Forward Proxy Policy: commands/load_balancer/patch/forward_proxy_policy.md
+        - Health Check: commands/load_balancer/patch/healthcheck.md
+        - HTTP Load Balancer: commands/load_balancer/patch/http_loadbalancer.md
+        - Origin Pool: commands/load_balancer/patch/origin_pool.md
+        - Proxy: commands/load_balancer/patch/proxy.md
+        - TCP Load Balancer: commands/load_balancer/patch/tcp_loadbalancer.md
+        - UDP Load Balancer: commands/load_balancer/patch/udp_loadbalancer.md
+      - Remove Labels:
+        - Remove Labels Overview: commands/load_balancer/remove-labels/index.md
+        - Forward Proxy Policy: commands/load_balancer/remove-labels/forward_proxy_policy.md
+        - Health Check: commands/load_balancer/remove-labels/healthcheck.md
+        - HTTP Load Balancer: commands/load_balancer/remove-labels/http_loadbalancer.md
+        - Origin Pool: commands/load_balancer/remove-labels/origin_pool.md
+        - Proxy: commands/load_balancer/remove-labels/proxy.md
+        - TCP Load Balancer: commands/load_balancer/remove-labels/tcp_loadbalancer.md
+        - UDP Load Balancer: commands/load_balancer/remove-labels/udp_loadbalancer.md
+      - Replace:
+        - Replace Overview: commands/load_balancer/replace/index.md
+        - Forward Proxy Policy: commands/load_balancer/replace/forward_proxy_policy.md
+        - Health Check: commands/load_balancer/replace/healthcheck.md
+        - HTTP Load Balancer: commands/load_balancer/replace/http_loadbalancer.md
+        - Origin Pool: commands/load_balancer/replace/origin_pool.md
+        - Proxy: commands/load_balancer/replace/proxy.md
+        - TCP Load Balancer: commands/load_balancer/replace/tcp_loadbalancer.md
+        - UDP Load Balancer: commands/load_balancer/replace/udp_loadbalancer.md
+      - Status:
+        - Status Overview: commands/load_balancer/status/index.md
+        - Forward Proxy Policy: commands/load_balancer/status/forward_proxy_policy.md
+        - Health Check: commands/load_balancer/status/healthcheck.md
+        - HTTP Load Balancer: commands/load_balancer/status/http_loadbalancer.md
+        - Origin Pool: commands/load_balancer/status/origin_pool.md
+        - Proxy: commands/load_balancer/status/proxy.md
+        - TCP Load Balancer: commands/load_balancer/status/tcp_loadbalancer.md
+        - UDP Load Balancer: commands/load_balancer/status/udp_loadbalancer.md
+    - Networking:
+      - Networking Overview: commands/networking/index.md
+      - Add Labels:
+        - Add Labels Overview: commands/networking/add-labels/index.md
+        - Address Allocator: commands/networking/add-labels/address_allocator.md
+        - Advertise Policy: commands/networking/add-labels/advertise_policy.md
+        - BGP: commands/networking/add-labels/bgp.md
+        - BGP ASN Set: commands/networking/add-labels/bgp_asn_set.md
+        - BGP Routing Policy: commands/networking/add-labels/bgp_routing_policy.md
+        - Cloud Connect: commands/networking/add-labels/cloud_connect.md
+        - Cloud Elastic IP: commands/networking/add-labels/cloud_elastic_ip.md
+        - Cloud Link: commands/networking/add-labels/cloud_link.md
+        - Dc Cluster Group: commands/networking/add-labels/dc_cluster_group.md
+        - DNS Compliance Checks: commands/networking/add-labels/dns_compliance_checks.md
+        - DNS Domain: commands/networking/add-labels/dns_domain.md
+        - DNS LB Health Check: commands/networking/add-labels/dns_lb_health_check.md
+        - DNS LB Pool: commands/networking/add-labels/dns_lb_pool.md
+        - DNS Load Balancer: commands/networking/add-labels/dns_load_balancer.md
+        - DNS Zone: commands/networking/add-labels/dns_zone.md
+        - External Connector: commands/networking/add-labels/external_connector.md
+        - Fleet: commands/networking/add-labels/fleet.md
+        - Forwarding Class: commands/networking/add-labels/forwarding_class.md
+        - IP Prefix Set: commands/networking/add-labels/ip_prefix_set.md
+        - NAT Policy: commands/networking/add-labels/nat_policy.md
+        - Network Connector: commands/networking/add-labels/network_connector.md
+        - Network Firewall: commands/networking/add-labels/network_firewall.md
+        - Network Interface: commands/networking/add-labels/network_interface.md
+        - Network Policy: commands/networking/add-labels/network_policy.md
+        - Network Policy Rule: commands/networking/add-labels/network_policy_rule.md
+        - Network Policy View: commands/networking/add-labels/network_policy_view.md
+        - Policy Based Routing: commands/networking/add-labels/policy_based_routing.md
+        - Route: commands/networking/add-labels/route.md
+        - Segment: commands/networking/add-labels/segment.md
+        - Site Mesh Group: commands/networking/add-labels/site_mesh_group.md
+        - Srv6 Network Slice: commands/networking/add-labels/srv6_network_slice.md
+        - Subnet: commands/networking/add-labels/subnet.md
+        - Virtual Host: commands/networking/add-labels/virtual_host.md
+        - Virtual Network: commands/networking/add-labels/virtual_network.md
+        - Virtual Site: commands/networking/add-labels/virtual_site.md
+      - Apply:
+        - Apply Overview: commands/networking/apply/index.md
+        - Address Allocator: commands/networking/apply/address_allocator.md
+        - Advertise Policy: commands/networking/apply/advertise_policy.md
+        - BGP: commands/networking/apply/bgp.md
+        - BGP ASN Set: commands/networking/apply/bgp_asn_set.md
+        - BGP Routing Policy: commands/networking/apply/bgp_routing_policy.md
+        - Cloud Connect: commands/networking/apply/cloud_connect.md
+        - Cloud Elastic IP: commands/networking/apply/cloud_elastic_ip.md
+        - Cloud Link: commands/networking/apply/cloud_link.md
+        - Dc Cluster Group: commands/networking/apply/dc_cluster_group.md
+        - DNS Compliance Checks: commands/networking/apply/dns_compliance_checks.md
+        - DNS Domain: commands/networking/apply/dns_domain.md
+        - DNS LB Health Check: commands/networking/apply/dns_lb_health_check.md
+        - DNS LB Pool: commands/networking/apply/dns_lb_pool.md
+        - DNS Load Balancer: commands/networking/apply/dns_load_balancer.md
+        - DNS Zone: commands/networking/apply/dns_zone.md
+        - External Connector: commands/networking/apply/external_connector.md
+        - Fleet: commands/networking/apply/fleet.md
+        - Forwarding Class: commands/networking/apply/forwarding_class.md
+        - IP Prefix Set: commands/networking/apply/ip_prefix_set.md
+        - NAT Policy: commands/networking/apply/nat_policy.md
+        - Network Connector: commands/networking/apply/network_connector.md
+        - Network Firewall: commands/networking/apply/network_firewall.md
+        - Network Interface: commands/networking/apply/network_interface.md
+        - Network Policy: commands/networking/apply/network_policy.md
+        - Network Policy Rule: commands/networking/apply/network_policy_rule.md
+        - Network Policy View: commands/networking/apply/network_policy_view.md
+        - Policy Based Routing: commands/networking/apply/policy_based_routing.md
+        - Route: commands/networking/apply/route.md
+        - Segment: commands/networking/apply/segment.md
+        - Site Mesh Group: commands/networking/apply/site_mesh_group.md
+        - Srv6 Network Slice: commands/networking/apply/srv6_network_slice.md
+        - Subnet: commands/networking/apply/subnet.md
+        - Virtual Host: commands/networking/apply/virtual_host.md
+        - Virtual Network: commands/networking/apply/virtual_network.md
+        - Virtual Site: commands/networking/apply/virtual_site.md
+      - Create:
+        - Create Overview: commands/networking/create/index.md
+        - Address Allocator: commands/networking/create/address_allocator.md
+        - Advertise Policy: commands/networking/create/advertise_policy.md
+        - BGP: commands/networking/create/bgp.md
+        - BGP ASN Set: commands/networking/create/bgp_asn_set.md
+        - BGP Routing Policy: commands/networking/create/bgp_routing_policy.md
+        - Cloud Connect: commands/networking/create/cloud_connect.md
+        - Cloud Elastic IP: commands/networking/create/cloud_elastic_ip.md
+        - Cloud Link: commands/networking/create/cloud_link.md
+        - Dc Cluster Group: commands/networking/create/dc_cluster_group.md
+        - DNS Compliance Checks: commands/networking/create/dns_compliance_checks.md
+        - DNS Domain: commands/networking/create/dns_domain.md
+        - DNS LB Health Check: commands/networking/create/dns_lb_health_check.md
+        - DNS LB Pool: commands/networking/create/dns_lb_pool.md
+        - DNS Load Balancer: commands/networking/create/dns_load_balancer.md
+        - DNS Zone: commands/networking/create/dns_zone.md
+        - External Connector: commands/networking/create/external_connector.md
+        - Fleet: commands/networking/create/fleet.md
+        - Forwarding Class: commands/networking/create/forwarding_class.md
+        - IP Prefix Set: commands/networking/create/ip_prefix_set.md
+        - NAT Policy: commands/networking/create/nat_policy.md
+        - Network Connector: commands/networking/create/network_connector.md
+        - Network Firewall: commands/networking/create/network_firewall.md
+        - Network Interface: commands/networking/create/network_interface.md
+        - Network Policy: commands/networking/create/network_policy.md
+        - Network Policy Rule: commands/networking/create/network_policy_rule.md
+        - Network Policy View: commands/networking/create/network_policy_view.md
+        - Policy Based Routing: commands/networking/create/policy_based_routing.md
+        - Route: commands/networking/create/route.md
+        - Segment: commands/networking/create/segment.md
+        - Site Mesh Group: commands/networking/create/site_mesh_group.md
+        - Srv6 Network Slice: commands/networking/create/srv6_network_slice.md
+        - Subnet: commands/networking/create/subnet.md
+        - Virtual Host: commands/networking/create/virtual_host.md
+        - Virtual Network: commands/networking/create/virtual_network.md
+        - Virtual Site: commands/networking/create/virtual_site.md
+      - Delete:
+        - Delete Overview: commands/networking/delete/index.md
+        - Address Allocator: commands/networking/delete/address_allocator.md
+        - Advertise Policy: commands/networking/delete/advertise_policy.md
+        - BGP: commands/networking/delete/bgp.md
+        - BGP ASN Set: commands/networking/delete/bgp_asn_set.md
+        - BGP Routing Policy: commands/networking/delete/bgp_routing_policy.md
+        - Cloud Connect: commands/networking/delete/cloud_connect.md
+        - Cloud Elastic IP: commands/networking/delete/cloud_elastic_ip.md
+        - Cloud Link: commands/networking/delete/cloud_link.md
+        - Dc Cluster Group: commands/networking/delete/dc_cluster_group.md
+        - DNS Compliance Checks: commands/networking/delete/dns_compliance_checks.md
+        - DNS Domain: commands/networking/delete/dns_domain.md
+        - DNS LB Health Check: commands/networking/delete/dns_lb_health_check.md
+        - DNS LB Pool: commands/networking/delete/dns_lb_pool.md
+        - DNS Load Balancer: commands/networking/delete/dns_load_balancer.md
+        - DNS Zone: commands/networking/delete/dns_zone.md
+        - External Connector: commands/networking/delete/external_connector.md
+        - Fleet: commands/networking/delete/fleet.md
+        - Forwarding Class: commands/networking/delete/forwarding_class.md
+        - IP Prefix Set: commands/networking/delete/ip_prefix_set.md
+        - NAT Policy: commands/networking/delete/nat_policy.md
+        - Network Connector: commands/networking/delete/network_connector.md
+        - Network Firewall: commands/networking/delete/network_firewall.md
+        - Network Interface: commands/networking/delete/network_interface.md
+        - Network Policy: commands/networking/delete/network_policy.md
+        - Network Policy Rule: commands/networking/delete/network_policy_rule.md
+        - Network Policy View: commands/networking/delete/network_policy_view.md
+        - Policy Based Routing: commands/networking/delete/policy_based_routing.md
+        - Route: commands/networking/delete/route.md
+        - Segment: commands/networking/delete/segment.md
+        - Site Mesh Group: commands/networking/delete/site_mesh_group.md
+        - Srv6 Network Slice: commands/networking/delete/srv6_network_slice.md
+        - Subnet: commands/networking/delete/subnet.md
+        - Virtual Host: commands/networking/delete/virtual_host.md
+        - Virtual Network: commands/networking/delete/virtual_network.md
+        - Virtual Site: commands/networking/delete/virtual_site.md
+      - Get:
+        - Get Overview: commands/networking/get/index.md
+        - Address Allocator: commands/networking/get/address_allocator.md
+        - Advertise Policy: commands/networking/get/advertise_policy.md
+        - BGP: commands/networking/get/bgp.md
+        - BGP ASN Set: commands/networking/get/bgp_asn_set.md
+        - BGP Routing Policy: commands/networking/get/bgp_routing_policy.md
+        - Cloud Connect: commands/networking/get/cloud_connect.md
+        - Cloud Elastic IP: commands/networking/get/cloud_elastic_ip.md
+        - Cloud Link: commands/networking/get/cloud_link.md
+        - Dc Cluster Group: commands/networking/get/dc_cluster_group.md
+        - DNS Compliance Checks: commands/networking/get/dns_compliance_checks.md
+        - DNS Domain: commands/networking/get/dns_domain.md
+        - DNS LB Health Check: commands/networking/get/dns_lb_health_check.md
+        - DNS LB Pool: commands/networking/get/dns_lb_pool.md
+        - DNS Load Balancer: commands/networking/get/dns_load_balancer.md
+        - DNS Zone: commands/networking/get/dns_zone.md
+        - External Connector: commands/networking/get/external_connector.md
+        - Fleet: commands/networking/get/fleet.md
+        - Forwarding Class: commands/networking/get/forwarding_class.md
+        - IP Prefix Set: commands/networking/get/ip_prefix_set.md
+        - NAT Policy: commands/networking/get/nat_policy.md
+        - Network Connector: commands/networking/get/network_connector.md
+        - Network Firewall: commands/networking/get/network_firewall.md
+        - Network Interface: commands/networking/get/network_interface.md
+        - Network Policy: commands/networking/get/network_policy.md
+        - Network Policy Rule: commands/networking/get/network_policy_rule.md
+        - Network Policy View: commands/networking/get/network_policy_view.md
+        - Policy Based Routing: commands/networking/get/policy_based_routing.md
+        - Route: commands/networking/get/route.md
+        - Segment: commands/networking/get/segment.md
+        - Site Mesh Group: commands/networking/get/site_mesh_group.md
+        - Srv6 Network Slice: commands/networking/get/srv6_network_slice.md
+        - Subnet: commands/networking/get/subnet.md
+        - Virtual Host: commands/networking/get/virtual_host.md
+        - Virtual Network: commands/networking/get/virtual_network.md
+        - Virtual Site: commands/networking/get/virtual_site.md
+      - List:
+        - List Overview: commands/networking/list/index.md
+        - Address Allocator: commands/networking/list/address_allocator.md
+        - Advertise Policy: commands/networking/list/advertise_policy.md
+        - BGP: commands/networking/list/bgp.md
+        - BGP ASN Set: commands/networking/list/bgp_asn_set.md
+        - BGP Routing Policy: commands/networking/list/bgp_routing_policy.md
+        - Cloud Connect: commands/networking/list/cloud_connect.md
+        - Cloud Elastic IP: commands/networking/list/cloud_elastic_ip.md
+        - Cloud Link: commands/networking/list/cloud_link.md
+        - Dc Cluster Group: commands/networking/list/dc_cluster_group.md
+        - DNS Compliance Checks: commands/networking/list/dns_compliance_checks.md
+        - DNS Domain: commands/networking/list/dns_domain.md
+        - DNS LB Health Check: commands/networking/list/dns_lb_health_check.md
+        - DNS LB Pool: commands/networking/list/dns_lb_pool.md
+        - DNS Load Balancer: commands/networking/list/dns_load_balancer.md
+        - DNS Zone: commands/networking/list/dns_zone.md
+        - External Connector: commands/networking/list/external_connector.md
+        - Fleet: commands/networking/list/fleet.md
+        - Forwarding Class: commands/networking/list/forwarding_class.md
+        - IP Prefix Set: commands/networking/list/ip_prefix_set.md
+        - NAT Policy: commands/networking/list/nat_policy.md
+        - Network Connector: commands/networking/list/network_connector.md
+        - Network Firewall: commands/networking/list/network_firewall.md
+        - Network Interface: commands/networking/list/network_interface.md
+        - Network Policy: commands/networking/list/network_policy.md
+        - Network Policy Rule: commands/networking/list/network_policy_rule.md
+        - Network Policy View: commands/networking/list/network_policy_view.md
+        - Policy Based Routing: commands/networking/list/policy_based_routing.md
+        - Route: commands/networking/list/route.md
+        - Segment: commands/networking/list/segment.md
+        - Site Mesh Group: commands/networking/list/site_mesh_group.md
+        - Srv6 Network Slice: commands/networking/list/srv6_network_slice.md
+        - Subnet: commands/networking/list/subnet.md
+        - Virtual Host: commands/networking/list/virtual_host.md
+        - Virtual Network: commands/networking/list/virtual_network.md
+        - Virtual Site: commands/networking/list/virtual_site.md
+      - Patch:
+        - Patch Overview: commands/networking/patch/index.md
+        - Address Allocator: commands/networking/patch/address_allocator.md
+        - Advertise Policy: commands/networking/patch/advertise_policy.md
+        - BGP: commands/networking/patch/bgp.md
+        - BGP ASN Set: commands/networking/patch/bgp_asn_set.md
+        - BGP Routing Policy: commands/networking/patch/bgp_routing_policy.md
+        - Cloud Connect: commands/networking/patch/cloud_connect.md
+        - Cloud Elastic IP: commands/networking/patch/cloud_elastic_ip.md
+        - Cloud Link: commands/networking/patch/cloud_link.md
+        - Dc Cluster Group: commands/networking/patch/dc_cluster_group.md
+        - DNS Compliance Checks: commands/networking/patch/dns_compliance_checks.md
+        - DNS Domain: commands/networking/patch/dns_domain.md
+        - DNS LB Health Check: commands/networking/patch/dns_lb_health_check.md
+        - DNS LB Pool: commands/networking/patch/dns_lb_pool.md
+        - DNS Load Balancer: commands/networking/patch/dns_load_balancer.md
+        - DNS Zone: commands/networking/patch/dns_zone.md
+        - External Connector: commands/networking/patch/external_connector.md
+        - Fleet: commands/networking/patch/fleet.md
+        - Forwarding Class: commands/networking/patch/forwarding_class.md
+        - IP Prefix Set: commands/networking/patch/ip_prefix_set.md
+        - NAT Policy: commands/networking/patch/nat_policy.md
+        - Network Connector: commands/networking/patch/network_connector.md
+        - Network Firewall: commands/networking/patch/network_firewall.md
+        - Network Interface: commands/networking/patch/network_interface.md
+        - Network Policy: commands/networking/patch/network_policy.md
+        - Network Policy Rule: commands/networking/patch/network_policy_rule.md
+        - Network Policy View: commands/networking/patch/network_policy_view.md
+        - Policy Based Routing: commands/networking/patch/policy_based_routing.md
+        - Route: commands/networking/patch/route.md
+        - Segment: commands/networking/patch/segment.md
+        - Site Mesh Group: commands/networking/patch/site_mesh_group.md
+        - Srv6 Network Slice: commands/networking/patch/srv6_network_slice.md
+        - Subnet: commands/networking/patch/subnet.md
+        - Virtual Host: commands/networking/patch/virtual_host.md
+        - Virtual Network: commands/networking/patch/virtual_network.md
+        - Virtual Site: commands/networking/patch/virtual_site.md
+      - Remove Labels:
+        - Remove Labels Overview: commands/networking/remove-labels/index.md
+        - Address Allocator: commands/networking/remove-labels/address_allocator.md
+        - Advertise Policy: commands/networking/remove-labels/advertise_policy.md
+        - BGP: commands/networking/remove-labels/bgp.md
+        - BGP ASN Set: commands/networking/remove-labels/bgp_asn_set.md
+        - BGP Routing Policy: commands/networking/remove-labels/bgp_routing_policy.md
+        - Cloud Connect: commands/networking/remove-labels/cloud_connect.md
+        - Cloud Elastic IP: commands/networking/remove-labels/cloud_elastic_ip.md
+        - Cloud Link: commands/networking/remove-labels/cloud_link.md
+        - Dc Cluster Group: commands/networking/remove-labels/dc_cluster_group.md
+        - DNS Compliance Checks: commands/networking/remove-labels/dns_compliance_checks.md
+        - DNS Domain: commands/networking/remove-labels/dns_domain.md
+        - DNS LB Health Check: commands/networking/remove-labels/dns_lb_health_check.md
+        - DNS LB Pool: commands/networking/remove-labels/dns_lb_pool.md
+        - DNS Load Balancer: commands/networking/remove-labels/dns_load_balancer.md
+        - DNS Zone: commands/networking/remove-labels/dns_zone.md
+        - External Connector: commands/networking/remove-labels/external_connector.md
+        - Fleet: commands/networking/remove-labels/fleet.md
+        - Forwarding Class: commands/networking/remove-labels/forwarding_class.md
+        - IP Prefix Set: commands/networking/remove-labels/ip_prefix_set.md
+        - NAT Policy: commands/networking/remove-labels/nat_policy.md
+        - Network Connector: commands/networking/remove-labels/network_connector.md
+        - Network Firewall: commands/networking/remove-labels/network_firewall.md
+        - Network Interface: commands/networking/remove-labels/network_interface.md
+        - Network Policy: commands/networking/remove-labels/network_policy.md
+        - Network Policy Rule: commands/networking/remove-labels/network_policy_rule.md
+        - Network Policy View: commands/networking/remove-labels/network_policy_view.md
+        - Policy Based Routing: commands/networking/remove-labels/policy_based_routing.md
+        - Route: commands/networking/remove-labels/route.md
+        - Segment: commands/networking/remove-labels/segment.md
+        - Site Mesh Group: commands/networking/remove-labels/site_mesh_group.md
+        - Srv6 Network Slice: commands/networking/remove-labels/srv6_network_slice.md
+        - Subnet: commands/networking/remove-labels/subnet.md
+        - Virtual Host: commands/networking/remove-labels/virtual_host.md
+        - Virtual Network: commands/networking/remove-labels/virtual_network.md
+        - Virtual Site: commands/networking/remove-labels/virtual_site.md
+      - Replace:
+        - Replace Overview: commands/networking/replace/index.md
+        - Address Allocator: commands/networking/replace/address_allocator.md
+        - Advertise Policy: commands/networking/replace/advertise_policy.md
+        - BGP: commands/networking/replace/bgp.md
+        - BGP ASN Set: commands/networking/replace/bgp_asn_set.md
+        - BGP Routing Policy: commands/networking/replace/bgp_routing_policy.md
+        - Cloud Connect: commands/networking/replace/cloud_connect.md
+        - Cloud Elastic IP: commands/networking/replace/cloud_elastic_ip.md
+        - Cloud Link: commands/networking/replace/cloud_link.md
+        - Dc Cluster Group: commands/networking/replace/dc_cluster_group.md
+        - DNS Compliance Checks: commands/networking/replace/dns_compliance_checks.md
+        - DNS Domain: commands/networking/replace/dns_domain.md
+        - DNS LB Health Check: commands/networking/replace/dns_lb_health_check.md
+        - DNS LB Pool: commands/networking/replace/dns_lb_pool.md
+        - DNS Load Balancer: commands/networking/replace/dns_load_balancer.md
+        - DNS Zone: commands/networking/replace/dns_zone.md
+        - External Connector: commands/networking/replace/external_connector.md
+        - Fleet: commands/networking/replace/fleet.md
+        - Forwarding Class: commands/networking/replace/forwarding_class.md
+        - IP Prefix Set: commands/networking/replace/ip_prefix_set.md
+        - NAT Policy: commands/networking/replace/nat_policy.md
+        - Network Connector: commands/networking/replace/network_connector.md
+        - Network Firewall: commands/networking/replace/network_firewall.md
+        - Network Interface: commands/networking/replace/network_interface.md
+        - Network Policy: commands/networking/replace/network_policy.md
+        - Network Policy Rule: commands/networking/replace/network_policy_rule.md
+        - Network Policy View: commands/networking/replace/network_policy_view.md
+        - Policy Based Routing: commands/networking/replace/policy_based_routing.md
+        - Route: commands/networking/replace/route.md
+        - Segment: commands/networking/replace/segment.md
+        - Site Mesh Group: commands/networking/replace/site_mesh_group.md
+        - Srv6 Network Slice: commands/networking/replace/srv6_network_slice.md
+        - Subnet: commands/networking/replace/subnet.md
+        - Virtual Host: commands/networking/replace/virtual_host.md
+        - Virtual Network: commands/networking/replace/virtual_network.md
+        - Virtual Site: commands/networking/replace/virtual_site.md
+      - Status:
+        - Status Overview: commands/networking/status/index.md
+        - Address Allocator: commands/networking/status/address_allocator.md
+        - Advertise Policy: commands/networking/status/advertise_policy.md
+        - BGP: commands/networking/status/bgp.md
+        - BGP ASN Set: commands/networking/status/bgp_asn_set.md
+        - BGP Routing Policy: commands/networking/status/bgp_routing_policy.md
+        - Cloud Connect: commands/networking/status/cloud_connect.md
+        - Cloud Elastic IP: commands/networking/status/cloud_elastic_ip.md
+        - Cloud Link: commands/networking/status/cloud_link.md
+        - Dc Cluster Group: commands/networking/status/dc_cluster_group.md
+        - DNS Compliance Checks: commands/networking/status/dns_compliance_checks.md
+        - DNS Domain: commands/networking/status/dns_domain.md
+        - DNS LB Health Check: commands/networking/status/dns_lb_health_check.md
+        - DNS LB Pool: commands/networking/status/dns_lb_pool.md
+        - DNS Load Balancer: commands/networking/status/dns_load_balancer.md
+        - DNS Zone: commands/networking/status/dns_zone.md
+        - External Connector: commands/networking/status/external_connector.md
+        - Fleet: commands/networking/status/fleet.md
+        - Forwarding Class: commands/networking/status/forwarding_class.md
+        - IP Prefix Set: commands/networking/status/ip_prefix_set.md
+        - NAT Policy: commands/networking/status/nat_policy.md
+        - Network Connector: commands/networking/status/network_connector.md
+        - Network Firewall: commands/networking/status/network_firewall.md
+        - Network Interface: commands/networking/status/network_interface.md
+        - Network Policy: commands/networking/status/network_policy.md
+        - Network Policy Rule: commands/networking/status/network_policy_rule.md
+        - Network Policy View: commands/networking/status/network_policy_view.md
+        - Policy Based Routing: commands/networking/status/policy_based_routing.md
+        - Route: commands/networking/status/route.md
+        - Segment: commands/networking/status/segment.md
+        - Site Mesh Group: commands/networking/status/site_mesh_group.md
+        - Srv6 Network Slice: commands/networking/status/srv6_network_slice.md
+        - Subnet: commands/networking/status/subnet.md
+        - Virtual Host: commands/networking/status/virtual_host.md
+        - Virtual Network: commands/networking/status/virtual_network.md
+        - Virtual Site: commands/networking/status/virtual_site.md
+    - Nginx:
+      - Nginx Overview: commands/nginx/index.md
+      - Add Labels: commands/nginx/add-labels/index.md
+      - Apply: commands/nginx/apply/index.md
+      - Create: commands/nginx/create/index.md
+      - Delete: commands/nginx/delete/index.md
+      - Get: commands/nginx/get/index.md
+      - List: commands/nginx/list/index.md
+      - Patch: commands/nginx/patch/index.md
+      - Remove Labels: commands/nginx/remove-labels/index.md
+      - Replace: commands/nginx/replace/index.md
+      - Status: commands/nginx/status/index.md
+    - Observability:
+      - Observability Overview: commands/observability/index.md
+      - Add Labels:
+        - Add Labels Overview: commands/observability/add-labels/index.md
+        - Alert Policy: commands/observability/add-labels/alert_policy.md
+        - Alert Receiver: commands/observability/add-labels/alert_receiver.md
+        - Global Log Receiver: commands/observability/add-labels/global_log_receiver.md
+        - Log Receiver: commands/observability/add-labels/log_receiver.md
+        - Report Config: commands/observability/add-labels/report_config.md
+      - Apply:
+        - Apply Overview: commands/observability/apply/index.md
+        - Alert Policy: commands/observability/apply/alert_policy.md
+        - Alert Receiver: commands/observability/apply/alert_receiver.md
+        - Global Log Receiver: commands/observability/apply/global_log_receiver.md
+        - Log Receiver: commands/observability/apply/log_receiver.md
+        - Report Config: commands/observability/apply/report_config.md
+      - Create:
+        - Create Overview: commands/observability/create/index.md
+        - Alert Policy: commands/observability/create/alert_policy.md
+        - Alert Receiver: commands/observability/create/alert_receiver.md
+        - Global Log Receiver: commands/observability/create/global_log_receiver.md
+        - Log Receiver: commands/observability/create/log_receiver.md
+        - Report Config: commands/observability/create/report_config.md
+      - Delete:
+        - Delete Overview: commands/observability/delete/index.md
+        - Alert Policy: commands/observability/delete/alert_policy.md
+        - Alert Receiver: commands/observability/delete/alert_receiver.md
+        - Global Log Receiver: commands/observability/delete/global_log_receiver.md
+        - Log Receiver: commands/observability/delete/log_receiver.md
+        - Report Config: commands/observability/delete/report_config.md
+      - Get:
+        - Get Overview: commands/observability/get/index.md
+        - Alert Policy: commands/observability/get/alert_policy.md
+        - Alert Receiver: commands/observability/get/alert_receiver.md
+        - Global Log Receiver: commands/observability/get/global_log_receiver.md
+        - Log Receiver: commands/observability/get/log_receiver.md
+        - Report Config: commands/observability/get/report_config.md
+      - List:
+        - List Overview: commands/observability/list/index.md
+        - Alert Policy: commands/observability/list/alert_policy.md
+        - Alert Receiver: commands/observability/list/alert_receiver.md
+        - Global Log Receiver: commands/observability/list/global_log_receiver.md
+        - Log Receiver: commands/observability/list/log_receiver.md
+        - Report Config: commands/observability/list/report_config.md
+      - Patch:
+        - Patch Overview: commands/observability/patch/index.md
+        - Alert Policy: commands/observability/patch/alert_policy.md
+        - Alert Receiver: commands/observability/patch/alert_receiver.md
+        - Global Log Receiver: commands/observability/patch/global_log_receiver.md
+        - Log Receiver: commands/observability/patch/log_receiver.md
+        - Report Config: commands/observability/patch/report_config.md
+      - Remove Labels:
+        - Remove Labels Overview: commands/observability/remove-labels/index.md
+        - Alert Policy: commands/observability/remove-labels/alert_policy.md
+        - Alert Receiver: commands/observability/remove-labels/alert_receiver.md
+        - Global Log Receiver: commands/observability/remove-labels/global_log_receiver.md
+        - Log Receiver: commands/observability/remove-labels/log_receiver.md
+        - Report Config: commands/observability/remove-labels/report_config.md
+      - Replace:
+        - Replace Overview: commands/observability/replace/index.md
+        - Alert Policy: commands/observability/replace/alert_policy.md
+        - Alert Receiver: commands/observability/replace/alert_receiver.md
+        - Global Log Receiver: commands/observability/replace/global_log_receiver.md
+        - Log Receiver: commands/observability/replace/log_receiver.md
+        - Report Config: commands/observability/replace/report_config.md
+      - Status:
+        - Status Overview: commands/observability/status/index.md
+        - Alert Policy: commands/observability/status/alert_policy.md
+        - Alert Receiver: commands/observability/status/alert_receiver.md
+        - Global Log Receiver: commands/observability/status/global_log_receiver.md
+        - Log Receiver: commands/observability/status/log_receiver.md
+        - Report Config: commands/observability/status/report_config.md
+    - Operations:
+      - Operations Overview: commands/operations/index.md
+      - Add Labels:
+        - Add Labels Overview: commands/operations/add-labels/index.md
+        - Customer Support: commands/operations/add-labels/customer_support.md
+      - Apply:
+        - Apply Overview: commands/operations/apply/index.md
+        - Customer Support: commands/operations/apply/customer_support.md
+      - Create:
+        - Create Overview: commands/operations/create/index.md
+        - Customer Support: commands/operations/create/customer_support.md
+      - Delete:
+        - Delete Overview: commands/operations/delete/index.md
+        - Customer Support: commands/operations/delete/customer_support.md
+      - Get:
+        - Get Overview: commands/operations/get/index.md
+        - Customer Support: commands/operations/get/customer_support.md
+      - List:
+        - List Overview: commands/operations/list/index.md
+        - Customer Support: commands/operations/list/customer_support.md
+      - Patch:
+        - Patch Overview: commands/operations/patch/index.md
+        - Customer Support: commands/operations/patch/customer_support.md
+      - Remove Labels:
+        - Remove Labels Overview: commands/operations/remove-labels/index.md
+        - Customer Support: commands/operations/remove-labels/customer_support.md
+      - Replace:
+        - Replace Overview: commands/operations/replace/index.md
+        - Customer Support: commands/operations/replace/customer_support.md
+      - Status:
+        - Status Overview: commands/operations/status/index.md
+        - Customer Support: commands/operations/status/customer_support.md
     - Request:
       - Request Overview: commands/request/index.md
       - Command Sequence: commands/request/command-sequence/index.md
@@ -572,6 +1566,352 @@ nav:
         - Get Policy Document: commands/request/secrets/get-policy-document.md
         - Get Public Key: commands/request/secrets/get-public-key.md
         - Secret Info: commands/request/secrets/secret-info.md
+    - Security:
+      - Security Overview: commands/security/index.md
+      - Add Labels:
+        - Add Labels Overview: commands/security/add-labels/index.md
+        - API Definition: commands/security/add-labels/api_definition.md
+        - App Firewall: commands/security/add-labels/app_firewall.md
+        - Bot Defense App Infrastructure: commands/security/add-labels/bot_defense_app_infrastructure.md
+        - CRL: commands/security/add-labels/crl.md
+        - Data Type: commands/security/add-labels/data_type.md
+        - Enhanced Firewall Policy: commands/security/add-labels/enhanced_firewall_policy.md
+        - Fast ACL: commands/security/add-labels/fast_acl.md
+        - Fast ACL Rule: commands/security/add-labels/fast_acl_rule.md
+        - Filter Set: commands/security/add-labels/filter_set.md
+        - Geo Location Set: commands/security/add-labels/geo_location_set.md
+        - Malicious User Mitigation: commands/security/add-labels/malicious_user_mitigation.md
+        - Policer: commands/security/add-labels/policer.md
+        - Protocol Inspection: commands/security/add-labels/protocol_inspection.md
+        - Protocol Policer: commands/security/add-labels/protocol_policer.md
+        - Rate Limiter: commands/security/add-labels/rate_limiter.md
+        - Rate Limiter Policy: commands/security/add-labels/rate_limiter_policy.md
+        - Secret Management Access: commands/security/add-labels/secret_management_access.md
+        - Secret Policy: commands/security/add-labels/secret_policy.md
+        - Secret Policy Rule: commands/security/add-labels/secret_policy_rule.md
+        - Service Policy: commands/security/add-labels/service_policy.md
+        - Service Policy Rule: commands/security/add-labels/service_policy_rule.md
+        - Trusted CA List: commands/security/add-labels/trusted_ca_list.md
+        - Voltshare Admin Policy: commands/security/add-labels/voltshare_admin_policy.md
+        - WAF Exclusion Policy: commands/security/add-labels/waf_exclusion_policy.md
+      - Apply:
+        - Apply Overview: commands/security/apply/index.md
+        - API Definition: commands/security/apply/api_definition.md
+        - App Firewall: commands/security/apply/app_firewall.md
+        - Bot Defense App Infrastructure: commands/security/apply/bot_defense_app_infrastructure.md
+        - CRL: commands/security/apply/crl.md
+        - Data Type: commands/security/apply/data_type.md
+        - Enhanced Firewall Policy: commands/security/apply/enhanced_firewall_policy.md
+        - Fast ACL: commands/security/apply/fast_acl.md
+        - Fast ACL Rule: commands/security/apply/fast_acl_rule.md
+        - Filter Set: commands/security/apply/filter_set.md
+        - Geo Location Set: commands/security/apply/geo_location_set.md
+        - Malicious User Mitigation: commands/security/apply/malicious_user_mitigation.md
+        - Policer: commands/security/apply/policer.md
+        - Protocol Inspection: commands/security/apply/protocol_inspection.md
+        - Protocol Policer: commands/security/apply/protocol_policer.md
+        - Rate Limiter: commands/security/apply/rate_limiter.md
+        - Rate Limiter Policy: commands/security/apply/rate_limiter_policy.md
+        - Secret Management Access: commands/security/apply/secret_management_access.md
+        - Secret Policy: commands/security/apply/secret_policy.md
+        - Secret Policy Rule: commands/security/apply/secret_policy_rule.md
+        - Service Policy: commands/security/apply/service_policy.md
+        - Service Policy Rule: commands/security/apply/service_policy_rule.md
+        - Trusted CA List: commands/security/apply/trusted_ca_list.md
+        - Voltshare Admin Policy: commands/security/apply/voltshare_admin_policy.md
+        - WAF Exclusion Policy: commands/security/apply/waf_exclusion_policy.md
+      - Create:
+        - Create Overview: commands/security/create/index.md
+        - API Definition: commands/security/create/api_definition.md
+        - App Firewall: commands/security/create/app_firewall.md
+        - Bot Defense App Infrastructure: commands/security/create/bot_defense_app_infrastructure.md
+        - CRL: commands/security/create/crl.md
+        - Data Type: commands/security/create/data_type.md
+        - Enhanced Firewall Policy: commands/security/create/enhanced_firewall_policy.md
+        - Fast ACL: commands/security/create/fast_acl.md
+        - Fast ACL Rule: commands/security/create/fast_acl_rule.md
+        - Filter Set: commands/security/create/filter_set.md
+        - Geo Location Set: commands/security/create/geo_location_set.md
+        - Malicious User Mitigation: commands/security/create/malicious_user_mitigation.md
+        - Policer: commands/security/create/policer.md
+        - Protocol Inspection: commands/security/create/protocol_inspection.md
+        - Protocol Policer: commands/security/create/protocol_policer.md
+        - Rate Limiter: commands/security/create/rate_limiter.md
+        - Rate Limiter Policy: commands/security/create/rate_limiter_policy.md
+        - Secret Management Access: commands/security/create/secret_management_access.md
+        - Secret Policy: commands/security/create/secret_policy.md
+        - Secret Policy Rule: commands/security/create/secret_policy_rule.md
+        - Service Policy: commands/security/create/service_policy.md
+        - Service Policy Rule: commands/security/create/service_policy_rule.md
+        - Trusted CA List: commands/security/create/trusted_ca_list.md
+        - Voltshare Admin Policy: commands/security/create/voltshare_admin_policy.md
+        - WAF Exclusion Policy: commands/security/create/waf_exclusion_policy.md
+      - Delete:
+        - Delete Overview: commands/security/delete/index.md
+        - API Definition: commands/security/delete/api_definition.md
+        - App Firewall: commands/security/delete/app_firewall.md
+        - Bot Defense App Infrastructure: commands/security/delete/bot_defense_app_infrastructure.md
+        - CRL: commands/security/delete/crl.md
+        - Data Type: commands/security/delete/data_type.md
+        - Enhanced Firewall Policy: commands/security/delete/enhanced_firewall_policy.md
+        - Fast ACL: commands/security/delete/fast_acl.md
+        - Fast ACL Rule: commands/security/delete/fast_acl_rule.md
+        - Filter Set: commands/security/delete/filter_set.md
+        - Geo Location Set: commands/security/delete/geo_location_set.md
+        - Malicious User Mitigation: commands/security/delete/malicious_user_mitigation.md
+        - Policer: commands/security/delete/policer.md
+        - Protocol Inspection: commands/security/delete/protocol_inspection.md
+        - Protocol Policer: commands/security/delete/protocol_policer.md
+        - Rate Limiter: commands/security/delete/rate_limiter.md
+        - Rate Limiter Policy: commands/security/delete/rate_limiter_policy.md
+        - Secret Management Access: commands/security/delete/secret_management_access.md
+        - Secret Policy: commands/security/delete/secret_policy.md
+        - Secret Policy Rule: commands/security/delete/secret_policy_rule.md
+        - Service Policy: commands/security/delete/service_policy.md
+        - Service Policy Rule: commands/security/delete/service_policy_rule.md
+        - Trusted CA List: commands/security/delete/trusted_ca_list.md
+        - Voltshare Admin Policy: commands/security/delete/voltshare_admin_policy.md
+        - WAF Exclusion Policy: commands/security/delete/waf_exclusion_policy.md
+      - Get:
+        - Get Overview: commands/security/get/index.md
+        - API Definition: commands/security/get/api_definition.md
+        - App Firewall: commands/security/get/app_firewall.md
+        - Bot Defense App Infrastructure: commands/security/get/bot_defense_app_infrastructure.md
+        - CRL: commands/security/get/crl.md
+        - Data Type: commands/security/get/data_type.md
+        - Enhanced Firewall Policy: commands/security/get/enhanced_firewall_policy.md
+        - Fast ACL: commands/security/get/fast_acl.md
+        - Fast ACL Rule: commands/security/get/fast_acl_rule.md
+        - Filter Set: commands/security/get/filter_set.md
+        - Geo Location Set: commands/security/get/geo_location_set.md
+        - Malicious User Mitigation: commands/security/get/malicious_user_mitigation.md
+        - Policer: commands/security/get/policer.md
+        - Protocol Inspection: commands/security/get/protocol_inspection.md
+        - Protocol Policer: commands/security/get/protocol_policer.md
+        - Rate Limiter: commands/security/get/rate_limiter.md
+        - Rate Limiter Policy: commands/security/get/rate_limiter_policy.md
+        - Secret Management Access: commands/security/get/secret_management_access.md
+        - Secret Policy: commands/security/get/secret_policy.md
+        - Secret Policy Rule: commands/security/get/secret_policy_rule.md
+        - Service Policy: commands/security/get/service_policy.md
+        - Service Policy Rule: commands/security/get/service_policy_rule.md
+        - Trusted CA List: commands/security/get/trusted_ca_list.md
+        - Voltshare Admin Policy: commands/security/get/voltshare_admin_policy.md
+        - WAF Exclusion Policy: commands/security/get/waf_exclusion_policy.md
+      - List:
+        - List Overview: commands/security/list/index.md
+        - API Definition: commands/security/list/api_definition.md
+        - App Firewall: commands/security/list/app_firewall.md
+        - Bot Defense App Infrastructure: commands/security/list/bot_defense_app_infrastructure.md
+        - CRL: commands/security/list/crl.md
+        - Data Type: commands/security/list/data_type.md
+        - Enhanced Firewall Policy: commands/security/list/enhanced_firewall_policy.md
+        - Fast ACL: commands/security/list/fast_acl.md
+        - Fast ACL Rule: commands/security/list/fast_acl_rule.md
+        - Filter Set: commands/security/list/filter_set.md
+        - Geo Location Set: commands/security/list/geo_location_set.md
+        - Malicious User Mitigation: commands/security/list/malicious_user_mitigation.md
+        - Policer: commands/security/list/policer.md
+        - Protocol Inspection: commands/security/list/protocol_inspection.md
+        - Protocol Policer: commands/security/list/protocol_policer.md
+        - Rate Limiter: commands/security/list/rate_limiter.md
+        - Rate Limiter Policy: commands/security/list/rate_limiter_policy.md
+        - Secret Management Access: commands/security/list/secret_management_access.md
+        - Secret Policy: commands/security/list/secret_policy.md
+        - Secret Policy Rule: commands/security/list/secret_policy_rule.md
+        - Service Policy: commands/security/list/service_policy.md
+        - Service Policy Rule: commands/security/list/service_policy_rule.md
+        - Trusted CA List: commands/security/list/trusted_ca_list.md
+        - Voltshare Admin Policy: commands/security/list/voltshare_admin_policy.md
+        - WAF Exclusion Policy: commands/security/list/waf_exclusion_policy.md
+      - Patch:
+        - Patch Overview: commands/security/patch/index.md
+        - API Definition: commands/security/patch/api_definition.md
+        - App Firewall: commands/security/patch/app_firewall.md
+        - Bot Defense App Infrastructure: commands/security/patch/bot_defense_app_infrastructure.md
+        - CRL: commands/security/patch/crl.md
+        - Data Type: commands/security/patch/data_type.md
+        - Enhanced Firewall Policy: commands/security/patch/enhanced_firewall_policy.md
+        - Fast ACL: commands/security/patch/fast_acl.md
+        - Fast ACL Rule: commands/security/patch/fast_acl_rule.md
+        - Filter Set: commands/security/patch/filter_set.md
+        - Geo Location Set: commands/security/patch/geo_location_set.md
+        - Malicious User Mitigation: commands/security/patch/malicious_user_mitigation.md
+        - Policer: commands/security/patch/policer.md
+        - Protocol Inspection: commands/security/patch/protocol_inspection.md
+        - Protocol Policer: commands/security/patch/protocol_policer.md
+        - Rate Limiter: commands/security/patch/rate_limiter.md
+        - Rate Limiter Policy: commands/security/patch/rate_limiter_policy.md
+        - Secret Management Access: commands/security/patch/secret_management_access.md
+        - Secret Policy: commands/security/patch/secret_policy.md
+        - Secret Policy Rule: commands/security/patch/secret_policy_rule.md
+        - Service Policy: commands/security/patch/service_policy.md
+        - Service Policy Rule: commands/security/patch/service_policy_rule.md
+        - Trusted CA List: commands/security/patch/trusted_ca_list.md
+        - Voltshare Admin Policy: commands/security/patch/voltshare_admin_policy.md
+        - WAF Exclusion Policy: commands/security/patch/waf_exclusion_policy.md
+      - Remove Labels:
+        - Remove Labels Overview: commands/security/remove-labels/index.md
+        - API Definition: commands/security/remove-labels/api_definition.md
+        - App Firewall: commands/security/remove-labels/app_firewall.md
+        - Bot Defense App Infrastructure: commands/security/remove-labels/bot_defense_app_infrastructure.md
+        - CRL: commands/security/remove-labels/crl.md
+        - Data Type: commands/security/remove-labels/data_type.md
+        - Enhanced Firewall Policy: commands/security/remove-labels/enhanced_firewall_policy.md
+        - Fast ACL: commands/security/remove-labels/fast_acl.md
+        - Fast ACL Rule: commands/security/remove-labels/fast_acl_rule.md
+        - Filter Set: commands/security/remove-labels/filter_set.md
+        - Geo Location Set: commands/security/remove-labels/geo_location_set.md
+        - Malicious User Mitigation: commands/security/remove-labels/malicious_user_mitigation.md
+        - Policer: commands/security/remove-labels/policer.md
+        - Protocol Inspection: commands/security/remove-labels/protocol_inspection.md
+        - Protocol Policer: commands/security/remove-labels/protocol_policer.md
+        - Rate Limiter: commands/security/remove-labels/rate_limiter.md
+        - Rate Limiter Policy: commands/security/remove-labels/rate_limiter_policy.md
+        - Secret Management Access: commands/security/remove-labels/secret_management_access.md
+        - Secret Policy: commands/security/remove-labels/secret_policy.md
+        - Secret Policy Rule: commands/security/remove-labels/secret_policy_rule.md
+        - Service Policy: commands/security/remove-labels/service_policy.md
+        - Service Policy Rule: commands/security/remove-labels/service_policy_rule.md
+        - Trusted CA List: commands/security/remove-labels/trusted_ca_list.md
+        - Voltshare Admin Policy: commands/security/remove-labels/voltshare_admin_policy.md
+        - WAF Exclusion Policy: commands/security/remove-labels/waf_exclusion_policy.md
+      - Replace:
+        - Replace Overview: commands/security/replace/index.md
+        - API Definition: commands/security/replace/api_definition.md
+        - App Firewall: commands/security/replace/app_firewall.md
+        - Bot Defense App Infrastructure: commands/security/replace/bot_defense_app_infrastructure.md
+        - CRL: commands/security/replace/crl.md
+        - Data Type: commands/security/replace/data_type.md
+        - Enhanced Firewall Policy: commands/security/replace/enhanced_firewall_policy.md
+        - Fast ACL: commands/security/replace/fast_acl.md
+        - Fast ACL Rule: commands/security/replace/fast_acl_rule.md
+        - Filter Set: commands/security/replace/filter_set.md
+        - Geo Location Set: commands/security/replace/geo_location_set.md
+        - Malicious User Mitigation: commands/security/replace/malicious_user_mitigation.md
+        - Policer: commands/security/replace/policer.md
+        - Protocol Inspection: commands/security/replace/protocol_inspection.md
+        - Protocol Policer: commands/security/replace/protocol_policer.md
+        - Rate Limiter: commands/security/replace/rate_limiter.md
+        - Rate Limiter Policy: commands/security/replace/rate_limiter_policy.md
+        - Secret Management Access: commands/security/replace/secret_management_access.md
+        - Secret Policy: commands/security/replace/secret_policy.md
+        - Secret Policy Rule: commands/security/replace/secret_policy_rule.md
+        - Service Policy: commands/security/replace/service_policy.md
+        - Service Policy Rule: commands/security/replace/service_policy_rule.md
+        - Trusted CA List: commands/security/replace/trusted_ca_list.md
+        - Voltshare Admin Policy: commands/security/replace/voltshare_admin_policy.md
+        - WAF Exclusion Policy: commands/security/replace/waf_exclusion_policy.md
+      - Status:
+        - Status Overview: commands/security/status/index.md
+        - API Definition: commands/security/status/api_definition.md
+        - App Firewall: commands/security/status/app_firewall.md
+        - Bot Defense App Infrastructure: commands/security/status/bot_defense_app_infrastructure.md
+        - CRL: commands/security/status/crl.md
+        - Data Type: commands/security/status/data_type.md
+        - Enhanced Firewall Policy: commands/security/status/enhanced_firewall_policy.md
+        - Fast ACL: commands/security/status/fast_acl.md
+        - Fast ACL Rule: commands/security/status/fast_acl_rule.md
+        - Filter Set: commands/security/status/filter_set.md
+        - Geo Location Set: commands/security/status/geo_location_set.md
+        - Malicious User Mitigation: commands/security/status/malicious_user_mitigation.md
+        - Policer: commands/security/status/policer.md
+        - Protocol Inspection: commands/security/status/protocol_inspection.md
+        - Protocol Policer: commands/security/status/protocol_policer.md
+        - Rate Limiter: commands/security/status/rate_limiter.md
+        - Rate Limiter Policy: commands/security/status/rate_limiter_policy.md
+        - Secret Management Access: commands/security/status/secret_management_access.md
+        - Secret Policy: commands/security/status/secret_policy.md
+        - Secret Policy Rule: commands/security/status/secret_policy_rule.md
+        - Service Policy: commands/security/status/service_policy.md
+        - Service Policy Rule: commands/security/status/service_policy_rule.md
+        - Trusted CA List: commands/security/status/trusted_ca_list.md
+        - Voltshare Admin Policy: commands/security/status/voltshare_admin_policy.md
+        - WAF Exclusion Policy: commands/security/status/waf_exclusion_policy.md
+    - Service Mesh:
+      - Service Mesh Overview: commands/service_mesh/index.md
+      - Add Labels:
+        - Add Labels Overview: commands/service_mesh/add-labels/index.md
+        - Cluster: commands/service_mesh/add-labels/cluster.md
+        - Container Registry: commands/service_mesh/add-labels/container_registry.md
+        - Discovery: commands/service_mesh/add-labels/discovery.md
+        - Endpoint: commands/service_mesh/add-labels/endpoint.md
+        - Nfv Service: commands/service_mesh/add-labels/nfv_service.md
+      - Apply:
+        - Apply Overview: commands/service_mesh/apply/index.md
+        - Cluster: commands/service_mesh/apply/cluster.md
+        - Container Registry: commands/service_mesh/apply/container_registry.md
+        - Discovery: commands/service_mesh/apply/discovery.md
+        - Endpoint: commands/service_mesh/apply/endpoint.md
+        - Nfv Service: commands/service_mesh/apply/nfv_service.md
+      - Create:
+        - Create Overview: commands/service_mesh/create/index.md
+        - Cluster: commands/service_mesh/create/cluster.md
+        - Container Registry: commands/service_mesh/create/container_registry.md
+        - Discovery: commands/service_mesh/create/discovery.md
+        - Endpoint: commands/service_mesh/create/endpoint.md
+        - Nfv Service: commands/service_mesh/create/nfv_service.md
+      - Delete:
+        - Delete Overview: commands/service_mesh/delete/index.md
+        - Cluster: commands/service_mesh/delete/cluster.md
+        - Container Registry: commands/service_mesh/delete/container_registry.md
+        - Discovery: commands/service_mesh/delete/discovery.md
+        - Endpoint: commands/service_mesh/delete/endpoint.md
+        - Nfv Service: commands/service_mesh/delete/nfv_service.md
+      - Get:
+        - Get Overview: commands/service_mesh/get/index.md
+        - Cluster: commands/service_mesh/get/cluster.md
+        - Container Registry: commands/service_mesh/get/container_registry.md
+        - Discovery: commands/service_mesh/get/discovery.md
+        - Endpoint: commands/service_mesh/get/endpoint.md
+        - Nfv Service: commands/service_mesh/get/nfv_service.md
+      - List:
+        - List Overview: commands/service_mesh/list/index.md
+        - Cluster: commands/service_mesh/list/cluster.md
+        - Container Registry: commands/service_mesh/list/container_registry.md
+        - Discovery: commands/service_mesh/list/discovery.md
+        - Endpoint: commands/service_mesh/list/endpoint.md
+        - Nfv Service: commands/service_mesh/list/nfv_service.md
+      - Patch:
+        - Patch Overview: commands/service_mesh/patch/index.md
+        - Cluster: commands/service_mesh/patch/cluster.md
+        - Container Registry: commands/service_mesh/patch/container_registry.md
+        - Discovery: commands/service_mesh/patch/discovery.md
+        - Endpoint: commands/service_mesh/patch/endpoint.md
+        - Nfv Service: commands/service_mesh/patch/nfv_service.md
+      - Remove Labels:
+        - Remove Labels Overview: commands/service_mesh/remove-labels/index.md
+        - Cluster: commands/service_mesh/remove-labels/cluster.md
+        - Container Registry: commands/service_mesh/remove-labels/container_registry.md
+        - Discovery: commands/service_mesh/remove-labels/discovery.md
+        - Endpoint: commands/service_mesh/remove-labels/endpoint.md
+        - Nfv Service: commands/service_mesh/remove-labels/nfv_service.md
+      - Replace:
+        - Replace Overview: commands/service_mesh/replace/index.md
+        - Cluster: commands/service_mesh/replace/cluster.md
+        - Container Registry: commands/service_mesh/replace/container_registry.md
+        - Discovery: commands/service_mesh/replace/discovery.md
+        - Endpoint: commands/service_mesh/replace/endpoint.md
+        - Nfv Service: commands/service_mesh/replace/nfv_service.md
+      - Status:
+        - Status Overview: commands/service_mesh/status/index.md
+        - Cluster: commands/service_mesh/status/cluster.md
+        - Container Registry: commands/service_mesh/status/container_registry.md
+        - Discovery: commands/service_mesh/status/discovery.md
+        - Endpoint: commands/service_mesh/status/endpoint.md
+        - Nfv Service: commands/service_mesh/status/nfv_service.md
+    - Shape Security:
+      - Shape Security Overview: commands/shape_security/index.md
+      - Add Labels: commands/shape_security/add-labels/index.md
+      - Apply: commands/shape_security/apply/index.md
+      - Create: commands/shape_security/create/index.md
+      - Delete: commands/shape_security/delete/index.md
+      - Get: commands/shape_security/get/index.md
+      - List: commands/shape_security/list/index.md
+      - Patch: commands/shape_security/patch/index.md
+      - Remove Labels: commands/shape_security/remove-labels/index.md
+      - Replace: commands/shape_security/replace/index.md
+      - Status: commands/shape_security/status/index.md
     - Site:
       - Site Overview: commands/site/index.md
       - AWS VPC:
@@ -587,13 +1927,129 @@ nav:
         - Replace: commands/site/azure_vnet/replace.md
         - Run: commands/site/azure_vnet/run.md
     - Subscription:
-      - Overview: commands/subscription/index.md
+      - Subscription Overview: commands/subscription/index.md
       - Activate: commands/subscription/activate/index.md
       - Activation Status: commands/subscription/activation-status/index.md
       - Addons: commands/subscription/addons/index.md
       - Quota: commands/subscription/quota/index.md
       - Show: commands/subscription/show/index.md
       - Validate: commands/subscription/validate/index.md
+    - Subscriptions:
+      - Subscriptions Overview: commands/subscriptions/index.md
+      - Add Labels: commands/subscriptions/add-labels/index.md
+      - Apply: commands/subscriptions/apply/index.md
+      - Create: commands/subscriptions/create/index.md
+      - Delete: commands/subscriptions/delete/index.md
+      - Get: commands/subscriptions/get/index.md
+      - List: commands/subscriptions/list/index.md
+      - Patch: commands/subscriptions/patch/index.md
+      - Remove Labels: commands/subscriptions/remove-labels/index.md
+      - Replace: commands/subscriptions/replace/index.md
+      - Status: commands/subscriptions/status/index.md
+    - Tenant Management:
+      - Tenant Management Overview: commands/tenant_management/index.md
+      - Add Labels:
+        - Add Labels Overview: commands/tenant_management/add-labels/index.md
+        - Tenant Configuration: commands/tenant_management/add-labels/tenant_configuration.md
+      - Apply:
+        - Apply Overview: commands/tenant_management/apply/index.md
+        - Tenant Configuration: commands/tenant_management/apply/tenant_configuration.md
+      - Create:
+        - Create Overview: commands/tenant_management/create/index.md
+        - Tenant Configuration: commands/tenant_management/create/tenant_configuration.md
+      - Delete:
+        - Delete Overview: commands/tenant_management/delete/index.md
+        - Tenant Configuration: commands/tenant_management/delete/tenant_configuration.md
+      - Get:
+        - Get Overview: commands/tenant_management/get/index.md
+        - Tenant Configuration: commands/tenant_management/get/tenant_configuration.md
+      - List:
+        - List Overview: commands/tenant_management/list/index.md
+        - Tenant Configuration: commands/tenant_management/list/tenant_configuration.md
+      - Patch:
+        - Patch Overview: commands/tenant_management/patch/index.md
+        - Tenant Configuration: commands/tenant_management/patch/tenant_configuration.md
+      - Remove Labels:
+        - Remove Labels Overview: commands/tenant_management/remove-labels/index.md
+        - Tenant Configuration: commands/tenant_management/remove-labels/tenant_configuration.md
+      - Replace:
+        - Replace Overview: commands/tenant_management/replace/index.md
+        - Tenant Configuration: commands/tenant_management/replace/tenant_configuration.md
+      - Status:
+        - Status Overview: commands/tenant_management/status/index.md
+        - Tenant Configuration: commands/tenant_management/status/tenant_configuration.md
+    - VPN:
+      - VPN Overview: commands/vpn/index.md
+      - Add Labels:
+        - Add Labels Overview: commands/vpn/add-labels/index.md
+        - Ike1: commands/vpn/add-labels/ike1.md
+        - Ike2: commands/vpn/add-labels/ike2.md
+        - IKE Phase1 Profile: commands/vpn/add-labels/ike_phase1_profile.md
+        - IKE Phase2 Profile: commands/vpn/add-labels/ike_phase2_profile.md
+        - Tunnel: commands/vpn/add-labels/tunnel.md
+      - Apply:
+        - Apply Overview: commands/vpn/apply/index.md
+        - Ike1: commands/vpn/apply/ike1.md
+        - Ike2: commands/vpn/apply/ike2.md
+        - IKE Phase1 Profile: commands/vpn/apply/ike_phase1_profile.md
+        - IKE Phase2 Profile: commands/vpn/apply/ike_phase2_profile.md
+        - Tunnel: commands/vpn/apply/tunnel.md
+      - Create:
+        - Create Overview: commands/vpn/create/index.md
+        - Ike1: commands/vpn/create/ike1.md
+        - Ike2: commands/vpn/create/ike2.md
+        - IKE Phase1 Profile: commands/vpn/create/ike_phase1_profile.md
+        - IKE Phase2 Profile: commands/vpn/create/ike_phase2_profile.md
+        - Tunnel: commands/vpn/create/tunnel.md
+      - Delete:
+        - Delete Overview: commands/vpn/delete/index.md
+        - Ike1: commands/vpn/delete/ike1.md
+        - Ike2: commands/vpn/delete/ike2.md
+        - IKE Phase1 Profile: commands/vpn/delete/ike_phase1_profile.md
+        - IKE Phase2 Profile: commands/vpn/delete/ike_phase2_profile.md
+        - Tunnel: commands/vpn/delete/tunnel.md
+      - Get:
+        - Get Overview: commands/vpn/get/index.md
+        - Ike1: commands/vpn/get/ike1.md
+        - Ike2: commands/vpn/get/ike2.md
+        - IKE Phase1 Profile: commands/vpn/get/ike_phase1_profile.md
+        - IKE Phase2 Profile: commands/vpn/get/ike_phase2_profile.md
+        - Tunnel: commands/vpn/get/tunnel.md
+      - List:
+        - List Overview: commands/vpn/list/index.md
+        - Ike1: commands/vpn/list/ike1.md
+        - Ike2: commands/vpn/list/ike2.md
+        - IKE Phase1 Profile: commands/vpn/list/ike_phase1_profile.md
+        - IKE Phase2 Profile: commands/vpn/list/ike_phase2_profile.md
+        - Tunnel: commands/vpn/list/tunnel.md
+      - Patch:
+        - Patch Overview: commands/vpn/patch/index.md
+        - Ike1: commands/vpn/patch/ike1.md
+        - Ike2: commands/vpn/patch/ike2.md
+        - IKE Phase1 Profile: commands/vpn/patch/ike_phase1_profile.md
+        - IKE Phase2 Profile: commands/vpn/patch/ike_phase2_profile.md
+        - Tunnel: commands/vpn/patch/tunnel.md
+      - Remove Labels:
+        - Remove Labels Overview: commands/vpn/remove-labels/index.md
+        - Ike1: commands/vpn/remove-labels/ike1.md
+        - Ike2: commands/vpn/remove-labels/ike2.md
+        - IKE Phase1 Profile: commands/vpn/remove-labels/ike_phase1_profile.md
+        - IKE Phase2 Profile: commands/vpn/remove-labels/ike_phase2_profile.md
+        - Tunnel: commands/vpn/remove-labels/tunnel.md
+      - Replace:
+        - Replace Overview: commands/vpn/replace/index.md
+        - Ike1: commands/vpn/replace/ike1.md
+        - Ike2: commands/vpn/replace/ike2.md
+        - IKE Phase1 Profile: commands/vpn/replace/ike_phase1_profile.md
+        - IKE Phase2 Profile: commands/vpn/replace/ike_phase2_profile.md
+        - Tunnel: commands/vpn/replace/tunnel.md
+      - Status:
+        - Status Overview: commands/vpn/status/index.md
+        - Ike1: commands/vpn/status/ike1.md
+        - Ike2: commands/vpn/status/ike2.md
+        - IKE Phase1 Profile: commands/vpn/status/ike_phase1_profile.md
+        - IKE Phase2 Profile: commands/vpn/status/ike_phase2_profile.md
+        - Tunnel: commands/vpn/status/tunnel.md
   - Guides:
     - guides/index.md
     - Load Balancers: guides/load-balancer.md


### PR DESCRIPTION
## Summary

Fix Documentation workflow failure caused by navigation mismatch in v5.0.0 breaking change.

**Status**: Resolves workflow failure with 269 navigation warnings → 0 warnings ✅

### Root Cause

v5.0.0 deleted the `f5xcctl configuration` command and replaced it with 22 domain-based commands (load_balancer, infrastructure, security, networking, etc.). The mkdocs.yml navigation still referenced 269 non-existent `commands/configuration/*.md` files, causing MkDocs strict build to fail with 269 warnings.

### Changes

1. **Regenerated command documentation** with v5.0.0 domain structure
2. **Updated mkdocs.yml navigation** - removed 269 configuration references, added 22 domain-based commands
3. **Fixed 3 cloudstatus nav entries** - corrected status/index.md → status.md paths

### Test Results

```
MkDocs Build (--strict): ✅ SUCCESS
- Before: 269 warnings (FAILED)
- After: 0 warnings (PASSED)
```

### Validation

- ✅ No orphaned `commands/configuration/` references
- ✅ All 22 domain commands in navigation (load_balancer, infrastructure, security, networking, observability, api_security, applications, bigip, billing, cdn, config, identity, monitoring, workspaces, etc.)
- ✅ Local mkdocs build passed with 0 warnings/errors
- ✅ Documentation built in 153 seconds

### Next Steps (Phase 2)

After this PR merges, we'll implement prevention measures:
1. Add breaking change detection to force doc regeneration on vX.0.0 releases
2. Add navigation validation step before MkDocs build
3. Enhance spec hash to include CLI version for better cache invalidation

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)