### PR TITLE
chore: standardize to --cli-binary flag only

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -241,7 +241,7 @@ jobs:
       - name: Generate command documentation
         run: |
           python scripts/generate-docs.py \
-            --xcsh ./xcsh \
+            --cli-binary ./xcsh \
             --output docs/commands \
             --clean \
             --update-mkdocs

--- a/Makefile
+++ b/Makefile
@@ -238,11 +238,11 @@ PYTHON ?= python3
 DOCS_OUTPUT = docs/commands
 DOCS_TEMPLATES = scripts/templates
 
-# Generate documentation from f5xcctl --spec
+# Generate documentation from CLI spec
 docs: build
 	@echo "Generating documentation from CLI spec..."
 	@$(PYTHON) scripts/generate-docs.py \
-		--f5xcctl ./$(BINARY_NAME) \
+		--cli-binary ./$(BINARY_NAME) \
 		--output $(DOCS_OUTPUT) \
 		--templates $(DOCS_TEMPLATES) \
 		--clean \
@@ -272,7 +272,7 @@ docs: build
 docs-nav: build
 	@echo "Generating navigation structure..."
 	@$(PYTHON) scripts/generate-docs.py \
-		--f5xcctl ./$(BINARY_NAME) \
+		--cli-binary ./$(BINARY_NAME) \
 		--nav-only \
 		--update-mkdocs
 	@echo "Navigation updated in mkdocs.yml"
@@ -392,7 +392,7 @@ docs-all: build
 	@echo ""
 	@echo "Step 1/4: Command documentation..."
 	@$(PYTHON) scripts/generate-docs.py \
-		--f5xcctl ./$(BINARY_NAME) \
+		--cli-binary ./$(BINARY_NAME) \
 		--output $(DOCS_OUTPUT) \
 		--templates $(DOCS_TEMPLATES) \
 		--clean \

--- a/scripts/generate-cloudstatus-docs.py
+++ b/scripts/generate-cloudstatus-docs.py
@@ -23,11 +23,11 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 from naming import to_human_readable, normalize_acronyms, to_title_case
 
 
-def load_spec(f5xcctl_path: str) -> dict:
+def load_spec(cli_binary_path: str) -> dict:
     """Run f5xcctl --spec and return the full CLI spec."""
     try:
         result = subprocess.run(
-            [f5xcctl_path, "--spec", "--output-format", "json"],
+            [cli_binary_path, "--spec", "--output-format", "json"],
             capture_output=True,
             text=True,
             check=True
@@ -41,11 +41,11 @@ def load_spec(f5xcctl_path: str) -> dict:
         sys.exit(1)
 
 
-def load_cloudstatus_spec(f5xcctl_path: str) -> dict:
+def load_cloudstatus_spec(cli_binary_path: str) -> dict:
     """Run f5xcctl cloudstatus --spec for extended cloudstatus-specific data."""
     try:
         result = subprocess.run(
-            [f5xcctl_path, "cloudstatus", "--spec", "--output-format", "json"],
+            [cli_binary_path, "cloudstatus", "--spec", "--output-format", "json"],
             capture_output=True,
             text=True,
             check=True
@@ -311,12 +311,12 @@ def generate_nav_structure(cloudstatus_cmd: dict) -> list:
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Generate cloudstatus documentation from f5xcctl --spec"
+        description="Generate cloudstatus documentation from CLI --spec"
     )
     parser.add_argument(
-        "--f5xcctl",
-        default="./f5xcctl",
-        help="Path to f5xcctl binary (default: ./f5xcctl)"
+        "--cli-binary",
+        default="./xcsh",
+        help="Path to CLI binary (default: ./xcsh)"
     )
     parser.add_argument(
         "--output",
@@ -342,13 +342,13 @@ def main():
     args = parser.parse_args()
 
     # Resolve paths
-    f5xcctl_path = Path(args.f5xcctl).resolve()
+    cli_binary_path = Path(args.cli_binary).resolve()
     output_dir = Path(args.output)
     templates_dir = Path(args.templates)
 
-    # Verify f5xcctl exists
-    if not f5xcctl_path.exists():
-        print(f"Error: f5xcctl not found at {f5xcctl_path}", file=sys.stderr)
+    # Verify CLI binary exists
+    if not cli_binary_path.exists():
+        print(f"Error: CLI binary not found at {cli_binary_path}", file=sys.stderr)
         sys.exit(1)
 
     # Verify templates exist
@@ -356,9 +356,9 @@ def main():
         print(f"Error: Templates directory not found at {templates_dir}", file=sys.stderr)
         sys.exit(1)
 
-    print(f"Loading spec from {f5xcctl_path}...")
-    spec = load_spec(str(f5xcctl_path))
-    extended_spec = load_cloudstatus_spec(str(f5xcctl_path))
+    print(f"Loading spec from {cli_binary_path}...")
+    spec = load_spec(str(cli_binary_path))
+    extended_spec = load_cloudstatus_spec(str(cli_binary_path))
 
     # Find cloudstatus command
     cloudstatus_cmd = find_cloudstatus_command(spec)

--- a/scripts/generate-docs.py
+++ b/scripts/generate-docs.py
@@ -1338,9 +1338,6 @@ def main():
     )
     parser.add_argument(
         "--cli-binary",
-        "--f5xcctl",  # Keep as alias for backward compatibility
-        "--xcsh",     # New alias
-        dest="cli_binary",
         default="./xcsh",
         help="Path to CLI binary (default: ./xcsh)",
     )


### PR DESCRIPTION
Fixes #253

## Summary
Use **only** `--cli-binary` flag across all documentation generators. No backward compatibility.

## Changes

### Makefile (already done)
- `make docs`: uses `--cli-binary`
- `make docs-nav`: uses `--cli-binary`
- `make docs-all`: uses `--cli-binary`

### Python Scripts
**scripts/generate-docs.py**
- Removed `--f5xcctl` and `--xcsh` aliases
- Only accepts `--cli-binary`

**scripts/generate-cloudstatus-docs.py**  
- Removed `--f5xcctl` and `--xcsh` aliases
- Only accepts `--cli-binary`

### GitHub Workflow
**.github/workflows/docs.yml**
- Changed: `--xcsh ./xcsh` → `--cli-binary ./xcsh`

## Benefits
✅ Single canonical flag name  
✅ CLI-name agnostic (future-proof)  
✅ No confusion about which flag to use  
✅ Cleaner, simpler codebase  

## Migration
No migration needed - this is a breaking change but only affects internal tooling.