### PR TITLE
fix: documentation generator flag compatibility

### DIFF
--- a/scripts/generate-docs.py
+++ b/scripts/generate-docs.py
@@ -1334,12 +1334,15 @@ f5xcctl {group} {action} {resource}
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Generate f5xcctl CLI documentation"
+        description="Generate CLI documentation"
     )
     parser.add_argument(
-        "--f5xcctl",
-        default="./f5xcctl",
-        help="Path to f5xcctl binary (default: ./f5xcctl)",
+        "--cli-binary",
+        "--f5xcctl",  # Keep as alias for backward compatibility
+        "--xcsh",     # New alias
+        dest="cli_binary",
+        default="./xcsh",
+        help="Path to CLI binary (default: ./xcsh)",
     )
     parser.add_argument(
         "--output",
@@ -1370,7 +1373,7 @@ def main():
     args = parser.parse_args()
 
     generator = VesctlDocsGenerator(
-        f5xcctl_path=args.f5xcctl,
+        f5xcctl_path=args.cli_binary,
         output_dir=args.output,
         template_dir=args.templates,
     )


### PR DESCRIPTION
Fixes #251

## Problem
Documentation workflow fails with:
```
generate-docs.py: error: unrecognized arguments: --xcsh ./xcsh
```

## Solution
Updated `generate-docs.py` to accept multiple flag aliases:
- `--cli-binary` (new primary, CLI-agnostic)
- `--f5xcctl` (backward compatibility)
- `--xcsh` (current workflow usage)

## Changes
- Updated argparse to accept all three flag names as aliases
- Changed internal variable: `args.f5xcctl` → `args.cli_binary`
- Updated help text to be CLI-name agnostic
- Default changed from `./f5xcctl` to `./xcsh`

## Testing
- ✅ Script accepts all three flag variants
- ⏳ Documentation workflow will test in CI

## Impact
- Fixes broken documentation generation workflow
- Maintains backward compatibility with old scripts
- Future-proof for any CLI name changes