### PR TITLE
fix: restore CHANGELOG.md after specs download to prevent dirty state

### DIFF
--- a/scripts/download-specs.sh
+++ b/scripts/download-specs.sh
@@ -225,3 +225,13 @@ fi
 log_success "Downloaded enriched specs $VERSION"
 log_info "Location: $SPECS_DIR/domains/"
 log_info "Domain files: $DOMAIN_COUNT"
+
+# Restore CHANGELOG.md to prevent git dirty state during releases
+# The downloaded specs ZIP may include a CHANGELOG.md that differs from our tracked version
+# This ensures GoReleaser's git validation passes without skipping any checks
+if [ -f "$SPECS_DIR/CHANGELOG.md" ] && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    if git ls-files --error-unmatch "$SPECS_DIR/CHANGELOG.md" >/dev/null 2>&1; then
+        log_info "Restoring CHANGELOG.md to tracked version..."
+        git checkout -- "$SPECS_DIR/CHANGELOG.md" 2>/dev/null && log_success "CHANGELOG.md restored" || log_warn "Could not restore CHANGELOG.md"
+    fi
+fi


### PR DESCRIPTION
## Summary

Fixes GoReleaser release workflow failure caused by 'git is in a dirty state' error.

### Root Cause
The `download-specs.sh` script extracts a ZIP file that includes a `CHANGELOG.md` differing from our tracked version. GoReleaser's git validation detects this modified file and fails.

### Solution
Instead of skipping validation (broad brush), this fix surgically restores the tracked `CHANGELOG.md` after ZIP extraction:

- ✅ GoReleaser's git validation passes without skipping any checks
- ✅ All other validation remains intact  
- ✅ Handles edge cases gracefully (non-git contexts, untracked files)
- ✅ Clear logging for debugging

### Changes
- `scripts/download-specs.sh`: Added git checkout to restore `CHANGELOG.md` after extraction

## Test Plan
- [x] Script handles git repo context check
- [x] Script handles tracked vs untracked file check
- [x] Graceful failure with warning if restore fails
- [ ] CI checks pass
- [ ] Release workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)