### PR TITLE
fix: update .gitignore binary names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Binaries
-f5xcctl
+xcsh
 *.exe
 *.exe~
 *.dll
@@ -60,12 +60,12 @@ site/
 .venv/
 __pycache__/
 *.pyc
-f5xcctl.darwin-arm64
+xcsh.darwin-arm64
 
 # Platform-specific binaries
-f5xcctl.darwin-*
-f5xcctl.linux-*
-f5xcctl.windows-*
+xcsh.darwin-*
+xcsh.linux-*
+xcsh.windows-*
 *.darwin-*
 *.linux-*
 *.windows-*


### PR DESCRIPTION
Update .gitignore to reflect new binary name `xcsh` instead of `f5xcctl`.

## Changes
- `f5xcctl` → `xcsh`
- `f5xcctl.darwin-*` → `xcsh.darwin-*`
- `f5xcctl.linux-*` → `xcsh.linux-*`
- `f5xcctl.windows-*` → `xcsh.windows-*`

Minor cleanup following PR #258.