### PR TITLE
fix: standardize examples to use 'example-' prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,18 +26,18 @@ f5xcctl configuration list http_loadbalancer
   → f5xcctl lb list http_loadbalancer (using alias)
 
 # Get a resource
-f5xcctl configuration get origin_pool mypool -n production
-  → f5xcctl infrastructure get origin_pool mypool -n production
-  → f5xcctl infra get origin_pool mypool -n production (using alias)
+f5xcctl configuration get origin_pool example-pool -n production
+  → f5xcctl infrastructure get origin_pool example-pool -n production
+  → f5xcctl infra get origin_pool example-pool -n production (using alias)
 
 # Create a resource
 f5xcctl configuration create certificate -i cert.yaml
   → f5xcctl identity create certificate -i cert.yaml
 
 # Delete a resource
-f5xcctl configuration delete http_loadbalancer my-lb --yes
-  → f5xcctl load_balancer delete http_loadbalancer my-lb --yes
-  → f5xcctl lb delete http_loadbalancer my-lb --yes
+f5xcctl configuration delete http_loadbalancer example-lb --yes
+  → f5xcctl load_balancer delete http_loadbalancer example-lb --yes
+  → f5xcctl lb delete http_loadbalancer example-lb --yes
 ```
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ f5xcctl lb list http_loadbalancer -n production
 
 ```bash
 # Get a load balancer configuration
-f5xcctl load_balancer get http_loadbalancer my-lb
+f5xcctl load_balancer get http_loadbalancer example-lb
 
 # Get from specific namespace
-f5xcctl lb get http_loadbalancer my-lb -n production
+f5xcctl lb get http_loadbalancer example-lb -n production
 ```
 
 #### Create a Resource
@@ -77,17 +77,17 @@ f5xcctl lb get http_loadbalancer my-lb -n production
 f5xcctl load_balancer create http_loadbalancer -i lb-config.yaml
 
 # Create from inline JSON
-f5xcctl lb create origin_pool --json-data '{"metadata":{"name":"my-pool"},...}'
+f5xcctl lb create origin_pool --json-data '{"metadata":{"name":"example-pool"},...}'
 ```
 
 #### Delete a Resource
 
 ```bash
 # Delete with confirmation
-f5xcctl load_balancer delete http_loadbalancer my-lb
+f5xcctl load_balancer delete http_loadbalancer example-lb
 
 # Delete without confirmation (for scripts)
-f5xcctl lb delete http_loadbalancer my-lb --yes
+f5xcctl lb delete http_loadbalancer example-lb --yes
 ```
 
 #### Apply (Create or Update)

--- a/cmd/api_endpoint.go
+++ b/cmd/api_endpoint.go
@@ -54,10 +54,10 @@ COMMANDS:
 AI assistants should run 'discover' first to understand the service mesh
 topology before using 'control' to create security policies.`,
 	Example: `  # Discover API endpoints in a namespace
-  f5xcctl api-endpoint discover --namespace default --app-type my-app
+  f5xcctl api-endpoint discover --namespace default --app-type example-app
 
   # Create L7 policies from discovered endpoints
-  f5xcctl api-endpoint control --discover-ns default --app-type my-app
+  f5xcctl api-endpoint control --discover-ns default --app-type example-app
 
   # Check available commands
   f5xcctl api-endpoint --help`,

--- a/cmd/domains.go
+++ b/cmd/domains.go
@@ -239,10 +239,10 @@ Provide a YAML or JSON file with the resource configuration using --input-file.`
 		longDesc += "Provide a YAML or JSON file with the resource configuration."
 
 		exampleText := fmt.Sprintf(`  # Create from file
-  f5xcctl %s create %s -n my-namespace -i config.yaml
+  f5xcctl %s create %s -n example-namespace -i config.yaml
 
   # Create with JSON input
-  f5xcctl %s create %s -n my-namespace -i config.json`, domain, rt.Name, domain, rt.Name)
+  f5xcctl %s create %s -n example-namespace -i config.json`, domain, rt.Name, domain, rt.Name)
 
 		subCmd := &cobra.Command{
 			Use:     rt.Name,
@@ -302,10 +302,10 @@ Requires confirmation unless --yes is specified.`, domainInfo.DisplayName, domai
 		longDesc += "Requires confirmation unless --yes is specified."
 
 		exampleText := fmt.Sprintf(`  # Delete a resource (with confirmation)
-  f5xcctl %s delete %s -n my-namespace my-resource
+  f5xcctl %s delete %s -n example-namespace example-resource
 
   # Delete without confirmation
-  f5xcctl %s delete %s -n my-namespace my-resource --yes`, domain, rt.Name, domain, rt.Name)
+  f5xcctl %s delete %s -n example-namespace example-resource --yes`, domain, rt.Name, domain, rt.Name)
 
 		subCmd := &cobra.Command{
 			Use:               fmt.Sprintf("%s <name>", rt.Name),
@@ -369,7 +369,7 @@ Use apply for create-or-update semantics.`, domainInfo.DisplayName, domainInfo.D
 		longDesc += "This performs a complete replacement of the resource."
 
 		exampleText := fmt.Sprintf(`  # Replace from file
-  f5xcctl %s replace %s -n my-namespace my-resource -i updated-config.yaml`, domain, rt.Name)
+  f5xcctl %s replace %s -n example-namespace example-resource -i updated-config.yaml`, domain, rt.Name)
 
 		subCmd := &cobra.Command{
 			Use:     fmt.Sprintf("%s <name>", rt.Name),
@@ -429,7 +429,7 @@ Returns the current operational state and any relevant status information.`, dom
 		}
 
 		exampleText := fmt.Sprintf(`  # Check status
-  f5xcctl %s status %s -n my-namespace my-resource`, domain, rt.Name)
+  f5xcctl %s status %s -n example-namespace example-resource`, domain, rt.Name)
 
 		subCmd := &cobra.Command{
 			Use:               fmt.Sprintf("%s <name>", rt.Name),
@@ -492,7 +492,7 @@ If the resource exists, it will be updated. If it doesn't exist, it will be crea
 		longDesc += "If the resource exists, it will be updated. If it doesn't exist, it will be created."
 
 		exampleText := fmt.Sprintf(`  # Apply from file
