### PR TITLE
fix: remove redundant cloudstatus docs generator

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -246,12 +246,38 @@ jobs:
             --clean \
             --update-mkdocs
 
-      - name: Generate cloudstatus documentation
+      - name: Validate cloudstatus documentation structure
         run: |
-          python scripts/generate-cloudstatus-docs.py \
-            --f5xcctl ./f5xcctl \
-            --output docs/commands/cloudstatus \
-            --clean
+          echo "=== Validating cloudstatus documentation structure ==="
+
+          # Define required files matching mkdocs.yml navigation
+          REQUIRED_FILES=(
+            "docs/commands/cloudstatus/status/index.md"
+            "docs/commands/cloudstatus/summary/index.md"
+            "docs/commands/cloudstatus/watch/index.md"
+            "docs/commands/cloudstatus/components/index.md"
+            "docs/commands/cloudstatus/incidents/index.md"
+            "docs/commands/cloudstatus/maintenance/index.md"
+            "docs/commands/cloudstatus/pops/index.md"
+          )
+
+          MISSING_FILES=()
+          for file in "${REQUIRED_FILES[@]}"; do
+            if [ ! -f "$file" ]; then
+              MISSING_FILES+=("$file")
+            fi
+          done
+
+          if [ ${#MISSING_FILES[@]} -gt 0 ]; then
+            echo "::error::Missing required cloudstatus documentation files"
+            printf '  ❌ %s\n' "${MISSING_FILES[@]}"
+            echo ""
+            echo "Generated structure:"
+            ls -R docs/commands/cloudstatus/ || echo "Directory not found"
+            exit 1
+          fi
+
+          echo "✅ All required cloudstatus documentation files present"
 
       - name: Save spec hash to cache
         run: |


### PR DESCRIPTION
## Summary

Remove the redundant `generate-cloudstatus-docs.py` step that was overwriting the correct documentation structure, causing MkDocs strict mode build failures.

## Problem

The Documentation workflow was failing because two scripts generated cloudstatus documentation in **different file structures**:

- **generate-docs.py** (correct): Creates `status/index.md`, `summary/index.md`, `watch/index.md` in subdirectories
- **generate-cloudstatus-docs.py** (wrong): Overwrites with flat files `status.md`, `summary.md`, `watch.md`

MkDocs navigation expects the directory structure with `index.md` files, so the second script's output causes strict mode failures.

## Solution

1. **Remove redundant generation step**: The main `generate-docs.py` script already handles all cloudstatus documentation correctly
2. **Add validation step**: Check that required cloudstatus files exist with the correct structure before MkDocs build runs

## Impact

- ✅ Eliminates recurring documentation build failures
- ✅ Simplifies workflow by removing redundant script
- ✅ Adds validation to catch structural issues early
- ✅ Low risk change - simplification that removes conflicts

## Testing

The fix has been validated:
- ✅ generate-docs.py creates correct structure (status/index.md, etc.)
- ✅ YAML syntax of workflow is valid
- ✅ Validation step will catch any future structural issues

Closes post-merge documentation workflow failures from PR #246.

🤖 Generated with [Claude Code](https://claude.com/claude-code)