-  f5xcctl %s apply %s -n my-namespace -i config.yaml`, domain, rt.Name)
+  f5xcctl %s apply %s -n example-namespace -i config.yaml`, domain, rt.Name)
 
 		subCmd := &cobra.Command{
 			Use:     rt.Name,
@@ -552,7 +552,7 @@ Only specified fields will be updated. Other fields remain unchanged.`, domainIn
 		longDesc += "Only specified fields will be updated."
 
 		exampleText := fmt.Sprintf(`  # Patch from file
-  f5xcctl %s patch %s -n my-namespace my-resource -i patch.yaml`, domain, rt.Name)
+  f5xcctl %s patch %s -n example-namespace example-resource -i patch.yaml`, domain, rt.Name)
 
 		subCmd := &cobra.Command{
 			Use:               fmt.Sprintf("%s <name>", rt.Name),
@@ -612,7 +612,7 @@ Specify label key-value pairs using --label-key and --label-value flags.`, domai
 		}
 
 		exampleText := fmt.Sprintf(`  # Add labels
-  f5xcctl %s add-labels %s -n my-namespace my-resource --label-key env --label-value prod`, domain, rt.Name)
+  f5xcctl %s add-labels %s -n example-namespace example-resource --label-key env --label-value prod`, domain, rt.Name)
 
 		subCmd := &cobra.Command{
 			Use:               fmt.Sprintf("%s <name>", rt.Name),
@@ -672,7 +672,7 @@ Specify the label keys to remove using --label-key flags.`, domainInfo.DisplayNa
 		}
 
 		exampleText := fmt.Sprintf(`  # Remove labels
-  f5xcctl %s remove-labels %s -n my-namespace my-resource --label-key env`, domain, rt.Name)
+  f5xcctl %s remove-labels %s -n example-namespace example-resource --label-key env`, domain, rt.Name)
 
 		subCmd := &cobra.Command{
 			Use:               fmt.Sprintf("%s <name>", rt.Name),

--- a/cmd/spec.go
+++ b/cmd/spec.go
@@ -334,7 +334,7 @@ func getAIHints() AIHintsSpec {
 			"Use --output-format json for programmatic parsing",
 			"Set F5XC_API_URL and F5XC_P12_FILE environment variables for persistent configuration",
 			"Use f5xcctl <domain> list <resource-type> to discover available resources (e.g., f5xcctl lb list http_loadbalancer)",
-			"Use f5xcctl <domain> get <resource-type> -n <namespace> <name> to retrieve specific resources (e.g., f5xcctl infra get origin_pool -n prod mypool)",
+			"Use f5xcctl <domain> get <resource-type> -n <namespace> <name> to retrieve specific resources (e.g., f5xcctl infra get origin_pool -n prod example-pool)",
 			"Always specify --namespace or -n for namespace-scoped resources",
 			"Use --spec to get complete CLI structure before constructing commands",
 			"Check exit codes for programmatic error handling (0=success, 1=generic, 2=validation, 3=auth, 4=connection, 5=not-found, 6=conflict, 7=rate-limit, 8=quota-exceeded, 9=feature-unavailable)",

--- a/docs/install/authentication.md
+++ b/docs/install/authentication.md
@@ -109,7 +109,7 @@ f5xcctl --api-token configuration list namespace
 
 ```bash
 export F5XC_API_TOKEN='your-api-token'
-f5xcctl login --tenant my-tenant --api-token
+f5xcctl login --tenant example-tenant --api-token
 ```
 
 ## Configuration File

--- a/docs/install/completions.md
+++ b/docs/install/completions.md
@@ -90,7 +90,7 @@ f5xcctl infrastructure get <TAB>
 f5xcctl load_balancer list http_loadbalancer -n <TAB>
 # Suggests: default, production, staging, etc. (from your F5 XC tenant)
 
-f5xcctl lb get origin_pool my-pool -n <TAB>
+f5xcctl lb get origin_pool example-pool -n <TAB>
 # Dynamic namespace completion for your specific namespace
 ```
 
@@ -99,7 +99,7 @@ f5xcctl lb get origin_pool my-pool -n <TAB>
 ```bash
 # Complete resource names (requires API access)
 f5xcctl load_balancer get http_loadbalancer <TAB>
-# Suggests: my-lb-1, prod-lb, staging-lb, etc. (from your namespace)
+# Suggests: example-lb-1, prod-lb, staging-lb, etc. (from your namespace)
 
 f5xcctl infrastructure delete origin_pool <TAB>
 # Shows available origin pools to delete
@@ -109,10 +109,10 @@ f5xcctl infrastructure delete origin_pool <TAB>
 
 ```bash
 # Complete label keys
-f5xcctl load_balancer add-labels http_loadbalancer my-lb --label-key <TAB>
+f5xcctl load_balancer add-labels http_loadbalancer example-lb --label-key <TAB>
 # Suggests: environment, application, owner, cost-center, tier, version
 
-f5xcctl lb add-labels http_loadbalancer my-lb -n production --label-key <TAB>
+f5xcctl lb add-labels http_loadbalancer example-lb -n production --label-key <TAB>
 # Common F5 XC label keys
 ```
 


### PR DESCRIPTION
## Summary

Standardize all example names to use `example-` prefix instead of `my-` prefix for consistency with OpenAPI and industry best practices.

## Changes

### Source Files (29 manual fixes)
- ✅ **cmd/domains.go**: 10 CRUD operation examples
  - Namespaces and resource names: `my-namespace`, `my-resource` → `example-namespace`, `example-resource`

- ✅ **cmd/api_endpoint.go**: 2 API endpoint examples
  - Application type: `my-app` → `example-app`

- ✅ **cmd/spec.go**: 1 CLI tips example
  - Resource pool: `mypool` → `example-pool` (added hyphen)

- ✅ **README.md**: 5 command examples
  - Load balancer and pool: `my-lb`, `my-pool` → `example-lb`, `example-pool`

- ✅ **CHANGELOG.md**: 6 historical examples
  - Updated v5 migration examples for consistency

- ✅ **docs/install/completions.md**: 4 shell completion examples
  - Resource names: `my-pool`, `my-lb`, `my-lb-1` → `example-*`

- ✅ **docs/install/authentication.md**: 1 login example
  - Tenant: `my-tenant` → `example-tenant`

### Auto-Generated Files (1,317 files)
- ⏳ **docs/commands/***: Will be regenerated automatically by CI

## Naming Convention Standard

- ✅ **Always use hyphens**: `example-pool` (NOT `examplepool`)
- ✅ **Consistent prefix**: All examples use `example-` prefix
- ✅ **Industry standard**: Follows OpenAPI best practices

## Validation

- ✅ All source violations fixed (29 instances)
- ✅ No "my-" patterns remain in source files
- ✅ All "example-" patterns use hyphens
- ✅ Tests pass: `go test ./pkg/...`
- ✅ Linting passes: `golangci-lint run` (0 issues)
- ✅ Build succeeds: `go build .`
- ✅ Help text shows new examples

## Testing

```bash
# Verify no "my-" patterns remain
grep -rn "my-namespace\|my-lb\|mypool" cmd/ README.md CHANGELOG.md docs/install/
# Result: No matches ✅

# Verify "example-" patterns present
grep -rn "example-namespace\|example-lb\|example-pool" cmd/ README.md CHANGELOG.md docs/install/ | wc -l
# Result: 48 matches ✅

# Verify binary help text
./f5xcctl load_balancer create http_loadbalancer --help | grep "example-namespace"
# Result: Shows example-namespace ✅
```

## CI Integration

When merged to main:
1. `docs.yml` workflow will trigger
2. `generate-docs.py` will regenerate 1,317 documentation files
3. All auto-generated examples will use new naming convention
4. GitHub Pages will deploy updated documentation

## Upstream Work

Issues to be filed in `robinmordasiewicz/f5xc-api-enriched`:
- [ ] Load balancer and networking specs (High priority)
- [ ] Configuration and identity specs (Medium priority)
- [ ] Other domain specs (Low priority)

## Checklist

- [x] All source violations fixed
- [x] Tests pass
- [x] Linting passes
- [x] Build succeeds
- [x] Manual verification of help text
- [x] Ready for CI validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)