### PR TITLE
fix: correct cloudstatus nav paths and sync with API v1.0.46

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -252,9 +252,9 @@ jobs:
 
           # Define required files matching mkdocs.yml navigation
           REQUIRED_FILES=(
-            "docs/commands/cloudstatus/status/index.md"
-            "docs/commands/cloudstatus/summary/index.md"
-            "docs/commands/cloudstatus/watch/index.md"
+            "docs/commands/cloudstatus/status.md"
+            "docs/commands/cloudstatus/summary.md"
+            "docs/commands/cloudstatus/watch.md"
             "docs/commands/cloudstatus/components/index.md"
             "docs/commands/cloudstatus/incidents/index.md"
             "docs/commands/cloudstatus/maintenance/index.md"

--- a/docs/install/homebrew.md
+++ b/docs/install/homebrew.md
@@ -1,23 +1,24 @@
 # Homebrew (macOS/Linux)
 
-Install f5xcctl on macOS or Linux using Homebrew:
+Install xcsh on macOS or Linux using Homebrew:
 
 ```bash
 brew tap robinmordasiewicz/tap
-brew install --cask f5xcctl
+brew install --cask xcsh
 ```
+
 
 **Upgrade to latest version:**
 
 ```bash
 brew update
-brew upgrade --cask f5xcctl
+brew upgrade --cask xcsh
 ```
 
 **Uninstall:**
 
 ```bash
-brew uninstall --cask f5xcctl
+brew uninstall --cask xcsh
 ```
 
 ## Shell Completions
@@ -38,7 +39,7 @@ The Homebrew cask includes shell completions for bash, zsh, and fish. These are 
     autoload -Uz compinit && compinit
     ```
 
-    Restart your terminal and test with `f5xcctl <TAB>`.
+    Restart your terminal and test with `xcsh <TAB>`.
 
 === "Bash"
 
@@ -55,35 +56,35 @@ The Homebrew cask includes shell completions for bash, zsh, and fish. These are 
       . "$(brew --prefix)/etc/profile.d/bash_completion.sh"
     ```
 
-    Restart your terminal and test with `f5xcctl <TAB>`.
+    Restart your terminal and test with `xcsh <TAB>`.
 
 === "Fish"
 
     Completions work automatically if fish was installed via Homebrew.
 
-    Test with `f5xcctl <TAB>`.
+    Test with `xcsh <TAB>`.
 
 !!! tip "Troubleshooting Completions"
     If completions don't work after setup:
 
     1. Ensure you've restarted your terminal
     2. For zsh, try running `rm -f ~/.zcompdump*` then restart
-    3. Verify completions are installed: `ls $(brew --prefix)/share/zsh/site-functions/_f5xcctl`
+    3. Verify completions are installed: `ls $(brew --prefix)/share/zsh/site-functions/_xcsh`
 
 ## Verify Installation
 
-After installation, verify f5xcctl is working:
+After installation, verify xcsh is working:
 
 ```bash
-f5xcctl version
+xcsh version
 ```
 
 Expected output:
 
 ```text
-f5xcctl version 5.5.0
-  commit:   07f81eb
-  built:    2025-12-21T11:26:06Z
+xcsh version 5.20.0
+  commit:   4b7d694
+  built:    2025-12-24T23:26:49Z
   go:       go1.25.5
   platform: darwin/arm64 [Possible values: linux/amd64,linux/arm64,darwin/amd64,darwin/arm64]
 ```

--- a/docs/install/source.md
+++ b/docs/install/source.md
@@ -1,6 +1,6 @@
 # Build from Source
 
-Build f5xcctl directly from source code.
+Build xcsh directly from source code.
 
 ## Prerequisites
 
@@ -11,23 +11,26 @@ Building from source requires:
 | Go | go1.25.5 | `go version` |
 | Git | any | `git --version` |
 
+
 ## Clone Repository
 
 ```bash
-git clone https://github.com/robinmordasiewicz/f5xcctl.git
-cd f5xcctl
+git clone https://github.com/robinmordasiewicz/xcsh.git
+cd xcsh
 ```
+
 
 ## Build
 
 ```bash
-go build -o f5xcctl .
+go build -o xcsh .
 ```
+
 
 ## Verify Build
 
 ```bash
-./f5xcctl version
+./xcsh version
 ```
 
 Expected output shows version, commit hash, build timestamp, Go version, and platform.
@@ -40,13 +43,13 @@ Move the binary to your PATH:
 
     ```bash
     mkdir -p ~/.local/bin
-    mv f5xcctl ~/.local/bin/
+    mv xcsh ~/.local/bin/
     ```
 
 === "System Install"
 
     ```bash
-    sudo mv f5xcctl /usr/local/bin/
+    sudo mv xcsh /usr/local/bin/
     ```
 
 ## Build with Version Info
@@ -54,8 +57,9 @@ Move the binary to your PATH:
 For release-quality builds with embedded version information:
 
 ```bash
-go build -ldflags="-X github.com/robinmordasiewicz/f5xcctl/cmd.Version=dev \
-  -X github.com/robinmordasiewicz/f5xcctl/cmd.GitCommit=$(git rev-parse --short HEAD) \
-  -X github.com/robinmordasiewicz/f5xcctl/cmd.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-  -o f5xcctl .
+go build -ldflags="-X github.com/robinmordasiewicz/xcsh/cmd.Version=dev \
+  -X github.com/robinmordasiewicz/xcsh/cmd.GitCommit=$(git rev-parse --short HEAD) \
+  -X github.com/robinmordasiewicz/xcsh/cmd.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  -o xcsh .
 ```
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,126 +97,106 @@ nav:
     - Authentication: install/authentication.md
   - Commands:
     - Overview: commands/index.md
-    - Ai Intelligence:
-      - Ai Intelligence Overview: commands/ai_intelligence/index.md
-      - Add Labels: commands/ai_intelligence/add-labels/index.md
-      - Apply: commands/ai_intelligence/apply/index.md
-      - Create: commands/ai_intelligence/create/index.md
-      - Delete: commands/ai_intelligence/delete/index.md
-      - Get: commands/ai_intelligence/get/index.md
-      - List: commands/ai_intelligence/list/index.md
-      - Patch: commands/ai_intelligence/patch/index.md
-      - Remove Labels: commands/ai_intelligence/remove-labels/index.md
-      - Replace: commands/ai_intelligence/replace/index.md
-      - Status: commands/ai_intelligence/status/index.md
+    - Admin Console And Ui:
+      - Admin Console And Ui Overview: commands/admin_console_and_ui/index.md
+      - Add Labels: commands/admin_console_and_ui/add-labels/index.md
+      - Apply: commands/admin_console_and_ui/apply/index.md
+      - Create: commands/admin_console_and_ui/create/index.md
+      - Delete: commands/admin_console_and_ui/delete/index.md
+      - Get: commands/admin_console_and_ui/get/index.md
+      - List: commands/admin_console_and_ui/list/index.md
+      - Patch: commands/admin_console_and_ui/patch/index.md
+      - Remove Labels: commands/admin_console_and_ui/remove-labels/index.md
+      - Replace: commands/admin_console_and_ui/replace/index.md
+      - Status: commands/admin_console_and_ui/status/index.md
+    - API:
+      - API Overview: commands/api/index.md
+      - Add Labels:
+        - Add Labels Overview: commands/api/add-labels/index.md
+        - API Credential: commands/api/add-labels/api_credential.md
+        - API Definition: commands/api/add-labels/api_definition.md
+        - App API Group: commands/api/add-labels/app_api_group.md
+      - Apply:
+        - Apply Overview: commands/api/apply/index.md
+        - API Credential: commands/api/apply/api_credential.md
+        - API Definition: commands/api/apply/api_definition.md
+        - App API Group: commands/api/apply/app_api_group.md
+      - Create:
+        - Create Overview: commands/api/create/index.md
+        - API Credential: commands/api/create/api_credential.md
+        - API Definition: commands/api/create/api_definition.md
+        - App API Group: commands/api/create/app_api_group.md
+      - Delete:
+        - Delete Overview: commands/api/delete/index.md
+        - API Credential: commands/api/delete/api_credential.md
+        - API Definition: commands/api/delete/api_definition.md
+        - App API Group: commands/api/delete/app_api_group.md
+      - Get:
+        - Get Overview: commands/api/get/index.md
+        - API Credential: commands/api/get/api_credential.md
+        - API Definition: commands/api/get/api_definition.md
+        - App API Group: commands/api/get/app_api_group.md
+      - List:
+        - List Overview: commands/api/list/index.md
+        - API Credential: commands/api/list/api_credential.md
+        - API Definition: commands/api/list/api_definition.md
+        - App API Group: commands/api/list/app_api_group.md
+      - Patch:
+        - Patch Overview: commands/api/patch/index.md
+        - API Credential: commands/api/patch/api_credential.md
+        - API Definition: commands/api/patch/api_definition.md
+        - App API Group: commands/api/patch/app_api_group.md
+      - Remove Labels:
+        - Remove Labels Overview: commands/api/remove-labels/index.md
+        - API Credential: commands/api/remove-labels/api_credential.md
+        - API Definition: commands/api/remove-labels/api_definition.md
+        - App API Group: commands/api/remove-labels/app_api_group.md
+      - Replace:
+        - Replace Overview: commands/api/replace/index.md
+        - API Credential: commands/api/replace/api_credential.md
+        - API Definition: commands/api/replace/api_definition.md
+        - App API Group: commands/api/replace/app_api_group.md
+      - Status:
+        - Status Overview: commands/api/status/index.md
+        - API Credential: commands/api/status/api_credential.md
+        - API Definition: commands/api/status/api_definition.md
+        - App API Group: commands/api/status/app_api_group.md
     - API Endpoint:
       - API Endpoint Overview: commands/api-endpoint/index.md
       - Control: commands/api-endpoint/control/index.md
       - Discover: commands/api-endpoint/discover/index.md
-    - API Security:
-      - API Security Overview: commands/api_security/index.md
+    - Authentication:
+      - Authentication Overview: commands/authentication/index.md
       - Add Labels:
-        - Add Labels Overview: commands/api_security/add-labels/index.md
-        - App API Group: commands/api_security/add-labels/app_api_group.md
-        - Sensitive Data Policy: commands/api_security/add-labels/sensitive_data_policy.md
+        - Add Labels Overview: commands/authentication/add-labels/index.md
+        - API Credential: commands/authentication/add-labels/api_credential.md
       - Apply:
-        - Apply Overview: commands/api_security/apply/index.md
-        - App API Group: commands/api_security/apply/app_api_group.md
-        - Sensitive Data Policy: commands/api_security/apply/sensitive_data_policy.md
+        - Apply Overview: commands/authentication/apply/index.md
+        - API Credential: commands/authentication/apply/api_credential.md
       - Create:
-        - Create Overview: commands/api_security/create/index.md
-        - App API Group: commands/api_security/create/app_api_group.md
-        - Sensitive Data Policy: commands/api_security/create/sensitive_data_policy.md
+        - Create Overview: commands/authentication/create/index.md
+        - API Credential: commands/authentication/create/api_credential.md
       - Delete:
-        - Delete Overview: commands/api_security/delete/index.md
-        - App API Group: commands/api_security/delete/app_api_group.md
-        - Sensitive Data Policy: commands/api_security/delete/sensitive_data_policy.md
+        - Delete Overview: commands/authentication/delete/index.md
+        - API Credential: commands/authentication/delete/api_credential.md
       - Get:
-        - Get Overview: commands/api_security/get/index.md
-        - App API Group: commands/api_security/get/app_api_group.md
-        - Sensitive Data Policy: commands/api_security/get/sensitive_data_policy.md
+        - Get Overview: commands/authentication/get/index.md
+        - API Credential: commands/authentication/get/api_credential.md
       - List:
-        - List Overview: commands/api_security/list/index.md
-        - App API Group: commands/api_security/list/app_api_group.md
-        - Sensitive Data Policy: commands/api_security/list/sensitive_data_policy.md
+        - List Overview: commands/authentication/list/index.md
+        - API Credential: commands/authentication/list/api_credential.md
       - Patch:
-        - Patch Overview: commands/api_security/patch/index.md
-        - App API Group: commands/api_security/patch/app_api_group.md
-        - Sensitive Data Policy: commands/api_security/patch/sensitive_data_policy.md
+        - Patch Overview: commands/authentication/patch/index.md
+        - API Credential: commands/authentication/patch/api_credential.md
       - Remove Labels:
-        - Remove Labels Overview: commands/api_security/remove-labels/index.md
-        - App API Group: commands/api_security/remove-labels/app_api_group.md
-        - Sensitive Data Policy: commands/api_security/remove-labels/sensitive_data_policy.md
+        - Remove Labels Overview: commands/authentication/remove-labels/index.md
+        - API Credential: commands/authentication/remove-labels/api_credential.md
       - Replace:
-        - Replace Overview: commands/api_security/replace/index.md
-        - App API Group: commands/api_security/replace/app_api_group.md
-        - Sensitive Data Policy: commands/api_security/replace/sensitive_data_policy.md
+        - Replace Overview: commands/authentication/replace/index.md
+        - API Credential: commands/authentication/replace/api_credential.md
       - Status:
-        - Status Overview: commands/api_security/status/index.md
-        - App API Group: commands/api_security/status/app_api_group.md
-        - Sensitive Data Policy: commands/api_security/status/sensitive_data_policy.md
-    - Applications:
-      - Applications Overview: commands/applications/index.md
-      - Add Labels:
-        - Add Labels Overview: commands/applications/add-labels/index.md
-        - App Setting: commands/applications/add-labels/app_setting.md
-        - App Type: commands/applications/add-labels/app_type.md
-        - Workload: commands/applications/add-labels/workload.md
-        - Workload Flavor: commands/applications/add-labels/workload_flavor.md
-      - Apply:
-        - Apply Overview: commands/applications/apply/index.md
-        - App Setting: commands/applications/apply/app_setting.md
-        - App Type: commands/applications/apply/app_type.md
-        - Workload: commands/applications/apply/workload.md
-        - Workload Flavor: commands/applications/apply/workload_flavor.md
-      - Create:
-        - Create Overview: commands/applications/create/index.md
-        - App Setting: commands/applications/create/app_setting.md
-        - App Type: commands/applications/create/app_type.md
-        - Workload: commands/applications/create/workload.md
-        - Workload Flavor: commands/applications/create/workload_flavor.md
-      - Delete:
-        - Delete Overview: commands/applications/delete/index.md
-        - App Setting: commands/applications/delete/app_setting.md
-        - App Type: commands/applications/delete/app_type.md
-        - Workload: commands/applications/delete/workload.md
-        - Workload Flavor: commands/applications/delete/workload_flavor.md
-      - Get:
-        - Get Overview: commands/applications/get/index.md
-        - App Setting: commands/applications/get/app_setting.md
-        - App Type: commands/applications/get/app_type.md
-        - Workload: commands/applications/get/workload.md
-        - Workload Flavor: commands/applications/get/workload_flavor.md
-      - List:
-        - List Overview: commands/applications/list/index.md
-        - App Setting: commands/applications/list/app_setting.md
-        - App Type: commands/applications/list/app_type.md
-        - Workload: commands/applications/list/workload.md
-        - Workload Flavor: commands/applications/list/workload_flavor.md
-      - Patch:
-        - Patch Overview: commands/applications/patch/index.md
-        - App Setting: commands/applications/patch/app_setting.md
-        - App Type: commands/applications/patch/app_type.md
-        - Workload: commands/applications/patch/workload.md
-        - Workload Flavor: commands/applications/patch/workload_flavor.md
-      - Remove Labels:
-        - Remove Labels Overview: commands/applications/remove-labels/index.md
-        - App Setting: commands/applications/remove-labels/app_setting.md
-        - App Type: commands/applications/remove-labels/app_type.md
-        - Workload: commands/applications/remove-labels/workload.md
-        - Workload Flavor: commands/applications/remove-labels/workload_flavor.md
-      - Replace:
-        - Replace Overview: commands/applications/replace/index.md
-        - App Setting: commands/applications/replace/app_setting.md
-        - App Type: commands/applications/replace/app_type.md
-        - Workload: commands/applications/replace/workload.md
-        - Workload Flavor: commands/applications/replace/workload_flavor.md
-      - Status:
-        - Status Overview: commands/applications/status/index.md
-        - App Setting: commands/applications/status/app_setting.md
-        - App Type: commands/applications/status/app_type.md
-        - Workload: commands/applications/status/workload.md
-        - Workload Flavor: commands/applications/status/workload_flavor.md
+        - Status Overview: commands/authentication/status/index.md
+        - API Credential: commands/authentication/status/api_credential.md
     - BIG-IP:
       - BIG-IP Overview: commands/bigip/index.md
       - Add Labels:
@@ -259,70 +239,330 @@ nav:
         - Status Overview: commands/bigip/status/index.md
         - BIG-IP APM: commands/bigip/status/bigip_apm.md
         - BIG-IP iRule: commands/bigip/status/bigip_irule.md
-    - Billing:
-      - Billing Overview: commands/billing/index.md
+    - Billing And Usage:
+      - Billing And Usage Overview: commands/billing_and_usage/index.md
       - Add Labels:
-        - Add Labels Overview: commands/billing/add-labels/index.md
-        - Quota: commands/billing/add-labels/quota.md
-      - Apply: commands/billing/apply/index.md
-      - Create: commands/billing/create/index.md
-      - Delete: commands/billing/delete/index.md
+        - Add Labels Overview: commands/billing_and_usage/add-labels/index.md
+        - Quota: commands/billing_and_usage/add-labels/quota.md
+      - Apply: commands/billing_and_usage/apply/index.md
+      - Create: commands/billing_and_usage/create/index.md
+      - Delete: commands/billing_and_usage/delete/index.md
       - Get:
-        - Get Overview: commands/billing/get/index.md
-        - Quota: commands/billing/get/quota.md
+        - Get Overview: commands/billing_and_usage/get/index.md
+        - Quota: commands/billing_and_usage/get/quota.md
       - List:
-        - List Overview: commands/billing/list/index.md
-        - Quota: commands/billing/list/quota.md
-      - Patch: commands/billing/patch/index.md
+        - List Overview: commands/billing_and_usage/list/index.md
+        - Quota: commands/billing_and_usage/list/quota.md
+      - Patch: commands/billing_and_usage/patch/index.md
       - Remove Labels:
-        - Remove Labels Overview: commands/billing/remove-labels/index.md
-        - Quota: commands/billing/remove-labels/quota.md
-      - Replace: commands/billing/replace/index.md
+        - Remove Labels Overview: commands/billing_and_usage/remove-labels/index.md
+        - Quota: commands/billing_and_usage/remove-labels/quota.md
+      - Replace: commands/billing_and_usage/replace/index.md
       - Status:
-        - Status Overview: commands/billing/status/index.md
-        - Quota: commands/billing/status/quota.md
+        - Status Overview: commands/billing_and_usage/status/index.md
+        - Quota: commands/billing_and_usage/status/quota.md
+    - Blindfold:
+      - Blindfold Overview: commands/blindfold/index.md
+      - Add Labels:
+        - Add Labels Overview: commands/blindfold/add-labels/index.md
+        - Secret Policy: commands/blindfold/add-labels/secret_policy.md
+        - Secret Policy Rule: commands/blindfold/add-labels/secret_policy_rule.md
+      - Apply:
+        - Apply Overview: commands/blindfold/apply/index.md
+        - Secret Policy: commands/blindfold/apply/secret_policy.md
+        - Secret Policy Rule: commands/blindfold/apply/secret_policy_rule.md
+      - Create:
+        - Create Overview: commands/blindfold/create/index.md
+        - Secret Policy: commands/blindfold/create/secret_policy.md
+        - Secret Policy Rule: commands/blindfold/create/secret_policy_rule.md
+      - Delete:
+        - Delete Overview: commands/blindfold/delete/index.md
+        - Secret Policy: commands/blindfold/delete/secret_policy.md
+        - Secret Policy Rule: commands/blindfold/delete/secret_policy_rule.md
+      - Get:
+        - Get Overview: commands/blindfold/get/index.md
+        - Secret Policy: commands/blindfold/get/secret_policy.md
+        - Secret Policy Rule: commands/blindfold/get/secret_policy_rule.md
+      - List:
+        - List Overview: commands/blindfold/list/index.md
+        - Secret Policy: commands/blindfold/list/secret_policy.md
+        - Secret Policy Rule: commands/blindfold/list/secret_policy_rule.md
+      - Patch:
+        - Patch Overview: commands/blindfold/patch/index.md
+        - Secret Policy: commands/blindfold/patch/secret_policy.md
+        - Secret Policy Rule: commands/blindfold/patch/secret_policy_rule.md
+      - Remove Labels:
+        - Remove Labels Overview: commands/blindfold/remove-labels/index.md
+        - Secret Policy: commands/blindfold/remove-labels/secret_policy.md
+        - Secret Policy Rule: commands/blindfold/remove-labels/secret_policy_rule.md
+      - Replace:
+        - Replace Overview: commands/blindfold/replace/index.md
+        - Secret Policy: commands/blindfold/replace/secret_policy.md
+        - Secret Policy Rule: commands/blindfold/replace/secret_policy_rule.md
+      - Status:
+        - Status Overview: commands/blindfold/status/index.md
+        - Secret Policy: commands/blindfold/status/secret_policy.md
+        - Secret Policy Rule: commands/blindfold/status/secret_policy_rule.md
+    - Bot And Threat Defense:
+      - Bot And Threat Defense Overview: commands/bot_and_threat_defense/index.md
+      - Add Labels:
+        - Add Labels Overview: commands/bot_and_threat_defense/add-labels/index.md
+        - Bot Defense App Infrastructure: commands/bot_and_threat_defense/add-labels/bot_defense_app_infrastructure.md
+      - Apply:
+        - Apply Overview: commands/bot_and_threat_defense/apply/index.md
+        - Bot Defense App Infrastructure: commands/bot_and_threat_defense/apply/bot_defense_app_infrastructure.md
+      - Create:
+        - Create Overview: commands/bot_and_threat_defense/create/index.md
+        - Bot Defense App Infrastructure: commands/bot_and_threat_defense/create/bot_defense_app_infrastructure.md
+      - Delete:
+        - Delete Overview: commands/bot_and_threat_defense/delete/index.md
+        - Bot Defense App Infrastructure: commands/bot_and_threat_defense/delete/bot_defense_app_infrastructure.md
+      - Get:
+        - Get Overview: commands/bot_and_threat_defense/get/index.md
+        - Bot Defense App Infrastructure: commands/bot_and_threat_defense/get/bot_defense_app_infrastructure.md
+      - List:
+        - List Overview: commands/bot_and_threat_defense/list/index.md
+        - Bot Defense App Infrastructure: commands/bot_and_threat_defense/list/bot_defense_app_infrastructure.md
+      - Patch:
+        - Patch Overview: commands/bot_and_threat_defense/patch/index.md
+        - Bot Defense App Infrastructure: commands/bot_and_threat_defense/patch/bot_defense_app_infrastructure.md
+      - Remove Labels:
+        - Remove Labels Overview: commands/bot_and_threat_defense/remove-labels/index.md
+        - Bot Defense App Infrastructure: commands/bot_and_threat_defense/remove-labels/bot_defense_app_infrastructure.md
+      - Replace:
+        - Replace Overview: commands/bot_and_threat_defense/replace/index.md
+        - Bot Defense App Infrastructure: commands/bot_and_threat_defense/replace/bot_defense_app_infrastructure.md
+      - Status:
+        - Status Overview: commands/bot_and_threat_defense/status/index.md
+        - Bot Defense App Infrastructure: commands/bot_and_threat_defense/status/bot_defense_app_infrastructure.md
     - CDN:
       - CDN Overview: commands/cdn/index.md
       - Add Labels:
         - Add Labels Overview: commands/cdn/add-labels/index.md
         - CDN Cache Rule: commands/cdn/add-labels/cdn_cache_rule.md
         - CDN Load Balancer: commands/cdn/add-labels/cdn_loadbalancer.md
+        - HTTP Load Balancer: commands/cdn/add-labels/http_loadbalancer.md
       - Apply:
         - Apply Overview: commands/cdn/apply/index.md
         - CDN Cache Rule: commands/cdn/apply/cdn_cache_rule.md
         - CDN Load Balancer: commands/cdn/apply/cdn_loadbalancer.md
+        - HTTP Load Balancer: commands/cdn/apply/http_loadbalancer.md
       - Create:
         - Create Overview: commands/cdn/create/index.md
         - CDN Cache Rule: commands/cdn/create/cdn_cache_rule.md
         - CDN Load Balancer: commands/cdn/create/cdn_loadbalancer.md
+        - HTTP Load Balancer: commands/cdn/create/http_loadbalancer.md
       - Delete:
         - Delete Overview: commands/cdn/delete/index.md
         - CDN Cache Rule: commands/cdn/delete/cdn_cache_rule.md
         - CDN Load Balancer: commands/cdn/delete/cdn_loadbalancer.md
+        - HTTP Load Balancer: commands/cdn/delete/http_loadbalancer.md
       - Get:
         - Get Overview: commands/cdn/get/index.md
         - CDN Cache Rule: commands/cdn/get/cdn_cache_rule.md
         - CDN Load Balancer: commands/cdn/get/cdn_loadbalancer.md
+        - HTTP Load Balancer: commands/cdn/get/http_loadbalancer.md
       - List:
         - List Overview: commands/cdn/list/index.md
         - CDN Cache Rule: commands/cdn/list/cdn_cache_rule.md
         - CDN Load Balancer: commands/cdn/list/cdn_loadbalancer.md
+        - HTTP Load Balancer: commands/cdn/list/http_loadbalancer.md
       - Patch:
         - Patch Overview: commands/cdn/patch/index.md
         - CDN Cache Rule: commands/cdn/patch/cdn_cache_rule.md
         - CDN Load Balancer: commands/cdn/patch/cdn_loadbalancer.md
+        - HTTP Load Balancer: commands/cdn/patch/http_loadbalancer.md
       - Remove Labels:
         - Remove Labels Overview: commands/cdn/remove-labels/index.md
         - CDN Cache Rule: commands/cdn/remove-labels/cdn_cache_rule.md
         - CDN Load Balancer: commands/cdn/remove-labels/cdn_loadbalancer.md
+        - HTTP Load Balancer: commands/cdn/remove-labels/http_loadbalancer.md
       - Replace:
         - Replace Overview: commands/cdn/replace/index.md
         - CDN Cache Rule: commands/cdn/replace/cdn_cache_rule.md
         - CDN Load Balancer: commands/cdn/replace/cdn_loadbalancer.md
+        - HTTP Load Balancer: commands/cdn/replace/http_loadbalancer.md
       - Status:
         - Status Overview: commands/cdn/status/index.md
         - CDN Cache Rule: commands/cdn/status/cdn_cache_rule.md
         - CDN Load Balancer: commands/cdn/status/cdn_loadbalancer.md
+        - HTTP Load Balancer: commands/cdn/status/http_loadbalancer.md
+    - CE Management:
+      - CE Management Overview: commands/ce_management/index.md
+      - Add Labels:
+        - Add Labels Overview: commands/ce_management/add-labels/index.md
+        - Network Interface: commands/ce_management/add-labels/network_interface.md
+        - Registration: commands/ce_management/add-labels/registration.md
+        - Usb Policy: commands/ce_management/add-labels/usb_policy.md
+      - Apply:
+        - Apply Overview: commands/ce_management/apply/index.md
+        - Network Interface: commands/ce_management/apply/network_interface.md
+        - Registration: commands/ce_management/apply/registration.md
+        - Usb Policy: commands/ce_management/apply/usb_policy.md
+      - Create:
+        - Create Overview: commands/ce_management/create/index.md
+        - Network Interface: commands/ce_management/create/network_interface.md
+        - Registration: commands/ce_management/create/registration.md
+        - Usb Policy: commands/ce_management/create/usb_policy.md
+      - Delete:
+        - Delete Overview: commands/ce_management/delete/index.md
+        - Network Interface: commands/ce_management/delete/network_interface.md
+        - Registration: commands/ce_management/delete/registration.md
+        - Usb Policy: commands/ce_management/delete/usb_policy.md
+      - Get:
+        - Get Overview: commands/ce_management/get/index.md
+        - Network Interface: commands/ce_management/get/network_interface.md
+        - Registration: commands/ce_management/get/registration.md
+        - Usb Policy: commands/ce_management/get/usb_policy.md
+      - List:
+        - List Overview: commands/ce_management/list/index.md
+        - Network Interface: commands/ce_management/list/network_interface.md
+        - Registration: commands/ce_management/list/registration.md
+        - Usb Policy: commands/ce_management/list/usb_policy.md
+      - Patch:
+        - Patch Overview: commands/ce_management/patch/index.md
+        - Network Interface: commands/ce_management/patch/network_interface.md
+        - Registration: commands/ce_management/patch/registration.md
+        - Usb Policy: commands/ce_management/patch/usb_policy.md
+      - Remove Labels:
+        - Remove Labels Overview: commands/ce_management/remove-labels/index.md
+        - Network Interface: commands/ce_management/remove-labels/network_interface.md
+        - Registration: commands/ce_management/remove-labels/registration.md
+        - Usb Policy: commands/ce_management/remove-labels/usb_policy.md
+      - Replace:
+        - Replace Overview: commands/ce_management/replace/index.md
+        - Network Interface: commands/ce_management/replace/network_interface.md
+        - Registration: commands/ce_management/replace/registration.md
+        - Usb Policy: commands/ce_management/replace/usb_policy.md
+      - Status:
+        - Status Overview: commands/ce_management/status/index.md
+        - Network Interface: commands/ce_management/status/network_interface.md
+        - Registration: commands/ce_management/status/registration.md
+        - Usb Policy: commands/ce_management/status/usb_policy.md
+    - Certificates:
+      - Certificates Overview: commands/certificates/index.md
+      - Add Labels:
+        - Add Labels Overview: commands/certificates/add-labels/index.md
+        - Certificate: commands/certificates/add-labels/certificate.md
+        - Certificate Chain: commands/certificates/add-labels/certificate_chain.md
+        - CRL: commands/certificates/add-labels/crl.md
+        - Trusted CA List: commands/certificates/add-labels/trusted_ca_list.md
+      - Apply:
+        - Apply Overview: commands/certificates/apply/index.md
+        - Certificate: commands/certificates/apply/certificate.md
+        - Certificate Chain: commands/certificates/apply/certificate_chain.md
+        - CRL: commands/certificates/apply/crl.md
+        - Trusted CA List: commands/certificates/apply/trusted_ca_list.md
+      - Create:
+        - Create Overview: commands/certificates/create/index.md
+        - Certificate: commands/certificates/create/certificate.md
+        - Certificate Chain: commands/certificates/create/certificate_chain.md
+        - CRL: commands/certificates/create/crl.md
+        - Trusted CA List: commands/certificates/create/trusted_ca_list.md
+      - Delete:
+        - Delete Overview: commands/certificates/delete/index.md
+        - Certificate: commands/certificates/delete/certificate.md
+        - Certificate Chain: commands/certificates/delete/certificate_chain.md
+        - CRL: commands/certificates/delete/crl.md
+        - Trusted CA List: commands/certificates/delete/trusted_ca_list.md
+      - Get:
+        - Get Overview: commands/certificates/get/index.md
+        - Certificate: commands/certificates/get/certificate.md
+        - Certificate Chain: commands/certificates/get/certificate_chain.md
+        - CRL: commands/certificates/get/crl.md
+        - Trusted CA List: commands/certificates/get/trusted_ca_list.md
+      - List:
+        - List Overview: commands/certificates/list/index.md
+        - Certificate: commands/certificates/list/certificate.md
+        - Certificate Chain: commands/certificates/list/certificate_chain.md
+        - CRL: commands/certificates/list/crl.md
+        - Trusted CA List: commands/certificates/list/trusted_ca_list.md
+      - Patch:
+        - Patch Overview: commands/certificates/patch/index.md
+        - Certificate: commands/certificates/patch/certificate.md
+        - Certificate Chain: commands/certificates/patch/certificate_chain.md
+        - CRL: commands/certificates/patch/crl.md
+        - Trusted CA List: commands/certificates/patch/trusted_ca_list.md
+      - Remove Labels:
+        - Remove Labels Overview: commands/certificates/remove-labels/index.md
+        - Certificate: commands/certificates/remove-labels/certificate.md
+        - Certificate Chain: commands/certificates/remove-labels/certificate_chain.md
+        - CRL: commands/certificates/remove-labels/crl.md
+        - Trusted CA List: commands/certificates/remove-labels/trusted_ca_list.md
+      - Replace:
+        - Replace Overview: commands/certificates/replace/index.md
+        - Certificate: commands/certificates/replace/certificate.md
+        - Certificate Chain: commands/certificates/replace/certificate_chain.md
+        - CRL: commands/certificates/replace/crl.md
+        - Trusted CA List: commands/certificates/replace/trusted_ca_list.md
+      - Status:
+        - Status Overview: commands/certificates/status/index.md
+        - Certificate: commands/certificates/status/certificate.md
+        - Certificate Chain: commands/certificates/status/certificate_chain.md
+        - CRL: commands/certificates/status/crl.md
+        - Trusted CA List: commands/certificates/status/trusted_ca_list.md
+    - Cloud Infrastructure:
+      - Cloud Infrastructure Overview: commands/cloud_infrastructure/index.md
+      - Add Labels:
+        - Add Labels Overview: commands/cloud_infrastructure/add-labels/index.md
+        - Cloud Connect: commands/cloud_infrastructure/add-labels/cloud_connect.md
+        - Cloud Credentials: commands/cloud_infrastructure/add-labels/cloud_credentials.md
+        - Cloud Elastic IP: commands/cloud_infrastructure/add-labels/cloud_elastic_ip.md
+        - Cloud Link: commands/cloud_infrastructure/add-labels/cloud_link.md
+      - Apply:
+        - Apply Overview: commands/cloud_infrastructure/apply/index.md
+        - Cloud Connect: commands/cloud_infrastructure/apply/cloud_connect.md
+        - Cloud Credentials: commands/cloud_infrastructure/apply/cloud_credentials.md
+        - Cloud Elastic IP: commands/cloud_infrastructure/apply/cloud_elastic_ip.md
+        - Cloud Link: commands/cloud_infrastructure/apply/cloud_link.md
+      - Create:
+        - Create Overview: commands/cloud_infrastructure/create/index.md
+        - Cloud Connect: commands/cloud_infrastructure/create/cloud_connect.md
+        - Cloud Credentials: commands/cloud_infrastructure/create/cloud_credentials.md
+        - Cloud Elastic IP: commands/cloud_infrastructure/create/cloud_elastic_ip.md
+        - Cloud Link: commands/cloud_infrastructure/create/cloud_link.md
+      - Delete:
+        - Delete Overview: commands/cloud_infrastructure/delete/index.md
+        - Cloud Connect: commands/cloud_infrastructure/delete/cloud_connect.md
+        - Cloud Credentials: commands/cloud_infrastructure/delete/cloud_credentials.md
+        - Cloud Elastic IP: commands/cloud_infrastructure/delete/cloud_elastic_ip.md
+        - Cloud Link: commands/cloud_infrastructure/delete/cloud_link.md
+      - Get:
+        - Get Overview: commands/cloud_infrastructure/get/index.md
+        - Cloud Connect: commands/cloud_infrastructure/get/cloud_connect.md
+        - Cloud Credentials: commands/cloud_infrastructure/get/cloud_credentials.md
+        - Cloud Elastic IP: commands/cloud_infrastructure/get/cloud_elastic_ip.md
+        - Cloud Link: commands/cloud_infrastructure/get/cloud_link.md
+      - List:
+        - List Overview: commands/cloud_infrastructure/list/index.md
+        - Cloud Connect: commands/cloud_infrastructure/list/cloud_connect.md
+        - Cloud Credentials: commands/cloud_infrastructure/list/cloud_credentials.md
+        - Cloud Elastic IP: commands/cloud_infrastructure/list/cloud_elastic_ip.md
+        - Cloud Link: commands/cloud_infrastructure/list/cloud_link.md
+      - Patch:
+        - Patch Overview: commands/cloud_infrastructure/patch/index.md
+        - Cloud Connect: commands/cloud_infrastructure/patch/cloud_connect.md
+        - Cloud Credentials: commands/cloud_infrastructure/patch/cloud_credentials.md
+        - Cloud Elastic IP: commands/cloud_infrastructure/patch/cloud_elastic_ip.md
+        - Cloud Link: commands/cloud_infrastructure/patch/cloud_link.md
+      - Remove Labels:
+        - Remove Labels Overview: commands/cloud_infrastructure/remove-labels/index.md
+        - Cloud Connect: commands/cloud_infrastructure/remove-labels/cloud_connect.md
+        - Cloud Credentials: commands/cloud_infrastructure/remove-labels/cloud_credentials.md
+        - Cloud Elastic IP: commands/cloud_infrastructure/remove-labels/cloud_elastic_ip.md
+        - Cloud Link: commands/cloud_infrastructure/remove-labels/cloud_link.md
+      - Replace:
+        - Replace Overview: commands/cloud_infrastructure/replace/index.md
+        - Cloud Connect: commands/cloud_infrastructure/replace/cloud_connect.md
+        - Cloud Credentials: commands/cloud_infrastructure/replace/cloud_credentials.md
+        - Cloud Elastic IP: commands/cloud_infrastructure/replace/cloud_elastic_ip.md
+        - Cloud Link: commands/cloud_infrastructure/replace/cloud_link.md
+      - Status:
+        - Status Overview: commands/cloud_infrastructure/status/index.md
+        - Cloud Connect: commands/cloud_infrastructure/status/cloud_connect.md
+        - Cloud Credentials: commands/cloud_infrastructure/status/cloud_credentials.md
+        - Cloud Elastic IP: commands/cloud_infrastructure/status/cloud_elastic_ip.md
+        - Cloud Link: commands/cloud_infrastructure/status/cloud_link.md
     - Cloudstatus:
       - Cloudstatus Overview: commands/cloudstatus/index.md
       - Components:
@@ -346,1072 +586,873 @@ nav:
         - Pops Overview: commands/cloudstatus/pops/index.md
         - List: commands/cloudstatus/pops/list.md
         - Status: commands/cloudstatus/pops/status.md
-      - Status: commands/cloudstatus/status/index.md
-      - Summary: commands/cloudstatus/summary/index.md
-      - Watch: commands/cloudstatus/watch/index.md
+      - Status: commands/cloudstatus/status.md
+      - Summary: commands/cloudstatus/summary.md
+      - Watch: commands/cloudstatus/watch.md
     - Completion: commands/completion/index.md
-    - Config:
-      - Config Overview: commands/config/index.md
+    - Data And Privacy Security:
+      - Data And Privacy Security Overview: commands/data_and_privacy_security/index.md
       - Add Labels:
-        - Add Labels Overview: commands/config/add-labels/index.md
-        - Known Label: commands/config/add-labels/known_label.md
-        - Known Label Key: commands/config/add-labels/known_label_key.md
+        - Add Labels Overview: commands/data_and_privacy_security/add-labels/index.md
+        - Data Type: commands/data_and_privacy_security/add-labels/data_type.md
+        - Sensitive Data Policy: commands/data_and_privacy_security/add-labels/sensitive_data_policy.md
       - Apply:
-        - Apply Overview: commands/config/apply/index.md
-        - Known Label: commands/config/apply/known_label.md
-        - Known Label Key: commands/config/apply/known_label_key.md
+        - Apply Overview: commands/data_and_privacy_security/apply/index.md
+        - Data Type: commands/data_and_privacy_security/apply/data_type.md
+        - Sensitive Data Policy: commands/data_and_privacy_security/apply/sensitive_data_policy.md
       - Create:
-        - Create Overview: commands/config/create/index.md
-        - Known Label: commands/config/create/known_label.md
-        - Known Label Key: commands/config/create/known_label_key.md
+        - Create Overview: commands/data_and_privacy_security/create/index.md
+        - Data Type: commands/data_and_privacy_security/create/data_type.md
+        - Sensitive Data Policy: commands/data_and_privacy_security/create/sensitive_data_policy.md
       - Delete:
-        - Delete Overview: commands/config/delete/index.md
-        - Known Label: commands/config/delete/known_label.md
-        - Known Label Key: commands/config/delete/known_label_key.md
+        - Delete Overview: commands/data_and_privacy_security/delete/index.md
+        - Data Type: commands/data_and_privacy_security/delete/data_type.md
+        - Sensitive Data Policy: commands/data_and_privacy_security/delete/sensitive_data_policy.md
       - Get:
-        - Get Overview: commands/config/get/index.md
-        - Known Label: commands/config/get/known_label.md
-        - Known Label Key: commands/config/get/known_label_key.md
+        - Get Overview: commands/data_and_privacy_security/get/index.md
+        - Data Type: commands/data_and_privacy_security/get/data_type.md
+        - Sensitive Data Policy: commands/data_and_privacy_security/get/sensitive_data_policy.md
       - List:
-        - List Overview: commands/config/list/index.md
-        - Known Label: commands/config/list/known_label.md
-        - Known Label Key: commands/config/list/known_label_key.md
+        - List Overview: commands/data_and_privacy_security/list/index.md
+        - Data Type: commands/data_and_privacy_security/list/data_type.md
+        - Sensitive Data Policy: commands/data_and_privacy_security/list/sensitive_data_policy.md
       - Patch:
-        - Patch Overview: commands/config/patch/index.md
-        - Known Label: commands/config/patch/known_label.md
-        - Known Label Key: commands/config/patch/known_label_key.md
+        - Patch Overview: commands/data_and_privacy_security/patch/index.md
+        - Data Type: commands/data_and_privacy_security/patch/data_type.md
+        - Sensitive Data Policy: commands/data_and_privacy_security/patch/sensitive_data_policy.md
       - Remove Labels:
-        - Remove Labels Overview: commands/config/remove-labels/index.md
-        - Known Label: commands/config/remove-labels/known_label.md
-        - Known Label Key: commands/config/remove-labels/known_label_key.md
+        - Remove Labels Overview: commands/data_and_privacy_security/remove-labels/index.md
+        - Data Type: commands/data_and_privacy_security/remove-labels/data_type.md
+        - Sensitive Data Policy: commands/data_and_privacy_security/remove-labels/sensitive_data_policy.md
       - Replace:
-        - Replace Overview: commands/config/replace/index.md
-        - Known Label: commands/config/replace/known_label.md
-        - Known Label Key: commands/config/replace/known_label_key.md
+        - Replace Overview: commands/data_and_privacy_security/replace/index.md
+        - Data Type: commands/data_and_privacy_security/replace/data_type.md
+        - Sensitive Data Policy: commands/data_and_privacy_security/replace/sensitive_data_policy.md
       - Status:
-        - Status Overview: commands/config/status/index.md
-        - Known Label: commands/config/status/known_label.md
-        - Known Label Key: commands/config/status/known_label_key.md
-    - Identity:
-      - Identity Overview: commands/identity/index.md
+        - Status Overview: commands/data_and_privacy_security/status/index.md
+        - Data Type: commands/data_and_privacy_security/status/data_type.md
+        - Sensitive Data Policy: commands/data_and_privacy_security/status/sensitive_data_policy.md
+    - Data Intelligence:
+      - Data Intelligence Overview: commands/data_intelligence/index.md
+      - Add Labels: commands/data_intelligence/add-labels/index.md
+      - Apply: commands/data_intelligence/apply/index.md
+      - Create: commands/data_intelligence/create/index.md
+      - Delete: commands/data_intelligence/delete/index.md
+      - Get: commands/data_intelligence/get/index.md
+      - List: commands/data_intelligence/list/index.md
+      - Patch: commands/data_intelligence/patch/index.md
+      - Remove Labels: commands/data_intelligence/remove-labels/index.md
+      - Replace: commands/data_intelligence/replace/index.md
+      - Status: commands/data_intelligence/status/index.md
+    - DDOS:
+      - DDOS Overview: commands/ddos/index.md
       - Add Labels:
-        - Add Labels Overview: commands/identity/add-labels/index.md
-        - API Credential: commands/identity/add-labels/api_credential.md
-        - Authentication: commands/identity/add-labels/authentication.md
-        - Certificate: commands/identity/add-labels/certificate.md
-        - Certificate Chain: commands/identity/add-labels/certificate_chain.md
-        - Contact: commands/identity/add-labels/contact.md
-        - K8S Cluster Role: commands/identity/add-labels/k8s_cluster_role.md
-        - K8S Cluster Role Binding: commands/identity/add-labels/k8s_cluster_role_binding.md
-        - Namespace: commands/identity/add-labels/namespace.md
-        - Role: commands/identity/add-labels/role.md
-        - Token: commands/identity/add-labels/token.md
-        - User Identification: commands/identity/add-labels/user_identification.md
+        - Add Labels Overview: commands/ddos/add-labels/index.md
+        - Infraprotect ASN: commands/ddos/add-labels/infraprotect_asn.md
+        - Infraprotect ASN Prefix: commands/ddos/add-labels/infraprotect_asn_prefix.md
+        - Infraprotect Deny List Rule: commands/ddos/add-labels/infraprotect_deny_list_rule.md
+        - Infraprotect Firewall Rule: commands/ddos/add-labels/infraprotect_firewall_rule.md
+        - Infraprotect Firewall Rule Group: commands/ddos/add-labels/infraprotect_firewall_rule_group.md
+        - Infraprotect Internet Prefix Advertisement: commands/ddos/add-labels/infraprotect_internet_prefix_advertisement.md
+        - Infraprotect Tunnel: commands/ddos/add-labels/infraprotect_tunnel.md
       - Apply:
-        - Apply Overview: commands/identity/apply/index.md
-        - API Credential: commands/identity/apply/api_credential.md
-        - Authentication: commands/identity/apply/authentication.md
-        - Certificate: commands/identity/apply/certificate.md
-        - Certificate Chain: commands/identity/apply/certificate_chain.md
-        - Contact: commands/identity/apply/contact.md
-        - K8S Cluster Role: commands/identity/apply/k8s_cluster_role.md
-        - K8S Cluster Role Binding: commands/identity/apply/k8s_cluster_role_binding.md
-        - Namespace: commands/identity/apply/namespace.md
-        - Role: commands/identity/apply/role.md
-        - Token: commands/identity/apply/token.md
-        - User Identification: commands/identity/apply/user_identification.md
+        - Apply Overview: commands/ddos/apply/index.md
+        - Infraprotect ASN: commands/ddos/apply/infraprotect_asn.md
+        - Infraprotect ASN Prefix: commands/ddos/apply/infraprotect_asn_prefix.md
+        - Infraprotect Deny List Rule: commands/ddos/apply/infraprotect_deny_list_rule.md
+        - Infraprotect Firewall Rule: commands/ddos/apply/infraprotect_firewall_rule.md
+        - Infraprotect Firewall Rule Group: commands/ddos/apply/infraprotect_firewall_rule_group.md
+        - Infraprotect Internet Prefix Advertisement: commands/ddos/apply/infraprotect_internet_prefix_advertisement.md
+        - Infraprotect Tunnel: commands/ddos/apply/infraprotect_tunnel.md
       - Create:
-        - Create Overview: commands/identity/create/index.md
-        - API Credential: commands/identity/create/api_credential.md
-        - Authentication: commands/identity/create/authentication.md
-        - Certificate: commands/identity/create/certificate.md
-        - Certificate Chain: commands/identity/create/certificate_chain.md
-        - Contact: commands/identity/create/contact.md
-        - K8S Cluster Role: commands/identity/create/k8s_cluster_role.md
-        - K8S Cluster Role Binding: commands/identity/create/k8s_cluster_role_binding.md
-        - Namespace: commands/identity/create/namespace.md
-        - Role: commands/identity/create/role.md
-        - Token: commands/identity/create/token.md
-        - User Identification: commands/identity/create/user_identification.md
+        - Create Overview: commands/ddos/create/index.md
+        - Infraprotect ASN: commands/ddos/create/infraprotect_asn.md
+        - Infraprotect ASN Prefix: commands/ddos/create/infraprotect_asn_prefix.md
+        - Infraprotect Deny List Rule: commands/ddos/create/infraprotect_deny_list_rule.md
+        - Infraprotect Firewall Rule: commands/ddos/create/infraprotect_firewall_rule.md
+        - Infraprotect Firewall Rule Group: commands/ddos/create/infraprotect_firewall_rule_group.md
+        - Infraprotect Internet Prefix Advertisement: commands/ddos/create/infraprotect_internet_prefix_advertisement.md
+        - Infraprotect Tunnel: commands/ddos/create/infraprotect_tunnel.md
       - Delete:
-        - Delete Overview: commands/identity/delete/index.md
-        - API Credential: commands/identity/delete/api_credential.md
-        - Authentication: commands/identity/delete/authentication.md
-        - Certificate: commands/identity/delete/certificate.md
-        - Certificate Chain: commands/identity/delete/certificate_chain.md
-        - Contact: commands/identity/delete/contact.md
-        - K8S Cluster Role: commands/identity/delete/k8s_cluster_role.md
-        - K8S Cluster Role Binding: commands/identity/delete/k8s_cluster_role_binding.md
-        - Namespace: commands/identity/delete/namespace.md
-        - Role: commands/identity/delete/role.md
-        - Token: commands/identity/delete/token.md
-        - User Identification: commands/identity/delete/user_identification.md
+        - Delete Overview: commands/ddos/delete/index.md
+        - Infraprotect ASN: commands/ddos/delete/infraprotect_asn.md
+        - Infraprotect ASN Prefix: commands/ddos/delete/infraprotect_asn_prefix.md
+        - Infraprotect Deny List Rule: commands/ddos/delete/infraprotect_deny_list_rule.md
+        - Infraprotect Firewall Rule: commands/ddos/delete/infraprotect_firewall_rule.md
+        - Infraprotect Firewall Rule Group: commands/ddos/delete/infraprotect_firewall_rule_group.md
+        - Infraprotect Internet Prefix Advertisement: commands/ddos/delete/infraprotect_internet_prefix_advertisement.md
+        - Infraprotect Tunnel: commands/ddos/delete/infraprotect_tunnel.md
       - Get:
-        - Get Overview: commands/identity/get/index.md
-        - API Credential: commands/identity/get/api_credential.md
-        - Authentication: commands/identity/get/authentication.md
-        - Certificate: commands/identity/get/certificate.md
-        - Certificate Chain: commands/identity/get/certificate_chain.md
-        - Contact: commands/identity/get/contact.md
-        - K8S Cluster Role: commands/identity/get/k8s_cluster_role.md
-        - K8S Cluster Role Binding: commands/identity/get/k8s_cluster_role_binding.md
-        - Namespace: commands/identity/get/namespace.md
-        - Role: commands/identity/get/role.md
-        - Token: commands/identity/get/token.md
-        - User Identification: commands/identity/get/user_identification.md
+        - Get Overview: commands/ddos/get/index.md
+        - Infraprotect ASN: commands/ddos/get/infraprotect_asn.md
+        - Infraprotect ASN Prefix: commands/ddos/get/infraprotect_asn_prefix.md
+        - Infraprotect Deny List Rule: commands/ddos/get/infraprotect_deny_list_rule.md
+        - Infraprotect Firewall Rule: commands/ddos/get/infraprotect_firewall_rule.md
+        - Infraprotect Firewall Rule Group: commands/ddos/get/infraprotect_firewall_rule_group.md
+        - Infraprotect Internet Prefix Advertisement: commands/ddos/get/infraprotect_internet_prefix_advertisement.md
+        - Infraprotect Tunnel: commands/ddos/get/infraprotect_tunnel.md
       - List:
-        - List Overview: commands/identity/list/index.md
-        - API Credential: commands/identity/list/api_credential.md
-        - Authentication: commands/identity/list/authentication.md
-        - Certificate: commands/identity/list/certificate.md
-        - Certificate Chain: commands/identity/list/certificate_chain.md
-        - Contact: commands/identity/list/contact.md
-        - K8S Cluster Role: commands/identity/list/k8s_cluster_role.md
-        - K8S Cluster Role Binding: commands/identity/list/k8s_cluster_role_binding.md
-        - Namespace: commands/identity/list/namespace.md
-        - Role: commands/identity/list/role.md
-        - Token: commands/identity/list/token.md
-        - User Identification: commands/identity/list/user_identification.md
+        - List Overview: commands/ddos/list/index.md
+        - Infraprotect ASN: commands/ddos/list/infraprotect_asn.md
+        - Infraprotect ASN Prefix: commands/ddos/list/infraprotect_asn_prefix.md
+        - Infraprotect Deny List Rule: commands/ddos/list/infraprotect_deny_list_rule.md
+        - Infraprotect Firewall Rule: commands/ddos/list/infraprotect_firewall_rule.md
+        - Infraprotect Firewall Rule Group: commands/ddos/list/infraprotect_firewall_rule_group.md
+        - Infraprotect Internet Prefix Advertisement: commands/ddos/list/infraprotect_internet_prefix_advertisement.md
+        - Infraprotect Tunnel: commands/ddos/list/infraprotect_tunnel.md
       - Patch:
-        - Patch Overview: commands/identity/patch/index.md
-        - API Credential: commands/identity/patch/api_credential.md
-        - Authentication: commands/identity/patch/authentication.md
-        - Certificate: commands/identity/patch/certificate.md
-        - Certificate Chain: commands/identity/patch/certificate_chain.md
-        - Contact: commands/identity/patch/contact.md
-        - K8S Cluster Role: commands/identity/patch/k8s_cluster_role.md
-        - K8S Cluster Role Binding: commands/identity/patch/k8s_cluster_role_binding.md
-        - Namespace: commands/identity/patch/namespace.md
-        - Role: commands/identity/patch/role.md
-        - Token: commands/identity/patch/token.md
-        - User Identification: commands/identity/patch/user_identification.md
+        - Patch Overview: commands/ddos/patch/index.md
+        - Infraprotect ASN: commands/ddos/patch/infraprotect_asn.md
+        - Infraprotect ASN Prefix: commands/ddos/patch/infraprotect_asn_prefix.md
+        - Infraprotect Deny List Rule: commands/ddos/patch/infraprotect_deny_list_rule.md
+        - Infraprotect Firewall Rule: commands/ddos/patch/infraprotect_firewall_rule.md
+        - Infraprotect Firewall Rule Group: commands/ddos/patch/infraprotect_firewall_rule_group.md
+        - Infraprotect Internet Prefix Advertisement: commands/ddos/patch/infraprotect_internet_prefix_advertisement.md
+        - Infraprotect Tunnel: commands/ddos/patch/infraprotect_tunnel.md
       - Remove Labels:
-        - Remove Labels Overview: commands/identity/remove-labels/index.md
-        - API Credential: commands/identity/remove-labels/api_credential.md
-        - Authentication: commands/identity/remove-labels/authentication.md
-        - Certificate: commands/identity/remove-labels/certificate.md
-        - Certificate Chain: commands/identity/remove-labels/certificate_chain.md
-        - Contact: commands/identity/remove-labels/contact.md
-        - K8S Cluster Role: commands/identity/remove-labels/k8s_cluster_role.md
-        - K8S Cluster Role Binding: commands/identity/remove-labels/k8s_cluster_role_binding.md
-        - Namespace: commands/identity/remove-labels/namespace.md
-        - Role: commands/identity/remove-labels/role.md
-        - Token: commands/identity/remove-labels/token.md
-        - User Identification: commands/identity/remove-labels/user_identification.md
+        - Remove Labels Overview: commands/ddos/remove-labels/index.md
+        - Infraprotect ASN: commands/ddos/remove-labels/infraprotect_asn.md
+        - Infraprotect ASN Prefix: commands/ddos/remove-labels/infraprotect_asn_prefix.md
+        - Infraprotect Deny List Rule: commands/ddos/remove-labels/infraprotect_deny_list_rule.md
+        - Infraprotect Firewall Rule: commands/ddos/remove-labels/infraprotect_firewall_rule.md
+        - Infraprotect Firewall Rule Group: commands/ddos/remove-labels/infraprotect_firewall_rule_group.md
+        - Infraprotect Internet Prefix Advertisement: commands/ddos/remove-labels/infraprotect_internet_prefix_advertisement.md
+        - Infraprotect Tunnel: commands/ddos/remove-labels/infraprotect_tunnel.md
       - Replace:
-        - Replace Overview: commands/identity/replace/index.md
-        - API Credential: commands/identity/replace/api_credential.md
-        - Authentication: commands/identity/replace/authentication.md
-        - Certificate: commands/identity/replace/certificate.md
-        - Certificate Chain: commands/identity/replace/certificate_chain.md
-        - Contact: commands/identity/replace/contact.md
-        - K8S Cluster Role: commands/identity/replace/k8s_cluster_role.md
-        - K8S Cluster Role Binding: commands/identity/replace/k8s_cluster_role_binding.md
-        - Namespace: commands/identity/replace/namespace.md
-        - Role: commands/identity/replace/role.md
-        - Token: commands/identity/replace/token.md
-        - User Identification: commands/identity/replace/user_identification.md
+        - Replace Overview: commands/ddos/replace/index.md
+        - Infraprotect ASN: commands/ddos/replace/infraprotect_asn.md
+        - Infraprotect ASN Prefix: commands/ddos/replace/infraprotect_asn_prefix.md
+        - Infraprotect Deny List Rule: commands/ddos/replace/infraprotect_deny_list_rule.md
+        - Infraprotect Firewall Rule: commands/ddos/replace/infraprotect_firewall_rule.md
+        - Infraprotect Firewall Rule Group: commands/ddos/replace/infraprotect_firewall_rule_group.md
+        - Infraprotect Internet Prefix Advertisement: commands/ddos/replace/infraprotect_internet_prefix_advertisement.md
+        - Infraprotect Tunnel: commands/ddos/replace/infraprotect_tunnel.md
       - Status:
-        - Status Overview: commands/identity/status/index.md
-        - API Credential: commands/identity/status/api_credential.md
-        - Authentication: commands/identity/status/authentication.md
-        - Certificate: commands/identity/status/certificate.md
-        - Certificate Chain: commands/identity/status/certificate_chain.md
-        - Contact: commands/identity/status/contact.md
-        - K8S Cluster Role: commands/identity/status/k8s_cluster_role.md
-        - K8S Cluster Role Binding: commands/identity/status/k8s_cluster_role_binding.md
-        - Namespace: commands/identity/status/namespace.md
-        - Role: commands/identity/status/role.md
-        - Token: commands/identity/status/token.md
-        - User Identification: commands/identity/status/user_identification.md
-    - Infrastructure:
-      - Infrastructure Overview: commands/infrastructure/index.md
+        - Status Overview: commands/ddos/status/index.md
+        - Infraprotect ASN: commands/ddos/status/infraprotect_asn.md
+        - Infraprotect ASN Prefix: commands/ddos/status/infraprotect_asn_prefix.md
+        - Infraprotect Deny List Rule: commands/ddos/status/infraprotect_deny_list_rule.md
+        - Infraprotect Firewall Rule: commands/ddos/status/infraprotect_firewall_rule.md
+        - Infraprotect Firewall Rule Group: commands/ddos/status/infraprotect_firewall_rule_group.md
+        - Infraprotect Internet Prefix Advertisement: commands/ddos/status/infraprotect_internet_prefix_advertisement.md
+        - Infraprotect Tunnel: commands/ddos/status/infraprotect_tunnel.md
+    - DNS:
+      - DNS Overview: commands/dns/index.md
       - Add Labels:
-        - Add Labels Overview: commands/infrastructure/add-labels/index.md
-        - AWS TGW Site: commands/infrastructure/add-labels/aws_tgw_site.md
-        - AWS VPC Site: commands/infrastructure/add-labels/aws_vpc_site.md
-        - Azure VNET Site: commands/infrastructure/add-labels/azure_vnet_site.md
-        - Cloud Credentials: commands/infrastructure/add-labels/cloud_credentials.md
-        - GCP VPC Site: commands/infrastructure/add-labels/gcp_vpc_site.md
-        - K8S Cluster: commands/infrastructure/add-labels/k8s_cluster.md
-        - K8S Pod Security Admission: commands/infrastructure/add-labels/k8s_pod_security_admission.md
-        - K8S Pod Security Policy: commands/infrastructure/add-labels/k8s_pod_security_policy.md
-        - Registration: commands/infrastructure/add-labels/registration.md
-        - Securemesh Site: commands/infrastructure/add-labels/securemesh_site.md
-        - Securemesh Site V2: commands/infrastructure/add-labels/securemesh_site_v2.md
-        - Usb Policy: commands/infrastructure/add-labels/usb_policy.md
-        - Virtual K8S: commands/infrastructure/add-labels/virtual_k8s.md
-        - Voltstack Site: commands/infrastructure/add-labels/voltstack_site.md
+        - Add Labels Overview: commands/dns/add-labels/index.md
+        - DNS Compliance Checks: commands/dns/add-labels/dns_compliance_checks.md
+        - DNS Domain: commands/dns/add-labels/dns_domain.md
+        - DNS LB Health Check: commands/dns/add-labels/dns_lb_health_check.md
+        - DNS LB Pool: commands/dns/add-labels/dns_lb_pool.md
+        - DNS Load Balancer: commands/dns/add-labels/dns_load_balancer.md
+        - DNS Zone: commands/dns/add-labels/dns_zone.md
       - Apply:
-        - Apply Overview: commands/infrastructure/apply/index.md
-        - AWS TGW Site: commands/infrastructure/apply/aws_tgw_site.md
-        - AWS VPC Site: commands/infrastructure/apply/aws_vpc_site.md
-        - Azure VNET Site: commands/infrastructure/apply/azure_vnet_site.md
-        - Cloud Credentials: commands/infrastructure/apply/cloud_credentials.md
-        - GCP VPC Site: commands/infrastructure/apply/gcp_vpc_site.md
-        - K8S Cluster: commands/infrastructure/apply/k8s_cluster.md
-        - K8S Pod Security Admission: commands/infrastructure/apply/k8s_pod_security_admission.md
-        - K8S Pod Security Policy: commands/infrastructure/apply/k8s_pod_security_policy.md
-        - Registration: commands/infrastructure/apply/registration.md
-        - Securemesh Site: commands/infrastructure/apply/securemesh_site.md
-        - Securemesh Site V2: commands/infrastructure/apply/securemesh_site_v2.md
-        - Usb Policy: commands/infrastructure/apply/usb_policy.md
-        - Virtual K8S: commands/infrastructure/apply/virtual_k8s.md
-        - Voltstack Site: commands/infrastructure/apply/voltstack_site.md
+        - Apply Overview: commands/dns/apply/index.md
+        - DNS Compliance Checks: commands/dns/apply/dns_compliance_checks.md
+        - DNS Domain: commands/dns/apply/dns_domain.md
+        - DNS LB Health Check: commands/dns/apply/dns_lb_health_check.md
+        - DNS LB Pool: commands/dns/apply/dns_lb_pool.md
+        - DNS Load Balancer: commands/dns/apply/dns_load_balancer.md
+        - DNS Zone: commands/dns/apply/dns_zone.md
       - Create:
-        - Create Overview: commands/infrastructure/create/index.md
-        - AWS TGW Site: commands/infrastructure/create/aws_tgw_site.md
-        - AWS VPC Site: commands/infrastructure/create/aws_vpc_site.md
-        - Azure VNET Site: commands/infrastructure/create/azure_vnet_site.md
-        - Cloud Credentials: commands/infrastructure/create/cloud_credentials.md
-        - GCP VPC Site: commands/infrastructure/create/gcp_vpc_site.md
-        - K8S Cluster: commands/infrastructure/create/k8s_cluster.md
-        - K8S Pod Security Admission: commands/infrastructure/create/k8s_pod_security_admission.md
-        - K8S Pod Security Policy: commands/infrastructure/create/k8s_pod_security_policy.md
-        - Registration: commands/infrastructure/create/registration.md
-        - Securemesh Site: commands/infrastructure/create/securemesh_site.md
-        - Securemesh Site V2: commands/infrastructure/create/securemesh_site_v2.md
-        - Usb Policy: commands/infrastructure/create/usb_policy.md
-        - Virtual K8S: commands/infrastructure/create/virtual_k8s.md
-        - Voltstack Site: commands/infrastructure/create/voltstack_site.md
+        - Create Overview: commands/dns/create/index.md
+        - DNS Compliance Checks: commands/dns/create/dns_compliance_checks.md
+        - DNS Domain: commands/dns/create/dns_domain.md
+        - DNS LB Health Check: commands/dns/create/dns_lb_health_check.md
+        - DNS LB Pool: commands/dns/create/dns_lb_pool.md
+        - DNS Load Balancer: commands/dns/create/dns_load_balancer.md
+        - DNS Zone: commands/dns/create/dns_zone.md
       - Delete:
-        - Delete Overview: commands/infrastructure/delete/index.md
-        - AWS TGW Site: commands/infrastructure/delete/aws_tgw_site.md
-        - AWS VPC Site: commands/infrastructure/delete/aws_vpc_site.md
-        - Azure VNET Site: commands/infrastructure/delete/azure_vnet_site.md
-        - Cloud Credentials: commands/infrastructure/delete/cloud_credentials.md
-        - GCP VPC Site: commands/infrastructure/delete/gcp_vpc_site.md
-        - K8S Cluster: commands/infrastructure/delete/k8s_cluster.md
-        - K8S Pod Security Admission: commands/infrastructure/delete/k8s_pod_security_admission.md
-        - K8S Pod Security Policy: commands/infrastructure/delete/k8s_pod_security_policy.md
-        - Registration: commands/infrastructure/delete/registration.md
-        - Securemesh Site: commands/infrastructure/delete/securemesh_site.md
-        - Securemesh Site V2: commands/infrastructure/delete/securemesh_site_v2.md
-        - Usb Policy: commands/infrastructure/delete/usb_policy.md
-        - Virtual K8S: commands/infrastructure/delete/virtual_k8s.md
-        - Voltstack Site: commands/infrastructure/delete/voltstack_site.md
+        - Delete Overview: commands/dns/delete/index.md
+        - DNS Compliance Checks: commands/dns/delete/dns_compliance_checks.md
+        - DNS Domain: commands/dns/delete/dns_domain.md
+        - DNS LB Health Check: commands/dns/delete/dns_lb_health_check.md
+        - DNS LB Pool: commands/dns/delete/dns_lb_pool.md
+        - DNS Load Balancer: commands/dns/delete/dns_load_balancer.md
+        - DNS Zone: commands/dns/delete/dns_zone.md
       - Get:
-        - Get Overview: commands/infrastructure/get/index.md
-        - AWS TGW Site: commands/infrastructure/get/aws_tgw_site.md
-        - AWS VPC Site: commands/infrastructure/get/aws_vpc_site.md
-        - Azure VNET Site: commands/infrastructure/get/azure_vnet_site.md
-        - Cloud Credentials: commands/infrastructure/get/cloud_credentials.md
-        - GCP VPC Site: commands/infrastructure/get/gcp_vpc_site.md
-        - K8S Cluster: commands/infrastructure/get/k8s_cluster.md
-        - K8S Pod Security Admission: commands/infrastructure/get/k8s_pod_security_admission.md
-        - K8S Pod Security Policy: commands/infrastructure/get/k8s_pod_security_policy.md
-        - Registration: commands/infrastructure/get/registration.md
-        - Securemesh Site: commands/infrastructure/get/securemesh_site.md
-        - Securemesh Site V2: commands/infrastructure/get/securemesh_site_v2.md
-        - Usb Policy: commands/infrastructure/get/usb_policy.md
-        - Virtual K8S: commands/infrastructure/get/virtual_k8s.md
-        - Voltstack Site: commands/infrastructure/get/voltstack_site.md
+        - Get Overview: commands/dns/get/index.md
+        - DNS Compliance Checks: commands/dns/get/dns_compliance_checks.md
+        - DNS Domain: commands/dns/get/dns_domain.md
+        - DNS LB Health Check: commands/dns/get/dns_lb_health_check.md
+        - DNS LB Pool: commands/dns/get/dns_lb_pool.md
+        - DNS Load Balancer: commands/dns/get/dns_load_balancer.md
+        - DNS Zone: commands/dns/get/dns_zone.md
       - List:
-        - List Overview: commands/infrastructure/list/index.md
-        - AWS TGW Site: commands/infrastructure/list/aws_tgw_site.md
-        - AWS VPC Site: commands/infrastructure/list/aws_vpc_site.md
-        - Azure VNET Site: commands/infrastructure/list/azure_vnet_site.md
-        - Cloud Credentials: commands/infrastructure/list/cloud_credentials.md
-        - GCP VPC Site: commands/infrastructure/list/gcp_vpc_site.md
-        - K8S Cluster: commands/infrastructure/list/k8s_cluster.md
-        - K8S Pod Security Admission: commands/infrastructure/list/k8s_pod_security_admission.md
-        - K8S Pod Security Policy: commands/infrastructure/list/k8s_pod_security_policy.md
-        - Registration: commands/infrastructure/list/registration.md
-        - Securemesh Site: commands/infrastructure/list/securemesh_site.md
-        - Securemesh Site V2: commands/infrastructure/list/securemesh_site_v2.md
-        - Usb Policy: commands/infrastructure/list/usb_policy.md
-        - Virtual K8S: commands/infrastructure/list/virtual_k8s.md
-        - Voltstack Site: commands/infrastructure/list/voltstack_site.md
+        - List Overview: commands/dns/list/index.md
+        - DNS Compliance Checks: commands/dns/list/dns_compliance_checks.md
+        - DNS Domain: commands/dns/list/dns_domain.md
+        - DNS LB Health Check: commands/dns/list/dns_lb_health_check.md
+        - DNS LB Pool: commands/dns/list/dns_lb_pool.md
+        - DNS Load Balancer: commands/dns/list/dns_load_balancer.md
+        - DNS Zone: commands/dns/list/dns_zone.md
       - Patch:
-        - Patch Overview: commands/infrastructure/patch/index.md
-        - AWS TGW Site: commands/infrastructure/patch/aws_tgw_site.md
-        - AWS VPC Site: commands/infrastructure/patch/aws_vpc_site.md
-        - Azure VNET Site: commands/infrastructure/patch/azure_vnet_site.md
-        - Cloud Credentials: commands/infrastructure/patch/cloud_credentials.md
-        - GCP VPC Site: commands/infrastructure/patch/gcp_vpc_site.md
-        - K8S Cluster: commands/infrastructure/patch/k8s_cluster.md
-        - K8S Pod Security Admission: commands/infrastructure/patch/k8s_pod_security_admission.md
-        - K8S Pod Security Policy: commands/infrastructure/patch/k8s_pod_security_policy.md
-        - Registration: commands/infrastructure/patch/registration.md
-        - Securemesh Site: commands/infrastructure/patch/securemesh_site.md
-        - Securemesh Site V2: commands/infrastructure/patch/securemesh_site_v2.md
-        - Usb Policy: commands/infrastructure/patch/usb_policy.md
-        - Virtual K8S: commands/infrastructure/patch/virtual_k8s.md
-        - Voltstack Site: commands/infrastructure/patch/voltstack_site.md
+        - Patch Overview: commands/dns/patch/index.md
+        - DNS Compliance Checks: commands/dns/patch/dns_compliance_checks.md
+        - DNS Domain: commands/dns/patch/dns_domain.md
+        - DNS LB Health Check: commands/dns/patch/dns_lb_health_check.md
+        - DNS LB Pool: commands/dns/patch/dns_lb_pool.md
+        - DNS Load Balancer: commands/dns/patch/dns_load_balancer.md
+        - DNS Zone: commands/dns/patch/dns_zone.md
       - Remove Labels:
-        - Remove Labels Overview: commands/infrastructure/remove-labels/index.md
-        - AWS TGW Site: commands/infrastructure/remove-labels/aws_tgw_site.md
-        - AWS VPC Site: commands/infrastructure/remove-labels/aws_vpc_site.md
-        - Azure VNET Site: commands/infrastructure/remove-labels/azure_vnet_site.md
-        - Cloud Credentials: commands/infrastructure/remove-labels/cloud_credentials.md
-        - GCP VPC Site: commands/infrastructure/remove-labels/gcp_vpc_site.md
-        - K8S Cluster: commands/infrastructure/remove-labels/k8s_cluster.md
-        - K8S Pod Security Admission: commands/infrastructure/remove-labels/k8s_pod_security_admission.md
-        - K8S Pod Security Policy: commands/infrastructure/remove-labels/k8s_pod_security_policy.md
-        - Registration: commands/infrastructure/remove-labels/registration.md
-        - Securemesh Site: commands/infrastructure/remove-labels/securemesh_site.md
-        - Securemesh Site V2: commands/infrastructure/remove-labels/securemesh_site_v2.md
-        - Usb Policy: commands/infrastructure/remove-labels/usb_policy.md
-        - Virtual K8S: commands/infrastructure/remove-labels/virtual_k8s.md
-        - Voltstack Site: commands/infrastructure/remove-labels/voltstack_site.md
+        - Remove Labels Overview: commands/dns/remove-labels/index.md
+        - DNS Compliance Checks: commands/dns/remove-labels/dns_compliance_checks.md
+        - DNS Domain: commands/dns/remove-labels/dns_domain.md
+        - DNS LB Health Check: commands/dns/remove-labels/dns_lb_health_check.md
+        - DNS LB Pool: commands/dns/remove-labels/dns_lb_pool.md
+        - DNS Load Balancer: commands/dns/remove-labels/dns_load_balancer.md
+        - DNS Zone: commands/dns/remove-labels/dns_zone.md
       - Replace:
-        - Replace Overview: commands/infrastructure/replace/index.md
-        - AWS TGW Site: commands/infrastructure/replace/aws_tgw_site.md
-        - AWS VPC Site: commands/infrastructure/replace/aws_vpc_site.md
-        - Azure VNET Site: commands/infrastructure/replace/azure_vnet_site.md
-        - Cloud Credentials: commands/infrastructure/replace/cloud_credentials.md
-        - GCP VPC Site: commands/infrastructure/replace/gcp_vpc_site.md
-        - K8S Cluster: commands/infrastructure/replace/k8s_cluster.md
-        - K8S Pod Security Admission: commands/infrastructure/replace/k8s_pod_security_admission.md
-        - K8S Pod Security Policy: commands/infrastructure/replace/k8s_pod_security_policy.md
-        - Registration: commands/infrastructure/replace/registration.md
-        - Securemesh Site: commands/infrastructure/replace/securemesh_site.md
-        - Securemesh Site V2: commands/infrastructure/replace/securemesh_site_v2.md
-        - Usb Policy: commands/infrastructure/replace/usb_policy.md
-        - Virtual K8S: commands/infrastructure/replace/virtual_k8s.md
-        - Voltstack Site: commands/infrastructure/replace/voltstack_site.md
+        - Replace Overview: commands/dns/replace/index.md
+        - DNS Compliance Checks: commands/dns/replace/dns_compliance_checks.md
+        - DNS Domain: commands/dns/replace/dns_domain.md
+        - DNS LB Health Check: commands/dns/replace/dns_lb_health_check.md
+        - DNS LB Pool: commands/dns/replace/dns_lb_pool.md
+        - DNS Load Balancer: commands/dns/replace/dns_load_balancer.md
+        - DNS Zone: commands/dns/replace/dns_zone.md
       - Status:
-        - Status Overview: commands/infrastructure/status/index.md
-        - AWS TGW Site: commands/infrastructure/status/aws_tgw_site.md
-        - AWS VPC Site: commands/infrastructure/status/aws_vpc_site.md
-        - Azure VNET Site: commands/infrastructure/status/azure_vnet_site.md
-        - Cloud Credentials: commands/infrastructure/status/cloud_credentials.md
-        - GCP VPC Site: commands/infrastructure/status/gcp_vpc_site.md
-        - K8S Cluster: commands/infrastructure/status/k8s_cluster.md
-        - K8S Pod Security Admission: commands/infrastructure/status/k8s_pod_security_admission.md
-        - K8S Pod Security Policy: commands/infrastructure/status/k8s_pod_security_policy.md
-        - Registration: commands/infrastructure/status/registration.md
-        - Securemesh Site: commands/infrastructure/status/securemesh_site.md
-        - Securemesh Site V2: commands/infrastructure/status/securemesh_site_v2.md
-        - Usb Policy: commands/infrastructure/status/usb_policy.md
-        - Virtual K8S: commands/infrastructure/status/virtual_k8s.md
-        - Voltstack Site: commands/infrastructure/status/voltstack_site.md
-    - Infrastructure Protection:
-      - Infrastructure Protection Overview: commands/infrastructure_protection/index.md
+        - Status Overview: commands/dns/status/index.md
+        - DNS Compliance Checks: commands/dns/status/dns_compliance_checks.md
+        - DNS Domain: commands/dns/status/dns_domain.md
+        - DNS LB Health Check: commands/dns/status/dns_lb_health_check.md
+        - DNS LB Pool: commands/dns/status/dns_lb_pool.md
+        - DNS Load Balancer: commands/dns/status/dns_load_balancer.md
+        - DNS Zone: commands/dns/status/dns_zone.md
+    - Domains:
+      - Domains Overview: commands/domains/index.md
+      - By Tier: commands/domains/by-tier/index.md
+    - Generative Ai:
+      - Generative Ai Overview: commands/generative_ai/index.md
+      - Add Labels: commands/generative_ai/add-labels/index.md
+      - Apply: commands/generative_ai/apply/index.md
+      - Create: commands/generative_ai/create/index.md
+      - Delete: commands/generative_ai/delete/index.md
+      - Get: commands/generative_ai/get/index.md
+      - List: commands/generative_ai/list/index.md
+      - Patch: commands/generative_ai/patch/index.md
+      - Remove Labels: commands/generative_ai/remove-labels/index.md
+      - Replace: commands/generative_ai/replace/index.md
+      - Status: commands/generative_ai/status/index.md
+    - Kubernetes:
+      - Kubernetes Overview: commands/kubernetes/index.md
       - Add Labels:
-        - Add Labels Overview: commands/infrastructure_protection/add-labels/index.md
-        - Infraprotect ASN: commands/infrastructure_protection/add-labels/infraprotect_asn.md
-        - Infraprotect ASN Prefix: commands/infrastructure_protection/add-labels/infraprotect_asn_prefix.md
-        - Infraprotect Deny List Rule: commands/infrastructure_protection/add-labels/infraprotect_deny_list_rule.md
-        - Infraprotect Firewall Rule: commands/infrastructure_protection/add-labels/infraprotect_firewall_rule.md
-        - Infraprotect Firewall Rule Group: commands/infrastructure_protection/add-labels/infraprotect_firewall_rule_group.md
-        - Infraprotect Internet Prefix Advertisement: commands/infrastructure_protection/add-labels/infraprotect_internet_prefix_advertisement.md
-        - Infraprotect Tunnel: commands/infrastructure_protection/add-labels/infraprotect_tunnel.md
+        - Add Labels Overview: commands/kubernetes/add-labels/index.md
+        - Workload: commands/kubernetes/add-labels/workload.md
       - Apply:
-        - Apply Overview: commands/infrastructure_protection/apply/index.md
-        - Infraprotect ASN: commands/infrastructure_protection/apply/infraprotect_asn.md
-        - Infraprotect ASN Prefix: commands/infrastructure_protection/apply/infraprotect_asn_prefix.md
-        - Infraprotect Deny List Rule: commands/infrastructure_protection/apply/infraprotect_deny_list_rule.md
-        - Infraprotect Firewall Rule: commands/infrastructure_protection/apply/infraprotect_firewall_rule.md
-        - Infraprotect Firewall Rule Group: commands/infrastructure_protection/apply/infraprotect_firewall_rule_group.md
-        - Infraprotect Internet Prefix Advertisement: commands/infrastructure_protection/apply/infraprotect_internet_prefix_advertisement.md
-        - Infraprotect Tunnel: commands/infrastructure_protection/apply/infraprotect_tunnel.md
+        - Apply Overview: commands/kubernetes/apply/index.md
+        - Workload: commands/kubernetes/apply/workload.md
       - Create:
-        - Create Overview: commands/infrastructure_protection/create/index.md
-        - Infraprotect ASN: commands/infrastructure_protection/create/infraprotect_asn.md
-        - Infraprotect ASN Prefix: commands/infrastructure_protection/create/infraprotect_asn_prefix.md
-        - Infraprotect Deny List Rule: commands/infrastructure_protection/create/infraprotect_deny_list_rule.md
-        - Infraprotect Firewall Rule: commands/infrastructure_protection/create/infraprotect_firewall_rule.md
-        - Infraprotect Firewall Rule Group: commands/infrastructure_protection/create/infraprotect_firewall_rule_group.md
-        - Infraprotect Internet Prefix Advertisement: commands/infrastructure_protection/create/infraprotect_internet_prefix_advertisement.md
-        - Infraprotect Tunnel: commands/infrastructure_protection/create/infraprotect_tunnel.md
+        - Create Overview: commands/kubernetes/create/index.md
+        - Workload: commands/kubernetes/create/workload.md
       - Delete:
-        - Delete Overview: commands/infrastructure_protection/delete/index.md
-        - Infraprotect ASN: commands/infrastructure_protection/delete/infraprotect_asn.md
-        - Infraprotect ASN Prefix: commands/infrastructure_protection/delete/infraprotect_asn_prefix.md
-        - Infraprotect Deny List Rule: commands/infrastructure_protection/delete/infraprotect_deny_list_rule.md
-        - Infraprotect Firewall Rule: commands/infrastructure_protection/delete/infraprotect_firewall_rule.md
-        - Infraprotect Firewall Rule Group: commands/infrastructure_protection/delete/infraprotect_firewall_rule_group.md
-        - Infraprotect Internet Prefix Advertisement: commands/infrastructure_protection/delete/infraprotect_internet_prefix_advertisement.md
-        - Infraprotect Tunnel: commands/infrastructure_protection/delete/infraprotect_tunnel.md
+        - Delete Overview: commands/kubernetes/delete/index.md
+        - Workload: commands/kubernetes/delete/workload.md
       - Get:
-        - Get Overview: commands/infrastructure_protection/get/index.md
-        - Infraprotect ASN: commands/infrastructure_protection/get/infraprotect_asn.md
-        - Infraprotect ASN Prefix: commands/infrastructure_protection/get/infraprotect_asn_prefix.md
-        - Infraprotect Deny List Rule: commands/infrastructure_protection/get/infraprotect_deny_list_rule.md
-        - Infraprotect Firewall Rule: commands/infrastructure_protection/get/infraprotect_firewall_rule.md
-        - Infraprotect Firewall Rule Group: commands/infrastructure_protection/get/infraprotect_firewall_rule_group.md
-        - Infraprotect Internet Prefix Advertisement: commands/infrastructure_protection/get/infraprotect_internet_prefix_advertisement.md
-        - Infraprotect Tunnel: commands/infrastructure_protection/get/infraprotect_tunnel.md
+        - Get Overview: commands/kubernetes/get/index.md
+        - Workload: commands/kubernetes/get/workload.md
       - List:
-        - List Overview: commands/infrastructure_protection/list/index.md
-        - Infraprotect ASN: commands/infrastructure_protection/list/infraprotect_asn.md
-        - Infraprotect ASN Prefix: commands/infrastructure_protection/list/infraprotect_asn_prefix.md
-        - Infraprotect Deny List Rule: commands/infrastructure_protection/list/infraprotect_deny_list_rule.md
-        - Infraprotect Firewall Rule: commands/infrastructure_protection/list/infraprotect_firewall_rule.md
-        - Infraprotect Firewall Rule Group: commands/infrastructure_protection/list/infraprotect_firewall_rule_group.md
-        - Infraprotect Internet Prefix Advertisement: commands/infrastructure_protection/list/infraprotect_internet_prefix_advertisement.md
-        - Infraprotect Tunnel: commands/infrastructure_protection/list/infraprotect_tunnel.md
+        - List Overview: commands/kubernetes/list/index.md
+        - Workload: commands/kubernetes/list/workload.md
       - Patch:
-        - Patch Overview: commands/infrastructure_protection/patch/index.md
-        - Infraprotect ASN: commands/infrastructure_protection/patch/infraprotect_asn.md
-        - Infraprotect ASN Prefix: commands/infrastructure_protection/patch/infraprotect_asn_prefix.md
-        - Infraprotect Deny List Rule: commands/infrastructure_protection/patch/infraprotect_deny_list_rule.md
-        - Infraprotect Firewall Rule: commands/infrastructure_protection/patch/infraprotect_firewall_rule.md
-        - Infraprotect Firewall Rule Group: commands/infrastructure_protection/patch/infraprotect_firewall_rule_group.md
-        - Infraprotect Internet Prefix Advertisement: commands/infrastructure_protection/patch/infraprotect_internet_prefix_advertisement.md
-        - Infraprotect Tunnel: commands/infrastructure_protection/patch/infraprotect_tunnel.md
+        - Patch Overview: commands/kubernetes/patch/index.md
+        - Workload: commands/kubernetes/patch/workload.md
       - Remove Labels:
-        - Remove Labels Overview: commands/infrastructure_protection/remove-labels/index.md
-        - Infraprotect ASN: commands/infrastructure_protection/remove-labels/infraprotect_asn.md
-        - Infraprotect ASN Prefix: commands/infrastructure_protection/remove-labels/infraprotect_asn_prefix.md
-        - Infraprotect Deny List Rule: commands/infrastructure_protection/remove-labels/infraprotect_deny_list_rule.md
-        - Infraprotect Firewall Rule: commands/infrastructure_protection/remove-labels/infraprotect_firewall_rule.md
-        - Infraprotect Firewall Rule Group: commands/infrastructure_protection/remove-labels/infraprotect_firewall_rule_group.md
-        - Infraprotect Internet Prefix Advertisement: commands/infrastructure_protection/remove-labels/infraprotect_internet_prefix_advertisement.md
-        - Infraprotect Tunnel: commands/infrastructure_protection/remove-labels/infraprotect_tunnel.md
+        - Remove Labels Overview: commands/kubernetes/remove-labels/index.md
+        - Workload: commands/kubernetes/remove-labels/workload.md
       - Replace:
-        - Replace Overview: commands/infrastructure_protection/replace/index.md
-        - Infraprotect ASN: commands/infrastructure_protection/replace/infraprotect_asn.md
-        - Infraprotect ASN Prefix: commands/infrastructure_protection/replace/infraprotect_asn_prefix.md
-        - Infraprotect Deny List Rule: commands/infrastructure_protection/replace/infraprotect_deny_list_rule.md
-        - Infraprotect Firewall Rule: commands/infrastructure_protection/replace/infraprotect_firewall_rule.md
-        - Infraprotect Firewall Rule Group: commands/infrastructure_protection/replace/infraprotect_firewall_rule_group.md
-        - Infraprotect Internet Prefix Advertisement: commands/infrastructure_protection/replace/infraprotect_internet_prefix_advertisement.md
-        - Infraprotect Tunnel: commands/infrastructure_protection/replace/infraprotect_tunnel.md
+        - Replace Overview: commands/kubernetes/replace/index.md
+        - Workload: commands/kubernetes/replace/workload.md
       - Status:
-        - Status Overview: commands/infrastructure_protection/status/index.md
-        - Infraprotect ASN: commands/infrastructure_protection/status/infraprotect_asn.md
-        - Infraprotect ASN Prefix: commands/infrastructure_protection/status/infraprotect_asn_prefix.md
-        - Infraprotect Deny List Rule: commands/infrastructure_protection/status/infraprotect_deny_list_rule.md
-        - Infraprotect Firewall Rule: commands/infrastructure_protection/status/infraprotect_firewall_rule.md
-        - Infraprotect Firewall Rule Group: commands/infrastructure_protection/status/infraprotect_firewall_rule_group.md
-        - Infraprotect Internet Prefix Advertisement: commands/infrastructure_protection/status/infraprotect_internet_prefix_advertisement.md
-        - Infraprotect Tunnel: commands/infrastructure_protection/status/infraprotect_tunnel.md
-    - Integrations:
-      - Integrations Overview: commands/integrations/index.md
+        - Status Overview: commands/kubernetes/status/index.md
+        - Workload: commands/kubernetes/status/workload.md
+    - Kubernetes And Orchestration:
+      - Kubernetes And Orchestration Overview: commands/kubernetes_and_orchestration/index.md
       - Add Labels:
-        - Add Labels Overview: commands/integrations/add-labels/index.md
-        - Cminstance: commands/integrations/add-labels/cminstance.md
-        - Tpm API Key: commands/integrations/add-labels/tpm_api_key.md
-        - Tpm Category: commands/integrations/add-labels/tpm_category.md
-        - Tpm Manager: commands/integrations/add-labels/tpm_manager.md
+        - Add Labels Overview: commands/kubernetes_and_orchestration/add-labels/index.md
+        - Cluster: commands/kubernetes_and_orchestration/add-labels/cluster.md
+        - Container Registry: commands/kubernetes_and_orchestration/add-labels/container_registry.md
+        - K8S Pod Security Admission: commands/kubernetes_and_orchestration/add-labels/k8s_pod_security_admission.md
+        - K8S Pod Security Policy: commands/kubernetes_and_orchestration/add-labels/k8s_pod_security_policy.md
+        - Virtual K8S: commands/kubernetes_and_orchestration/add-labels/virtual_k8s.md
+        - Workload: commands/kubernetes_and_orchestration/add-labels/workload.md
+        - Workload Flavor: commands/kubernetes_and_orchestration/add-labels/workload_flavor.md
       - Apply:
-        - Apply Overview: commands/integrations/apply/index.md
-        - Cminstance: commands/integrations/apply/cminstance.md
-        - Tpm API Key: commands/integrations/apply/tpm_api_key.md
-        - Tpm Category: commands/integrations/apply/tpm_category.md
-        - Tpm Manager: commands/integrations/apply/tpm_manager.md
+        - Apply Overview: commands/kubernetes_and_orchestration/apply/index.md
+        - Cluster: commands/kubernetes_and_orchestration/apply/cluster.md
+        - Container Registry: commands/kubernetes_and_orchestration/apply/container_registry.md
+        - K8S Pod Security Admission: commands/kubernetes_and_orchestration/apply/k8s_pod_security_admission.md
+        - K8S Pod Security Policy: commands/kubernetes_and_orchestration/apply/k8s_pod_security_policy.md
+        - Virtual K8S: commands/kubernetes_and_orchestration/apply/virtual_k8s.md
+        - Workload: commands/kubernetes_and_orchestration/apply/workload.md
+        - Workload Flavor: commands/kubernetes_and_orchestration/apply/workload_flavor.md
       - Create:
-        - Create Overview: commands/integrations/create/index.md
-        - Cminstance: commands/integrations/create/cminstance.md
-        - Tpm API Key: commands/integrations/create/tpm_api_key.md
-        - Tpm Category: commands/integrations/create/tpm_category.md
-        - Tpm Manager: commands/integrations/create/tpm_manager.md
+        - Create Overview: commands/kubernetes_and_orchestration/create/index.md
+        - Cluster: commands/kubernetes_and_orchestration/create/cluster.md
+        - Container Registry: commands/kubernetes_and_orchestration/create/container_registry.md
+        - K8S Pod Security Admission: commands/kubernetes_and_orchestration/create/k8s_pod_security_admission.md
+        - K8S Pod Security Policy: commands/kubernetes_and_orchestration/create/k8s_pod_security_policy.md
+        - Virtual K8S: commands/kubernetes_and_orchestration/create/virtual_k8s.md
+        - Workload: commands/kubernetes_and_orchestration/create/workload.md
+        - Workload Flavor: commands/kubernetes_and_orchestration/create/workload_flavor.md
       - Delete:
-        - Delete Overview: commands/integrations/delete/index.md
-        - Cminstance: commands/integrations/delete/cminstance.md
+        - Delete Overview: commands/kubernetes_and_orchestration/delete/index.md
+        - Cluster: commands/kubernetes_and_orchestration/delete/cluster.md
+        - Container Registry: commands/kubernetes_and_orchestration/delete/container_registry.md
+        - K8S Pod Security Admission: commands/kubernetes_and_orchestration/delete/k8s_pod_security_admission.md
+        - K8S Pod Security Policy: commands/kubernetes_and_orchestration/delete/k8s_pod_security_policy.md
+        - Virtual K8S: commands/kubernetes_and_orchestration/delete/virtual_k8s.md
+        - Workload: commands/kubernetes_and_orchestration/delete/workload.md
+        - Workload Flavor: commands/kubernetes_and_orchestration/delete/workload_flavor.md
       - Get:
-        - Get Overview: commands/integrations/get/index.md
-        - Cminstance: commands/integrations/get/cminstance.md
-        - Tpm API Key: commands/integrations/get/tpm_api_key.md
-        - Tpm Category: commands/integrations/get/tpm_category.md
-        - Tpm Manager: commands/integrations/get/tpm_manager.md
+        - Get Overview: commands/kubernetes_and_orchestration/get/index.md
+        - Cluster: commands/kubernetes_and_orchestration/get/cluster.md
+        - Container Registry: commands/kubernetes_and_orchestration/get/container_registry.md
+        - K8S Pod Security Admission: commands/kubernetes_and_orchestration/get/k8s_pod_security_admission.md
+        - K8S Pod Security Policy: commands/kubernetes_and_orchestration/get/k8s_pod_security_policy.md
+        - Virtual K8S: commands/kubernetes_and_orchestration/get/virtual_k8s.md
+        - Workload: commands/kubernetes_and_orchestration/get/workload.md
+        - Workload Flavor: commands/kubernetes_and_orchestration/get/workload_flavor.md
       - List:
-        - List Overview: commands/integrations/list/index.md
-        - Cminstance: commands/integrations/list/cminstance.md
-        - Tpm API Key: commands/integrations/list/tpm_api_key.md
-        - Tpm Category: commands/integrations/list/tpm_category.md
-        - Tpm Manager: commands/integrations/list/tpm_manager.md
+        - List Overview: commands/kubernetes_and_orchestration/list/index.md
+        - Cluster: commands/kubernetes_and_orchestration/list/cluster.md
+        - Container Registry: commands/kubernetes_and_orchestration/list/container_registry.md
+        - K8S Pod Security Admission: commands/kubernetes_and_orchestration/list/k8s_pod_security_admission.md
+        - K8S Pod Security Policy: commands/kubernetes_and_orchestration/list/k8s_pod_security_policy.md
+        - Virtual K8S: commands/kubernetes_and_orchestration/list/virtual_k8s.md
+        - Workload: commands/kubernetes_and_orchestration/list/workload.md
+        - Workload Flavor: commands/kubernetes_and_orchestration/list/workload_flavor.md
       - Patch:
-        - Patch Overview: commands/integrations/patch/index.md
-        - Cminstance: commands/integrations/patch/cminstance.md
-        - Tpm API Key: commands/integrations/patch/tpm_api_key.md
-        - Tpm Category: commands/integrations/patch/tpm_category.md
+        - Patch Overview: commands/kubernetes_and_orchestration/patch/index.md
+        - Cluster: commands/kubernetes_and_orchestration/patch/cluster.md
+        - Container Registry: commands/kubernetes_and_orchestration/patch/container_registry.md
+        - K8S Pod Security Admission: commands/kubernetes_and_orchestration/patch/k8s_pod_security_admission.md
+        - K8S Pod Security Policy: commands/kubernetes_and_orchestration/patch/k8s_pod_security_policy.md
+        - Virtual K8S: commands/kubernetes_and_orchestration/patch/virtual_k8s.md
+        - Workload: commands/kubernetes_and_orchestration/patch/workload.md
+        - Workload Flavor: commands/kubernetes_and_orchestration/patch/workload_flavor.md
       - Remove Labels:
-        - Remove Labels Overview: commands/integrations/remove-labels/index.md
-        - Cminstance: commands/integrations/remove-labels/cminstance.md
-        - Tpm API Key: commands/integrations/remove-labels/tpm_api_key.md
-        - Tpm Category: commands/integrations/remove-labels/tpm_category.md
-        - Tpm Manager: commands/integrations/remove-labels/tpm_manager.md
+        - Remove Labels Overview: commands/kubernetes_and_orchestration/remove-labels/index.md
+        - Cluster: commands/kubernetes_and_orchestration/remove-labels/cluster.md
+        - Container Registry: commands/kubernetes_and_orchestration/remove-labels/container_registry.md
+        - K8S Pod Security Admission: commands/kubernetes_and_orchestration/remove-labels/k8s_pod_security_admission.md
+        - K8S Pod Security Policy: commands/kubernetes_and_orchestration/remove-labels/k8s_pod_security_policy.md
+        - Virtual K8S: commands/kubernetes_and_orchestration/remove-labels/virtual_k8s.md
+        - Workload: commands/kubernetes_and_orchestration/remove-labels/workload.md
+        - Workload Flavor: commands/kubernetes_and_orchestration/remove-labels/workload_flavor.md
       - Replace:
-        - Replace Overview: commands/integrations/replace/index.md
-        - Cminstance: commands/integrations/replace/cminstance.md
-        - Tpm API Key: commands/integrations/replace/tpm_api_key.md
-        - Tpm Category: commands/integrations/replace/tpm_category.md
+        - Replace Overview: commands/kubernetes_and_orchestration/replace/index.md
+        - Cluster: commands/kubernetes_and_orchestration/replace/cluster.md
+        - Container Registry: commands/kubernetes_and_orchestration/replace/container_registry.md
+        - K8S Pod Security Admission: commands/kubernetes_and_orchestration/replace/k8s_pod_security_admission.md
+        - K8S Pod Security Policy: commands/kubernetes_and_orchestration/replace/k8s_pod_security_policy.md
+        - Virtual K8S: commands/kubernetes_and_orchestration/replace/virtual_k8s.md
+        - Workload: commands/kubernetes_and_orchestration/replace/workload.md
+        - Workload Flavor: commands/kubernetes_and_orchestration/replace/workload_flavor.md
       - Status:
-        - Status Overview: commands/integrations/status/index.md
-        - Cminstance: commands/integrations/status/cminstance.md
-    - Load Balancer:
-      - Load Balancer Overview: commands/load_balancer/index.md
+        - Status Overview: commands/kubernetes_and_orchestration/status/index.md
+        - Cluster: commands/kubernetes_and_orchestration/status/cluster.md
+        - Container Registry: commands/kubernetes_and_orchestration/status/container_registry.md
+        - K8S Pod Security Admission: commands/kubernetes_and_orchestration/status/k8s_pod_security_admission.md
+        - K8S Pod Security Policy: commands/kubernetes_and_orchestration/status/k8s_pod_security_policy.md
+        - Virtual K8S: commands/kubernetes_and_orchestration/status/virtual_k8s.md
+        - Workload: commands/kubernetes_and_orchestration/status/workload.md
+        - Workload Flavor: commands/kubernetes_and_orchestration/status/workload_flavor.md
+    - Marketplace:
+      - Marketplace Overview: commands/marketplace/index.md
       - Add Labels:
-        - Add Labels Overview: commands/load_balancer/add-labels/index.md
-        - Forward Proxy Policy: commands/load_balancer/add-labels/forward_proxy_policy.md
-        - Health Check: commands/load_balancer/add-labels/healthcheck.md
-        - HTTP Load Balancer: commands/load_balancer/add-labels/http_loadbalancer.md
-        - Origin Pool: commands/load_balancer/add-labels/origin_pool.md
-        - Proxy: commands/load_balancer/add-labels/proxy.md
-        - TCP Load Balancer: commands/load_balancer/add-labels/tcp_loadbalancer.md
-        - UDP Load Balancer: commands/load_balancer/add-labels/udp_loadbalancer.md
+        - Add Labels Overview: commands/marketplace/add-labels/index.md
+        - Cminstance: commands/marketplace/add-labels/cminstance.md
+        - External Connector: commands/marketplace/add-labels/external_connector.md
+        - Tpm API Key: commands/marketplace/add-labels/tpm_api_key.md
+        - Tpm Category: commands/marketplace/add-labels/tpm_category.md
+        - Tpm Manager: commands/marketplace/add-labels/tpm_manager.md
+        - Voltshare Admin Policy: commands/marketplace/add-labels/voltshare_admin_policy.md
       - Apply:
-        - Apply Overview: commands/load_balancer/apply/index.md
-        - Forward Proxy Policy: commands/load_balancer/apply/forward_proxy_policy.md
-        - Health Check: commands/load_balancer/apply/healthcheck.md
-        - HTTP Load Balancer: commands/load_balancer/apply/http_loadbalancer.md
-        - Origin Pool: commands/load_balancer/apply/origin_pool.md
-        - Proxy: commands/load_balancer/apply/proxy.md
-        - TCP Load Balancer: commands/load_balancer/apply/tcp_loadbalancer.md
-        - UDP Load Balancer: commands/load_balancer/apply/udp_loadbalancer.md
+        - Apply Overview: commands/marketplace/apply/index.md
+        - Cminstance: commands/marketplace/apply/cminstance.md
+        - External Connector: commands/marketplace/apply/external_connector.md
+        - Tpm API Key: commands/marketplace/apply/tpm_api_key.md
+        - Tpm Category: commands/marketplace/apply/tpm_category.md
+        - Tpm Manager: commands/marketplace/apply/tpm_manager.md
+        - Voltshare Admin Policy: commands/marketplace/apply/voltshare_admin_policy.md
       - Create:
-        - Create Overview: commands/load_balancer/create/index.md
-        - Forward Proxy Policy: commands/load_balancer/create/forward_proxy_policy.md
-        - Health Check: commands/load_balancer/create/healthcheck.md
-        - HTTP Load Balancer: commands/load_balancer/create/http_loadbalancer.md
-        - Origin Pool: commands/load_balancer/create/origin_pool.md
-        - Proxy: commands/load_balancer/create/proxy.md
-        - TCP Load Balancer: commands/load_balancer/create/tcp_loadbalancer.md
-        - UDP Load Balancer: commands/load_balancer/create/udp_loadbalancer.md
+        - Create Overview: commands/marketplace/create/index.md
+        - Cminstance: commands/marketplace/create/cminstance.md
+        - External Connector: commands/marketplace/create/external_connector.md
+        - Tpm API Key: commands/marketplace/create/tpm_api_key.md
+        - Tpm Category: commands/marketplace/create/tpm_category.md
+        - Tpm Manager: commands/marketplace/create/tpm_manager.md
+        - Voltshare Admin Policy: commands/marketplace/create/voltshare_admin_policy.md
       - Delete:
-        - Delete Overview: commands/load_balancer/delete/index.md
-        - Forward Proxy Policy: commands/load_balancer/delete/forward_proxy_policy.md
-        - Health Check: commands/load_balancer/delete/healthcheck.md
-        - HTTP Load Balancer: commands/load_balancer/delete/http_loadbalancer.md
-        - Origin Pool: commands/load_balancer/delete/origin_pool.md
-        - Proxy: commands/load_balancer/delete/proxy.md
-        - TCP Load Balancer: commands/load_balancer/delete/tcp_loadbalancer.md
-        - UDP Load Balancer: commands/load_balancer/delete/udp_loadbalancer.md
+        - Delete Overview: commands/marketplace/delete/index.md
+        - Cminstance: commands/marketplace/delete/cminstance.md
+        - External Connector: commands/marketplace/delete/external_connector.md
+        - Voltshare Admin Policy: commands/marketplace/delete/voltshare_admin_policy.md
       - Get:
-        - Get Overview: commands/load_balancer/get/index.md
-        - Forward Proxy Policy: commands/load_balancer/get/forward_proxy_policy.md
-        - Health Check: commands/load_balancer/get/healthcheck.md
-        - HTTP Load Balancer: commands/load_balancer/get/http_loadbalancer.md
-        - Origin Pool: commands/load_balancer/get/origin_pool.md
-        - Proxy: commands/load_balancer/get/proxy.md
-        - TCP Load Balancer: commands/load_balancer/get/tcp_loadbalancer.md
-        - UDP Load Balancer: commands/load_balancer/get/udp_loadbalancer.md
+        - Get Overview: commands/marketplace/get/index.md
+        - Cminstance: commands/marketplace/get/cminstance.md
+        - External Connector: commands/marketplace/get/external_connector.md
+        - Tpm API Key: commands/marketplace/get/tpm_api_key.md
+        - Tpm Category: commands/marketplace/get/tpm_category.md
+        - Tpm Manager: commands/marketplace/get/tpm_manager.md
+        - Voltshare Admin Policy: commands/marketplace/get/voltshare_admin_policy.md
       - List:
-        - List Overview: commands/load_balancer/list/index.md
-        - Forward Proxy Policy: commands/load_balancer/list/forward_proxy_policy.md
-        - Health Check: commands/load_balancer/list/healthcheck.md
-        - HTTP Load Balancer: commands/load_balancer/list/http_loadbalancer.md
-        - Origin Pool: commands/load_balancer/list/origin_pool.md
-        - Proxy: commands/load_balancer/list/proxy.md
-        - TCP Load Balancer: commands/load_balancer/list/tcp_loadbalancer.md
-        - UDP Load Balancer: commands/load_balancer/list/udp_loadbalancer.md
+        - List Overview: commands/marketplace/list/index.md
+        - Cminstance: commands/marketplace/list/cminstance.md
+        - External Connector: commands/marketplace/list/external_connector.md
+        - Tpm API Key: commands/marketplace/list/tpm_api_key.md
+        - Tpm Category: commands/marketplace/list/tpm_category.md
+        - Tpm Manager: commands/marketplace/list/tpm_manager.md
+        - Voltshare Admin Policy: commands/marketplace/list/voltshare_admin_policy.md
       - Patch:
-        - Patch Overview: commands/load_balancer/patch/index.md
-        - Forward Proxy Policy: commands/load_balancer/patch/forward_proxy_policy.md
-        - Health Check: commands/load_balancer/patch/healthcheck.md
-        - HTTP Load Balancer: commands/load_balancer/patch/http_loadbalancer.md
-        - Origin Pool: commands/load_balancer/patch/origin_pool.md
-        - Proxy: commands/load_balancer/patch/proxy.md
-        - TCP Load Balancer: commands/load_balancer/patch/tcp_loadbalancer.md
-        - UDP Load Balancer: commands/load_balancer/patch/udp_loadbalancer.md
+        - Patch Overview: commands/marketplace/patch/index.md
+        - Cminstance: commands/marketplace/patch/cminstance.md
+        - External Connector: commands/marketplace/patch/external_connector.md
+        - Tpm API Key: commands/marketplace/patch/tpm_api_key.md
+        - Tpm Category: commands/marketplace/patch/tpm_category.md
+        - Voltshare Admin Policy: commands/marketplace/patch/voltshare_admin_policy.md
       - Remove Labels:
-        - Remove Labels Overview: commands/load_balancer/remove-labels/index.md
-        - Forward Proxy Policy: commands/load_balancer/remove-labels/forward_proxy_policy.md
-        - Health Check: commands/load_balancer/remove-labels/healthcheck.md
-        - HTTP Load Balancer: commands/load_balancer/remove-labels/http_loadbalancer.md
-        - Origin Pool: commands/load_balancer/remove-labels/origin_pool.md
-        - Proxy: commands/load_balancer/remove-labels/proxy.md
-        - TCP Load Balancer: commands/load_balancer/remove-labels/tcp_loadbalancer.md
-        - UDP Load Balancer: commands/load_balancer/remove-labels/udp_loadbalancer.md
+        - Remove Labels Overview: commands/marketplace/remove-labels/index.md
+        - Cminstance: commands/marketplace/remove-labels/cminstance.md
+        - External Connector: commands/marketplace/remove-labels/external_connector.md
+        - Tpm API Key: commands/marketplace/remove-labels/tpm_api_key.md
+        - Tpm Category: commands/marketplace/remove-labels/tpm_category.md
+        - Tpm Manager: commands/marketplace/remove-labels/tpm_manager.md
+        - Voltshare Admin Policy: commands/marketplace/remove-labels/voltshare_admin_policy.md
       - Replace:
-        - Replace Overview: commands/load_balancer/replace/index.md
-        - Forward Proxy Policy: commands/load_balancer/replace/forward_proxy_policy.md
-        - Health Check: commands/load_balancer/replace/healthcheck.md
-        - HTTP Load Balancer: commands/load_balancer/replace/http_loadbalancer.md
-        - Origin Pool: commands/load_balancer/replace/origin_pool.md
-        - Proxy: commands/load_balancer/replace/proxy.md
-        - TCP Load Balancer: commands/load_balancer/replace/tcp_loadbalancer.md
-        - UDP Load Balancer: commands/load_balancer/replace/udp_loadbalancer.md
+        - Replace Overview: commands/marketplace/replace/index.md
+        - Cminstance: commands/marketplace/replace/cminstance.md
+        - External Connector: commands/marketplace/replace/external_connector.md
+        - Tpm API Key: commands/marketplace/replace/tpm_api_key.md
+        - Tpm Category: commands/marketplace/replace/tpm_category.md
+        - Voltshare Admin Policy: commands/marketplace/replace/voltshare_admin_policy.md
       - Status:
-        - Status Overview: commands/load_balancer/status/index.md
-        - Forward Proxy Policy: commands/load_balancer/status/forward_proxy_policy.md
-        - Health Check: commands/load_balancer/status/healthcheck.md
-        - HTTP Load Balancer: commands/load_balancer/status/http_loadbalancer.md
-        - Origin Pool: commands/load_balancer/status/origin_pool.md
-        - Proxy: commands/load_balancer/status/proxy.md
-        - TCP Load Balancer: commands/load_balancer/status/tcp_loadbalancer.md
-        - UDP Load Balancer: commands/load_balancer/status/udp_loadbalancer.md
-    - Networking:
-      - Networking Overview: commands/networking/index.md
+        - Status Overview: commands/marketplace/status/index.md
+        - Cminstance: commands/marketplace/status/cminstance.md
+        - External Connector: commands/marketplace/status/external_connector.md
+        - Voltshare Admin Policy: commands/marketplace/status/voltshare_admin_policy.md
+    - Network:
+      - Network Overview: commands/network/index.md
       - Add Labels:
-        - Add Labels Overview: commands/networking/add-labels/index.md
-        - Address Allocator: commands/networking/add-labels/address_allocator.md
-        - Advertise Policy: commands/networking/add-labels/advertise_policy.md
-        - BGP: commands/networking/add-labels/bgp.md
-        - BGP ASN Set: commands/networking/add-labels/bgp_asn_set.md
-        - BGP Routing Policy: commands/networking/add-labels/bgp_routing_policy.md
-        - Cloud Connect: commands/networking/add-labels/cloud_connect.md
-        - Cloud Elastic IP: commands/networking/add-labels/cloud_elastic_ip.md
-        - Cloud Link: commands/networking/add-labels/cloud_link.md
-        - Dc Cluster Group: commands/networking/add-labels/dc_cluster_group.md
-        - DNS Compliance Checks: commands/networking/add-labels/dns_compliance_checks.md
-        - DNS Domain: commands/networking/add-labels/dns_domain.md
-        - DNS LB Health Check: commands/networking/add-labels/dns_lb_health_check.md
-        - DNS LB Pool: commands/networking/add-labels/dns_lb_pool.md
-        - DNS Load Balancer: commands/networking/add-labels/dns_load_balancer.md
-        - DNS Zone: commands/networking/add-labels/dns_zone.md
-        - External Connector: commands/networking/add-labels/external_connector.md
-        - Fleet: commands/networking/add-labels/fleet.md
-        - Forwarding Class: commands/networking/add-labels/forwarding_class.md
-        - IP Prefix Set: commands/networking/add-labels/ip_prefix_set.md
-        - NAT Policy: commands/networking/add-labels/nat_policy.md
-        - Network Connector: commands/networking/add-labels/network_connector.md
-        - Network Firewall: commands/networking/add-labels/network_firewall.md
-        - Network Interface: commands/networking/add-labels/network_interface.md
-        - Network Policy: commands/networking/add-labels/network_policy.md
-        - Network Policy Rule: commands/networking/add-labels/network_policy_rule.md
-        - Network Policy View: commands/networking/add-labels/network_policy_view.md
-        - Policy Based Routing: commands/networking/add-labels/policy_based_routing.md
-        - Route: commands/networking/add-labels/route.md
-        - Segment: commands/networking/add-labels/segment.md
-        - Site Mesh Group: commands/networking/add-labels/site_mesh_group.md
-        - Srv6 Network Slice: commands/networking/add-labels/srv6_network_slice.md
-        - Subnet: commands/networking/add-labels/subnet.md
-        - Virtual Host: commands/networking/add-labels/virtual_host.md
-        - Virtual Network: commands/networking/add-labels/virtual_network.md
-        - Virtual Site: commands/networking/add-labels/virtual_site.md
+        - Add Labels Overview: commands/network/add-labels/index.md
+        - Address Allocator: commands/network/add-labels/address_allocator.md
+        - Advertise Policy: commands/network/add-labels/advertise_policy.md
+        - BGP: commands/network/add-labels/bgp.md
+        - BGP ASN Set: commands/network/add-labels/bgp_asn_set.md
+        - BGP Routing Policy: commands/network/add-labels/bgp_routing_policy.md
+        - Dc Cluster Group: commands/network/add-labels/dc_cluster_group.md
+        - Forwarding Class: commands/network/add-labels/forwarding_class.md
+        - Ike1: commands/network/add-labels/ike1.md
+        - Ike2: commands/network/add-labels/ike2.md
+        - IKE Phase1 Profile: commands/network/add-labels/ike_phase1_profile.md
+        - IKE Phase2 Profile: commands/network/add-labels/ike_phase2_profile.md
+        - IP Prefix Set: commands/network/add-labels/ip_prefix_set.md
+        - Network Connector: commands/network/add-labels/network_connector.md
+        - Route: commands/network/add-labels/route.md
+        - Srv6 Network Slice: commands/network/add-labels/srv6_network_slice.md
+        - Subnet: commands/network/add-labels/subnet.md
+        - Tunnel: commands/network/add-labels/tunnel.md
       - Apply:
-        - Apply Overview: commands/networking/apply/index.md
-        - Address Allocator: commands/networking/apply/address_allocator.md
-        - Advertise Policy: commands/networking/apply/advertise_policy.md
-        - BGP: commands/networking/apply/bgp.md
-        - BGP ASN Set: commands/networking/apply/bgp_asn_set.md
-        - BGP Routing Policy: commands/networking/apply/bgp_routing_policy.md
-        - Cloud Connect: commands/networking/apply/cloud_connect.md
-        - Cloud Elastic IP: commands/networking/apply/cloud_elastic_ip.md
-        - Cloud Link: commands/networking/apply/cloud_link.md
-        - Dc Cluster Group: commands/networking/apply/dc_cluster_group.md
-        - DNS Compliance Checks: commands/networking/apply/dns_compliance_checks.md
-        - DNS Domain: commands/networking/apply/dns_domain.md
-        - DNS LB Health Check: commands/networking/apply/dns_lb_health_check.md
-        - DNS LB Pool: commands/networking/apply/dns_lb_pool.md
-        - DNS Load Balancer: commands/networking/apply/dns_load_balancer.md
-        - DNS Zone: commands/networking/apply/dns_zone.md
-        - External Connector: commands/networking/apply/external_connector.md
-        - Fleet: commands/networking/apply/fleet.md
-        - Forwarding Class: commands/networking/apply/forwarding_class.md
-        - IP Prefix Set: commands/networking/apply/ip_prefix_set.md
-        - NAT Policy: commands/networking/apply/nat_policy.md
-        - Network Connector: commands/networking/apply/network_connector.md
-        - Network Firewall: commands/networking/apply/network_firewall.md
-        - Network Interface: commands/networking/apply/network_interface.md
-        - Network Policy: commands/networking/apply/network_policy.md
-        - Network Policy Rule: commands/networking/apply/network_policy_rule.md
-        - Network Policy View: commands/networking/apply/network_policy_view.md
-        - Policy Based Routing: commands/networking/apply/policy_based_routing.md
-        - Route: commands/networking/apply/route.md
-        - Segment: commands/networking/apply/segment.md
-        - Site Mesh Group: commands/networking/apply/site_mesh_group.md
-        - Srv6 Network Slice: commands/networking/apply/srv6_network_slice.md
-        - Subnet: commands/networking/apply/subnet.md
-        - Virtual Host: commands/networking/apply/virtual_host.md
-        - Virtual Network: commands/networking/apply/virtual_network.md
-        - Virtual Site: commands/networking/apply/virtual_site.md
+        - Apply Overview: commands/network/apply/index.md
+        - Address Allocator: commands/network/apply/address_allocator.md
+        - Advertise Policy: commands/network/apply/advertise_policy.md
+        - BGP: commands/network/apply/bgp.md
+        - BGP ASN Set: commands/network/apply/bgp_asn_set.md
+        - BGP Routing Policy: commands/network/apply/bgp_routing_policy.md
+        - Dc Cluster Group: commands/network/apply/dc_cluster_group.md
+        - Forwarding Class: commands/network/apply/forwarding_class.md
+        - Ike1: commands/network/apply/ike1.md
+        - Ike2: commands/network/apply/ike2.md
+        - IKE Phase1 Profile: commands/network/apply/ike_phase1_profile.md
+        - IKE Phase2 Profile: commands/network/apply/ike_phase2_profile.md
+        - IP Prefix Set: commands/network/apply/ip_prefix_set.md
+        - Network Connector: commands/network/apply/network_connector.md
+        - Route: commands/network/apply/route.md
+        - Srv6 Network Slice: commands/network/apply/srv6_network_slice.md
+        - Subnet: commands/network/apply/subnet.md
+        - Tunnel: commands/network/apply/tunnel.md
       - Create:
-        - Create Overview: commands/networking/create/index.md
-        - Address Allocator: commands/networking/create/address_allocator.md
-        - Advertise Policy: commands/networking/create/advertise_policy.md
-        - BGP: commands/networking/create/bgp.md
-        - BGP ASN Set: commands/networking/create/bgp_asn_set.md
-        - BGP Routing Policy: commands/networking/create/bgp_routing_policy.md
-        - Cloud Connect: commands/networking/create/cloud_connect.md
-        - Cloud Elastic IP: commands/networking/create/cloud_elastic_ip.md
-        - Cloud Link: commands/networking/create/cloud_link.md
-        - Dc Cluster Group: commands/networking/create/dc_cluster_group.md
-        - DNS Compliance Checks: commands/networking/create/dns_compliance_checks.md
-        - DNS Domain: commands/networking/create/dns_domain.md
-        - DNS LB Health Check: commands/networking/create/dns_lb_health_check.md
-        - DNS LB Pool: commands/networking/create/dns_lb_pool.md
-        - DNS Load Balancer: commands/networking/create/dns_load_balancer.md
-        - DNS Zone: commands/networking/create/dns_zone.md
-        - External Connector: commands/networking/create/external_connector.md
-        - Fleet: commands/networking/create/fleet.md
-        - Forwarding Class: commands/networking/create/forwarding_class.md
-        - IP Prefix Set: commands/networking/create/ip_prefix_set.md
-        - NAT Policy: commands/networking/create/nat_policy.md
-        - Network Connector: commands/networking/create/network_connector.md
-        - Network Firewall: commands/networking/create/network_firewall.md
-        - Network Interface: commands/networking/create/network_interface.md
-        - Network Policy: commands/networking/create/network_policy.md
-        - Network Policy Rule: commands/networking/create/network_policy_rule.md
-        - Network Policy View: commands/networking/create/network_policy_view.md
-        - Policy Based Routing: commands/networking/create/policy_based_routing.md
-        - Route: commands/networking/create/route.md
-        - Segment: commands/networking/create/segment.md
-        - Site Mesh Group: commands/networking/create/site_mesh_group.md
-        - Srv6 Network Slice: commands/networking/create/srv6_network_slice.md
-        - Subnet: commands/networking/create/subnet.md
-        - Virtual Host: commands/networking/create/virtual_host.md
-        - Virtual Network: commands/networking/create/virtual_network.md
-        - Virtual Site: commands/networking/create/virtual_site.md
+        - Create Overview: commands/network/create/index.md
+        - Address Allocator: commands/network/create/address_allocator.md
+        - Advertise Policy: commands/network/create/advertise_policy.md
+        - BGP: commands/network/create/bgp.md
+        - BGP ASN Set: commands/network/create/bgp_asn_set.md
+        - BGP Routing Policy: commands/network/create/bgp_routing_policy.md
+        - Dc Cluster Group: commands/network/create/dc_cluster_group.md
+        - Forwarding Class: commands/network/create/forwarding_class.md
+        - Ike1: commands/network/create/ike1.md
+        - Ike2: commands/network/create/ike2.md
+        - IKE Phase1 Profile: commands/network/create/ike_phase1_profile.md
+        - IKE Phase2 Profile: commands/network/create/ike_phase2_profile.md
+        - IP Prefix Set: commands/network/create/ip_prefix_set.md
+        - Network Connector: commands/network/create/network_connector.md
+        - Route: commands/network/create/route.md
+        - Srv6 Network Slice: commands/network/create/srv6_network_slice.md
+        - Subnet: commands/network/create/subnet.md
+        - Tunnel: commands/network/create/tunnel.md
       - Delete:
-        - Delete Overview: commands/networking/delete/index.md
-        - Address Allocator: commands/networking/delete/address_allocator.md
-        - Advertise Policy: commands/networking/delete/advertise_policy.md
-        - BGP: commands/networking/delete/bgp.md
-        - BGP ASN Set: commands/networking/delete/bgp_asn_set.md
-        - BGP Routing Policy: commands/networking/delete/bgp_routing_policy.md
-        - Cloud Connect: commands/networking/delete/cloud_connect.md
-        - Cloud Elastic IP: commands/networking/delete/cloud_elastic_ip.md
-        - Cloud Link: commands/networking/delete/cloud_link.md
-        - Dc Cluster Group: commands/networking/delete/dc_cluster_group.md
-        - DNS Compliance Checks: commands/networking/delete/dns_compliance_checks.md
-        - DNS Domain: commands/networking/delete/dns_domain.md
-        - DNS LB Health Check: commands/networking/delete/dns_lb_health_check.md
-        - DNS LB Pool: commands/networking/delete/dns_lb_pool.md
-        - DNS Load Balancer: commands/networking/delete/dns_load_balancer.md
-        - DNS Zone: commands/networking/delete/dns_zone.md
-        - External Connector: commands/networking/delete/external_connector.md
-        - Fleet: commands/networking/delete/fleet.md
-        - Forwarding Class: commands/networking/delete/forwarding_class.md
-        - IP Prefix Set: commands/networking/delete/ip_prefix_set.md
-        - NAT Policy: commands/networking/delete/nat_policy.md
-        - Network Connector: commands/networking/delete/network_connector.md
-        - Network Firewall: commands/networking/delete/network_firewall.md
-        - Network Interface: commands/networking/delete/network_interface.md
-        - Network Policy: commands/networking/delete/network_policy.md
-        - Network Policy Rule: commands/networking/delete/network_policy_rule.md
-        - Network Policy View: commands/networking/delete/network_policy_view.md
-        - Policy Based Routing: commands/networking/delete/policy_based_routing.md
-        - Route: commands/networking/delete/route.md
-        - Segment: commands/networking/delete/segment.md
-        - Site Mesh Group: commands/networking/delete/site_mesh_group.md
-        - Srv6 Network Slice: commands/networking/delete/srv6_network_slice.md
-        - Subnet: commands/networking/delete/subnet.md
-        - Virtual Host: commands/networking/delete/virtual_host.md
-        - Virtual Network: commands/networking/delete/virtual_network.md
-        - Virtual Site: commands/networking/delete/virtual_site.md
+        - Delete Overview: commands/network/delete/index.md
+        - Address Allocator: commands/network/delete/address_allocator.md
+        - Advertise Policy: commands/network/delete/advertise_policy.md
+        - BGP: commands/network/delete/bgp.md
+        - BGP ASN Set: commands/network/delete/bgp_asn_set.md
+        - BGP Routing Policy: commands/network/delete/bgp_routing_policy.md
+        - Dc Cluster Group: commands/network/delete/dc_cluster_group.md
+        - Forwarding Class: commands/network/delete/forwarding_class.md
+        - Ike1: commands/network/delete/ike1.md
+        - Ike2: commands/network/delete/ike2.md
+        - IKE Phase1 Profile: commands/network/delete/ike_phase1_profile.md
+        - IKE Phase2 Profile: commands/network/delete/ike_phase2_profile.md
+        - IP Prefix Set: commands/network/delete/ip_prefix_set.md
+        - Network Connector: commands/network/delete/network_connector.md
+        - Route: commands/network/delete/route.md
+        - Srv6 Network Slice: commands/network/delete/srv6_network_slice.md
+        - Subnet: commands/network/delete/subnet.md
+        - Tunnel: commands/network/delete/tunnel.md
       - Get:
-        - Get Overview: commands/networking/get/index.md
-        - Address Allocator: commands/networking/get/address_allocator.md
-        - Advertise Policy: commands/networking/get/advertise_policy.md
-        - BGP: commands/networking/get/bgp.md
-        - BGP ASN Set: commands/networking/get/bgp_asn_set.md
-        - BGP Routing Policy: commands/networking/get/bgp_routing_policy.md
-        - Cloud Connect: commands/networking/get/cloud_connect.md
-        - Cloud Elastic IP: commands/networking/get/cloud_elastic_ip.md
-        - Cloud Link: commands/networking/get/cloud_link.md
-        - Dc Cluster Group: commands/networking/get/dc_cluster_group.md
-        - DNS Compliance Checks: commands/networking/get/dns_compliance_checks.md
-        - DNS Domain: commands/networking/get/dns_domain.md
-        - DNS LB Health Check: commands/networking/get/dns_lb_health_check.md
-        - DNS LB Pool: commands/networking/get/dns_lb_pool.md
-        - DNS Load Balancer: commands/networking/get/dns_load_balancer.md
-        - DNS Zone: commands/networking/get/dns_zone.md
-        - External Connector: commands/networking/get/external_connector.md
-        - Fleet: commands/networking/get/fleet.md
-        - Forwarding Class: commands/networking/get/forwarding_class.md
-        - IP Prefix Set: commands/networking/get/ip_prefix_set.md
-        - NAT Policy: commands/networking/get/nat_policy.md
-        - Network Connector: commands/networking/get/network_connector.md
-        - Network Firewall: commands/networking/get/network_firewall.md
-        - Network Interface: commands/networking/get/network_interface.md
-        - Network Policy: commands/networking/get/network_policy.md
-        - Network Policy Rule: commands/networking/get/network_policy_rule.md
-        - Network Policy View: commands/networking/get/network_policy_view.md
-        - Policy Based Routing: commands/networking/get/policy_based_routing.md
-        - Route: commands/networking/get/route.md
-        - Segment: commands/networking/get/segment.md
-        - Site Mesh Group: commands/networking/get/site_mesh_group.md
-        - Srv6 Network Slice: commands/networking/get/srv6_network_slice.md
-        - Subnet: commands/networking/get/subnet.md
-        - Virtual Host: commands/networking/get/virtual_host.md
-        - Virtual Network: commands/networking/get/virtual_network.md
-        - Virtual Site: commands/networking/get/virtual_site.md
+        - Get Overview: commands/network/get/index.md
+        - Address Allocator: commands/network/get/address_allocator.md
+        - Advertise Policy: commands/network/get/advertise_policy.md
+        - BGP: commands/network/get/bgp.md
+        - BGP ASN Set: commands/network/get/bgp_asn_set.md
+        - BGP Routing Policy: commands/network/get/bgp_routing_policy.md
+        - Dc Cluster Group: commands/network/get/dc_cluster_group.md
+        - Forwarding Class: commands/network/get/forwarding_class.md
+        - Ike1: commands/network/get/ike1.md
+        - Ike2: commands/network/get/ike2.md
+        - IKE Phase1 Profile: commands/network/get/ike_phase1_profile.md
+        - IKE Phase2 Profile: commands/network/get/ike_phase2_profile.md
+        - IP Prefix Set: commands/network/get/ip_prefix_set.md
+        - Network Connector: commands/network/get/network_connector.md
+        - Route: commands/network/get/route.md
+        - Srv6 Network Slice: commands/network/get/srv6_network_slice.md
+        - Subnet: commands/network/get/subnet.md
+        - Tunnel: commands/network/get/tunnel.md
       - List:
-        - List Overview: commands/networking/list/index.md
-        - Address Allocator: commands/networking/list/address_allocator.md
-        - Advertise Policy: commands/networking/list/advertise_policy.md
-        - BGP: commands/networking/list/bgp.md
-        - BGP ASN Set: commands/networking/list/bgp_asn_set.md
-        - BGP Routing Policy: commands/networking/list/bgp_routing_policy.md
-        - Cloud Connect: commands/networking/list/cloud_connect.md
-        - Cloud Elastic IP: commands/networking/list/cloud_elastic_ip.md
-        - Cloud Link: commands/networking/list/cloud_link.md
-        - Dc Cluster Group: commands/networking/list/dc_cluster_group.md
-        - DNS Compliance Checks: commands/networking/list/dns_compliance_checks.md
-        - DNS Domain: commands/networking/list/dns_domain.md
-        - DNS LB Health Check: commands/networking/list/dns_lb_health_check.md
-        - DNS LB Pool: commands/networking/list/dns_lb_pool.md
-        - DNS Load Balancer: commands/networking/list/dns_load_balancer.md
-        - DNS Zone: commands/networking/list/dns_zone.md
-        - External Connector: commands/networking/list/external_connector.md
-        - Fleet: commands/networking/list/fleet.md
-        - Forwarding Class: commands/networking/list/forwarding_class.md
-        - IP Prefix Set: commands/networking/list/ip_prefix_set.md
-        - NAT Policy: commands/networking/list/nat_policy.md
-        - Network Connector: commands/networking/list/network_connector.md
-        - Network Firewall: commands/networking/list/network_firewall.md
-        - Network Interface: commands/networking/list/network_interface.md
-        - Network Policy: commands/networking/list/network_policy.md
-        - Network Policy Rule: commands/networking/list/network_policy_rule.md
-        - Network Policy View: commands/networking/list/network_policy_view.md
-        - Policy Based Routing: commands/networking/list/policy_based_routing.md
-        - Route: commands/networking/list/route.md
-        - Segment: commands/networking/list/segment.md
-        - Site Mesh Group: commands/networking/list/site_mesh_group.md
-        - Srv6 Network Slice: commands/networking/list/srv6_network_slice.md
-        - Subnet: commands/networking/list/subnet.md
-        - Virtual Host: commands/networking/list/virtual_host.md
-        - Virtual Network: commands/networking/list/virtual_network.md
-        - Virtual Site: commands/networking/list/virtual_site.md
+        - List Overview: commands/network/list/index.md
+        - Address Allocator: commands/network/list/address_allocator.md
+        - Advertise Policy: commands/network/list/advertise_policy.md
+        - BGP: commands/network/list/bgp.md
+        - BGP ASN Set: commands/network/list/bgp_asn_set.md
+        - BGP Routing Policy: commands/network/list/bgp_routing_policy.md
+        - Dc Cluster Group: commands/network/list/dc_cluster_group.md
+        - Forwarding Class: commands/network/list/forwarding_class.md
+        - Ike1: commands/network/list/ike1.md
+        - Ike2: commands/network/list/ike2.md
+        - IKE Phase1 Profile: commands/network/list/ike_phase1_profile.md
+        - IKE Phase2 Profile: commands/network/list/ike_phase2_profile.md
+        - IP Prefix Set: commands/network/list/ip_prefix_set.md
+        - Network Connector: commands/network/list/network_connector.md
+        - Route: commands/network/list/route.md
+        - Srv6 Network Slice: commands/network/list/srv6_network_slice.md
+        - Subnet: commands/network/list/subnet.md
+        - Tunnel: commands/network/list/tunnel.md
       - Patch:
-        - Patch Overview: commands/networking/patch/index.md
-        - Address Allocator: commands/networking/patch/address_allocator.md
-        - Advertise Policy: commands/networking/patch/advertise_policy.md
-        - BGP: commands/networking/patch/bgp.md
-        - BGP ASN Set: commands/networking/patch/bgp_asn_set.md
-        - BGP Routing Policy: commands/networking/patch/bgp_routing_policy.md
-        - Cloud Connect: commands/networking/patch/cloud_connect.md
-        - Cloud Elastic IP: commands/networking/patch/cloud_elastic_ip.md
-        - Cloud Link: commands/networking/patch/cloud_link.md
-        - Dc Cluster Group: commands/networking/patch/dc_cluster_group.md
-        - DNS Compliance Checks: commands/networking/patch/dns_compliance_checks.md
-        - DNS Domain: commands/networking/patch/dns_domain.md
-        - DNS LB Health Check: commands/networking/patch/dns_lb_health_check.md
-        - DNS LB Pool: commands/networking/patch/dns_lb_pool.md
-        - DNS Load Balancer: commands/networking/patch/dns_load_balancer.md
-        - DNS Zone: commands/networking/patch/dns_zone.md
-        - External Connector: commands/networking/patch/external_connector.md
-        - Fleet: commands/networking/patch/fleet.md
-        - Forwarding Class: commands/networking/patch/forwarding_class.md
-        - IP Prefix Set: commands/networking/patch/ip_prefix_set.md
-        - NAT Policy: commands/networking/patch/nat_policy.md
-        - Network Connector: commands/networking/patch/network_connector.md
-        - Network Firewall: commands/networking/patch/network_firewall.md
-        - Network Interface: commands/networking/patch/network_interface.md
-        - Network Policy: commands/networking/patch/network_policy.md
-        - Network Policy Rule: commands/networking/patch/network_policy_rule.md
-        - Network Policy View: commands/networking/patch/network_policy_view.md
-        - Policy Based Routing: commands/networking/patch/policy_based_routing.md
-        - Route: commands/networking/patch/route.md
-        - Segment: commands/networking/patch/segment.md
-        - Site Mesh Group: commands/networking/patch/site_mesh_group.md
-        - Srv6 Network Slice: commands/networking/patch/srv6_network_slice.md
-        - Subnet: commands/networking/patch/subnet.md
-        - Virtual Host: commands/networking/patch/virtual_host.md
-        - Virtual Network: commands/networking/patch/virtual_network.md
-        - Virtual Site: commands/networking/patch/virtual_site.md
+        - Patch Overview: commands/network/patch/index.md
+        - Address Allocator: commands/network/patch/address_allocator.md
+        - Advertise Policy: commands/network/patch/advertise_policy.md
+        - BGP: commands/network/patch/bgp.md
+        - BGP ASN Set: commands/network/patch/bgp_asn_set.md
+        - BGP Routing Policy: commands/network/patch/bgp_routing_policy.md
+        - Dc Cluster Group: commands/network/patch/dc_cluster_group.md
+        - Forwarding Class: commands/network/patch/forwarding_class.md
+        - Ike1: commands/network/patch/ike1.md
+        - Ike2: commands/network/patch/ike2.md
+        - IKE Phase1 Profile: commands/network/patch/ike_phase1_profile.md
+        - IKE Phase2 Profile: commands/network/patch/ike_phase2_profile.md
+        - IP Prefix Set: commands/network/patch/ip_prefix_set.md
+        - Network Connector: commands/network/patch/network_connector.md
+        - Route: commands/network/patch/route.md
+        - Srv6 Network Slice: commands/network/patch/srv6_network_slice.md
+        - Subnet: commands/network/patch/subnet.md
+        - Tunnel: commands/network/patch/tunnel.md
       - Remove Labels:
-        - Remove Labels Overview: commands/networking/remove-labels/index.md
-        - Address Allocator: commands/networking/remove-labels/address_allocator.md
-        - Advertise Policy: commands/networking/remove-labels/advertise_policy.md
-        - BGP: commands/networking/remove-labels/bgp.md
-        - BGP ASN Set: commands/networking/remove-labels/bgp_asn_set.md
-        - BGP Routing Policy: commands/networking/remove-labels/bgp_routing_policy.md
-        - Cloud Connect: commands/networking/remove-labels/cloud_connect.md
-        - Cloud Elastic IP: commands/networking/remove-labels/cloud_elastic_ip.md
-        - Cloud Link: commands/networking/remove-labels/cloud_link.md
-        - Dc Cluster Group: commands/networking/remove-labels/dc_cluster_group.md
-        - DNS Compliance Checks: commands/networking/remove-labels/dns_compliance_checks.md
-        - DNS Domain: commands/networking/remove-labels/dns_domain.md
-        - DNS LB Health Check: commands/networking/remove-labels/dns_lb_health_check.md
-        - DNS LB Pool: commands/networking/remove-labels/dns_lb_pool.md
-        - DNS Load Balancer: commands/networking/remove-labels/dns_load_balancer.md
-        - DNS Zone: commands/networking/remove-labels/dns_zone.md
-        - External Connector: commands/networking/remove-labels/external_connector.md
-        - Fleet: commands/networking/remove-labels/fleet.md
-        - Forwarding Class: commands/networking/remove-labels/forwarding_class.md
-        - IP Prefix Set: commands/networking/remove-labels/ip_prefix_set.md
-        - NAT Policy: commands/networking/remove-labels/nat_policy.md
-        - Network Connector: commands/networking/remove-labels/network_connector.md
-        - Network Firewall: commands/networking/remove-labels/network_firewall.md
-        - Network Interface: commands/networking/remove-labels/network_interface.md
-        - Network Policy: commands/networking/remove-labels/network_policy.md
-        - Network Policy Rule: commands/networking/remove-labels/network_policy_rule.md
-        - Network Policy View: commands/networking/remove-labels/network_policy_view.md
-        - Policy Based Routing: commands/networking/remove-labels/policy_based_routing.md
-        - Route: commands/networking/remove-labels/route.md
-        - Segment: commands/networking/remove-labels/segment.md
-        - Site Mesh Group: commands/networking/remove-labels/site_mesh_group.md
-        - Srv6 Network Slice: commands/networking/remove-labels/srv6_network_slice.md
-        - Subnet: commands/networking/remove-labels/subnet.md
-        - Virtual Host: commands/networking/remove-labels/virtual_host.md
-        - Virtual Network: commands/networking/remove-labels/virtual_network.md
-        - Virtual Site: commands/networking/remove-labels/virtual_site.md
+        - Remove Labels Overview: commands/network/remove-labels/index.md
+        - Address Allocator: commands/network/remove-labels/address_allocator.md
+        - Advertise Policy: commands/network/remove-labels/advertise_policy.md
+        - BGP: commands/network/remove-labels/bgp.md
+        - BGP ASN Set: commands/network/remove-labels/bgp_asn_set.md
+        - BGP Routing Policy: commands/network/remove-labels/bgp_routing_policy.md
+        - Dc Cluster Group: commands/network/remove-labels/dc_cluster_group.md
+        - Forwarding Class: commands/network/remove-labels/forwarding_class.md
+        - Ike1: commands/network/remove-labels/ike1.md
+        - Ike2: commands/network/remove-labels/ike2.md
+        - IKE Phase1 Profile: commands/network/remove-labels/ike_phase1_profile.md
+        - IKE Phase2 Profile: commands/network/remove-labels/ike_phase2_profile.md
+        - IP Prefix Set: commands/network/remove-labels/ip_prefix_set.md
+        - Network Connector: commands/network/remove-labels/network_connector.md
+        - Route: commands/network/remove-labels/route.md
+        - Srv6 Network Slice: commands/network/remove-labels/srv6_network_slice.md
+        - Subnet: commands/network/remove-labels/subnet.md
+        - Tunnel: commands/network/remove-labels/tunnel.md
       - Replace:
-        - Replace Overview: commands/networking/replace/index.md
-        - Address Allocator: commands/networking/replace/address_allocator.md
-        - Advertise Policy: commands/networking/replace/advertise_policy.md
-        - BGP: commands/networking/replace/bgp.md
-        - BGP ASN Set: commands/networking/replace/bgp_asn_set.md
-        - BGP Routing Policy: commands/networking/replace/bgp_routing_policy.md
-        - Cloud Connect: commands/networking/replace/cloud_connect.md
-        - Cloud Elastic IP: commands/networking/replace/cloud_elastic_ip.md
-        - Cloud Link: commands/networking/replace/cloud_link.md
-        - Dc Cluster Group: commands/networking/replace/dc_cluster_group.md
-        - DNS Compliance Checks: commands/networking/replace/dns_compliance_checks.md
-        - DNS Domain: commands/networking/replace/dns_domain.md
-        - DNS LB Health Check: commands/networking/replace/dns_lb_health_check.md
-        - DNS LB Pool: commands/networking/replace/dns_lb_pool.md
-        - DNS Load Balancer: commands/networking/replace/dns_load_balancer.md
-        - DNS Zone: commands/networking/replace/dns_zone.md
-        - External Connector: commands/networking/replace/external_connector.md
-        - Fleet: commands/networking/replace/fleet.md
-        - Forwarding Class: commands/networking/replace/forwarding_class.md
-        - IP Prefix Set: commands/networking/replace/ip_prefix_set.md
-        - NAT Policy: commands/networking/replace/nat_policy.md
-        - Network Connector: commands/networking/replace/network_connector.md
-        - Network Firewall: commands/networking/replace/network_firewall.md
-        - Network Interface: commands/networking/replace/network_interface.md
-        - Network Policy: commands/networking/replace/network_policy.md
-        - Network Policy Rule: commands/networking/replace/network_policy_rule.md
-        - Network Policy View: commands/networking/replace/network_policy_view.md
-        - Policy Based Routing: commands/networking/replace/policy_based_routing.md
-        - Route: commands/networking/replace/route.md
-        - Segment: commands/networking/replace/segment.md
-        - Site Mesh Group: commands/networking/replace/site_mesh_group.md
-        - Srv6 Network Slice: commands/networking/replace/srv6_network_slice.md
-        - Subnet: commands/networking/replace/subnet.md
-        - Virtual Host: commands/networking/replace/virtual_host.md
-        - Virtual Network: commands/networking/replace/virtual_network.md
-        - Virtual Site: commands/networking/replace/virtual_site.md
+        - Replace Overview: commands/network/replace/index.md
+        - Address Allocator: commands/network/replace/address_allocator.md
+        - Advertise Policy: commands/network/replace/advertise_policy.md
+        - BGP: commands/network/replace/bgp.md
+        - BGP ASN Set: commands/network/replace/bgp_asn_set.md
+        - BGP Routing Policy: commands/network/replace/bgp_routing_policy.md
+        - Dc Cluster Group: commands/network/replace/dc_cluster_group.md
+        - Forwarding Class: commands/network/replace/forwarding_class.md
+        - Ike1: commands/network/replace/ike1.md
+        - Ike2: commands/network/replace/ike2.md
+        - IKE Phase1 Profile: commands/network/replace/ike_phase1_profile.md
+        - IKE Phase2 Profile: commands/network/replace/ike_phase2_profile.md
+        - IP Prefix Set: commands/network/replace/ip_prefix_set.md
+        - Network Connector: commands/network/replace/network_connector.md
+        - Route: commands/network/replace/route.md
+        - Srv6 Network Slice: commands/network/replace/srv6_network_slice.md
+        - Subnet: commands/network/replace/subnet.md
+        - Tunnel: commands/network/replace/tunnel.md
       - Status:
-        - Status Overview: commands/networking/status/index.md
-        - Address Allocator: commands/networking/status/address_allocator.md
-        - Advertise Policy: commands/networking/status/advertise_policy.md
-        - BGP: commands/networking/status/bgp.md
-        - BGP ASN Set: commands/networking/status/bgp_asn_set.md
-        - BGP Routing Policy: commands/networking/status/bgp_routing_policy.md
-        - Cloud Connect: commands/networking/status/cloud_connect.md
-        - Cloud Elastic IP: commands/networking/status/cloud_elastic_ip.md
-        - Cloud Link: commands/networking/status/cloud_link.md
-        - Dc Cluster Group: commands/networking/status/dc_cluster_group.md
-        - DNS Compliance Checks: commands/networking/status/dns_compliance_checks.md
-        - DNS Domain: commands/networking/status/dns_domain.md
-        - DNS LB Health Check: commands/networking/status/dns_lb_health_check.md
-        - DNS LB Pool: commands/networking/status/dns_lb_pool.md
-        - DNS Load Balancer: commands/networking/status/dns_load_balancer.md
-        - DNS Zone: commands/networking/status/dns_zone.md
-        - External Connector: commands/networking/status/external_connector.md
-        - Fleet: commands/networking/status/fleet.md
-        - Forwarding Class: commands/networking/status/forwarding_class.md
-        - IP Prefix Set: commands/networking/status/ip_prefix_set.md
-        - NAT Policy: commands/networking/status/nat_policy.md
-        - Network Connector: commands/networking/status/network_connector.md
-        - Network Firewall: commands/networking/status/network_firewall.md
-        - Network Interface: commands/networking/status/network_interface.md
-        - Network Policy: commands/networking/status/network_policy.md
-        - Network Policy Rule: commands/networking/status/network_policy_rule.md
-        - Network Policy View: commands/networking/status/network_policy_view.md
-        - Policy Based Routing: commands/networking/status/policy_based_routing.md
-        - Route: commands/networking/status/route.md
-        - Segment: commands/networking/status/segment.md
-        - Site Mesh Group: commands/networking/status/site_mesh_group.md
-        - Srv6 Network Slice: commands/networking/status/srv6_network_slice.md
-        - Subnet: commands/networking/status/subnet.md
-        - Virtual Host: commands/networking/status/virtual_host.md
-        - Virtual Network: commands/networking/status/virtual_network.md
-        - Virtual Site: commands/networking/status/virtual_site.md
-    - Nginx:
-      - Nginx Overview: commands/nginx/index.md
-      - Add Labels: commands/nginx/add-labels/index.md
-      - Apply: commands/nginx/apply/index.md
-      - Create: commands/nginx/create/index.md
-      - Delete: commands/nginx/delete/index.md
-      - Get: commands/nginx/get/index.md
-      - List: commands/nginx/list/index.md
-      - Patch: commands/nginx/patch/index.md
-      - Remove Labels: commands/nginx/remove-labels/index.md
-      - Replace: commands/nginx/replace/index.md
-      - Status: commands/nginx/status/index.md
+        - Status Overview: commands/network/status/index.md
+        - Address Allocator: commands/network/status/address_allocator.md
+        - Advertise Policy: commands/network/status/advertise_policy.md
+        - BGP: commands/network/status/bgp.md
+        - BGP ASN Set: commands/network/status/bgp_asn_set.md
+        - BGP Routing Policy: commands/network/status/bgp_routing_policy.md
+        - Dc Cluster Group: commands/network/status/dc_cluster_group.md
+        - Forwarding Class: commands/network/status/forwarding_class.md
+        - Ike1: commands/network/status/ike1.md
+        - Ike2: commands/network/status/ike2.md
+        - IKE Phase1 Profile: commands/network/status/ike_phase1_profile.md
+        - IKE Phase2 Profile: commands/network/status/ike_phase2_profile.md
+        - IP Prefix Set: commands/network/status/ip_prefix_set.md
+        - Network Connector: commands/network/status/network_connector.md
+        - Route: commands/network/status/route.md
+        - Srv6 Network Slice: commands/network/status/srv6_network_slice.md
+        - Subnet: commands/network/status/subnet.md
+        - Tunnel: commands/network/status/tunnel.md
+    - Network Security:
+      - Network Security Overview: commands/network_security/index.md
+      - Add Labels:
+        - Add Labels Overview: commands/network_security/add-labels/index.md
+        - Fast ACL: commands/network_security/add-labels/fast_acl.md
+        - Fast ACL Rule: commands/network_security/add-labels/fast_acl_rule.md
+        - Filter Set: commands/network_security/add-labels/filter_set.md
+        - Forward Proxy Policy: commands/network_security/add-labels/forward_proxy_policy.md
+        - NAT Policy: commands/network_security/add-labels/nat_policy.md
+        - Network Firewall: commands/network_security/add-labels/network_firewall.md
+        - Network Policy: commands/network_security/add-labels/network_policy.md
+        - Network Policy Rule: commands/network_security/add-labels/network_policy_rule.md
+        - Network Policy View: commands/network_security/add-labels/network_policy_view.md
+        - Policy Based Routing: commands/network_security/add-labels/policy_based_routing.md
+        - Segment: commands/network_security/add-labels/segment.md
+        - Service Policy: commands/network_security/add-labels/service_policy.md
+      - Apply:
+        - Apply Overview: commands/network_security/apply/index.md
+        - Fast ACL: commands/network_security/apply/fast_acl.md
+        - Fast ACL Rule: commands/network_security/apply/fast_acl_rule.md
+        - Filter Set: commands/network_security/apply/filter_set.md
+        - Forward Proxy Policy: commands/network_security/apply/forward_proxy_policy.md
+        - NAT Policy: commands/network_security/apply/nat_policy.md
+        - Network Firewall: commands/network_security/apply/network_firewall.md
+        - Network Policy: commands/network_security/apply/network_policy.md
+        - Network Policy Rule: commands/network_security/apply/network_policy_rule.md
+        - Network Policy View: commands/network_security/apply/network_policy_view.md
+        - Policy Based Routing: commands/network_security/apply/policy_based_routing.md
+        - Segment: commands/network_security/apply/segment.md
+        - Service Policy: commands/network_security/apply/service_policy.md
+      - Create:
+        - Create Overview: commands/network_security/create/index.md
+        - Fast ACL: commands/network_security/create/fast_acl.md
+        - Fast ACL Rule: commands/network_security/create/fast_acl_rule.md
+        - Filter Set: commands/network_security/create/filter_set.md
+        - Forward Proxy Policy: commands/network_security/create/forward_proxy_policy.md
+        - NAT Policy: commands/network_security/create/nat_policy.md
+        - Network Firewall: commands/network_security/create/network_firewall.md
+        - Network Policy: commands/network_security/create/network_policy.md
+        - Network Policy Rule: commands/network_security/create/network_policy_rule.md
+        - Network Policy View: commands/network_security/create/network_policy_view.md
+        - Policy Based Routing: commands/network_security/create/policy_based_routing.md
+        - Segment: commands/network_security/create/segment.md
+        - Service Policy: commands/network_security/create/service_policy.md
+      - Delete:
+        - Delete Overview: commands/network_security/delete/index.md
+        - Fast ACL: commands/network_security/delete/fast_acl.md
+        - Fast ACL Rule: commands/network_security/delete/fast_acl_rule.md
+        - Filter Set: commands/network_security/delete/filter_set.md
+        - Forward Proxy Policy: commands/network_security/delete/forward_proxy_policy.md
+        - NAT Policy: commands/network_security/delete/nat_policy.md
+        - Network Firewall: commands/network_security/delete/network_firewall.md
+        - Network Policy: commands/network_security/delete/network_policy.md
+        - Network Policy Rule: commands/network_security/delete/network_policy_rule.md
+        - Network Policy View: commands/network_security/delete/network_policy_view.md
+        - Policy Based Routing: commands/network_security/delete/policy_based_routing.md
+        - Segment: commands/network_security/delete/segment.md
+        - Service Policy: commands/network_security/delete/service_policy.md
+      - Get:
+        - Get Overview: commands/network_security/get/index.md
+        - Fast ACL: commands/network_security/get/fast_acl.md
+        - Fast ACL Rule: commands/network_security/get/fast_acl_rule.md
+        - Filter Set: commands/network_security/get/filter_set.md
+        - Forward Proxy Policy: commands/network_security/get/forward_proxy_policy.md
+        - NAT Policy: commands/network_security/get/nat_policy.md
+        - Network Firewall: commands/network_security/get/network_firewall.md
+        - Network Policy: commands/network_security/get/network_policy.md
+        - Network Policy Rule: commands/network_security/get/network_policy_rule.md
+        - Network Policy View: commands/network_security/get/network_policy_view.md
+        - Policy Based Routing: commands/network_security/get/policy_based_routing.md
+        - Segment: commands/network_security/get/segment.md
+        - Service Policy: commands/network_security/get/service_policy.md
+      - List:
+        - List Overview: commands/network_security/list/index.md
+        - Fast ACL: commands/network_security/list/fast_acl.md
+        - Fast ACL Rule: commands/network_security/list/fast_acl_rule.md
+        - Filter Set: commands/network_security/list/filter_set.md
+        - Forward Proxy Policy: commands/network_security/list/forward_proxy_policy.md
+        - NAT Policy: commands/network_security/list/nat_policy.md
+        - Network Firewall: commands/network_security/list/network_firewall.md
+        - Network Policy: commands/network_security/list/network_policy.md
+        - Network Policy Rule: commands/network_security/list/network_policy_rule.md
+        - Network Policy View: commands/network_security/list/network_policy_view.md
+        - Policy Based Routing: commands/network_security/list/policy_based_routing.md
+        - Segment: commands/network_security/list/segment.md
+        - Service Policy: commands/network_security/list/service_policy.md
+      - Patch:
+        - Patch Overview: commands/network_security/patch/index.md
+        - Fast ACL: commands/network_security/patch/fast_acl.md
+        - Fast ACL Rule: commands/network_security/patch/fast_acl_rule.md
+        - Filter Set: commands/network_security/patch/filter_set.md
+        - Forward Proxy Policy: commands/network_security/patch/forward_proxy_policy.md
+        - NAT Policy: commands/network_security/patch/nat_policy.md
+        - Network Firewall: commands/network_security/patch/network_firewall.md
+        - Network Policy: commands/network_security/patch/network_policy.md
+        - Network Policy Rule: commands/network_security/patch/network_policy_rule.md
+        - Network Policy View: commands/network_security/patch/network_policy_view.md
+        - Policy Based Routing: commands/network_security/patch/policy_based_routing.md
+        - Segment: commands/network_security/patch/segment.md
+        - Service Policy: commands/network_security/patch/service_policy.md
+      - Remove Labels:
+        - Remove Labels Overview: commands/network_security/remove-labels/index.md
+        - Fast ACL: commands/network_security/remove-labels/fast_acl.md
+        - Fast ACL Rule: commands/network_security/remove-labels/fast_acl_rule.md
+        - Filter Set: commands/network_security/remove-labels/filter_set.md
+        - Forward Proxy Policy: commands/network_security/remove-labels/forward_proxy_policy.md
+        - NAT Policy: commands/network_security/remove-labels/nat_policy.md
+        - Network Firewall: commands/network_security/remove-labels/network_firewall.md
+        - Network Policy: commands/network_security/remove-labels/network_policy.md
+        - Network Policy Rule: commands/network_security/remove-labels/network_policy_rule.md
+        - Network Policy View: commands/network_security/remove-labels/network_policy_view.md
+        - Policy Based Routing: commands/network_security/remove-labels/policy_based_routing.md
+        - Segment: commands/network_security/remove-labels/segment.md
+        - Service Policy: commands/network_security/remove-labels/service_policy.md
+      - Replace:
+        - Replace Overview: commands/network_security/replace/index.md
+        - Fast ACL: commands/network_security/replace/fast_acl.md
+        - Fast ACL Rule: commands/network_security/replace/fast_acl_rule.md
+        - Filter Set: commands/network_security/replace/filter_set.md
+        - Forward Proxy Policy: commands/network_security/replace/forward_proxy_policy.md
+        - NAT Policy: commands/network_security/replace/nat_policy.md
+        - Network Firewall: commands/network_security/replace/network_firewall.md
+        - Network Policy: commands/network_security/replace/network_policy.md
+        - Network Policy Rule: commands/network_security/replace/network_policy_rule.md
+        - Network Policy View: commands/network_security/replace/network_policy_view.md
+        - Policy Based Routing: commands/network_security/replace/policy_based_routing.md
+        - Segment: commands/network_security/replace/segment.md
+        - Service Policy: commands/network_security/replace/service_policy.md
+      - Status:
+        - Status Overview: commands/network_security/status/index.md
+        - Fast ACL: commands/network_security/status/fast_acl.md
+        - Fast ACL Rule: commands/network_security/status/fast_acl_rule.md
+        - Filter Set: commands/network_security/status/filter_set.md
+        - Forward Proxy Policy: commands/network_security/status/forward_proxy_policy.md
+        - NAT Policy: commands/network_security/status/nat_policy.md
+        - Network Firewall: commands/network_security/status/network_firewall.md
+        - Network Policy: commands/network_security/status/network_policy.md
+        - Network Policy Rule: commands/network_security/status/network_policy_rule.md
+        - Network Policy View: commands/network_security/status/network_policy_view.md
+        - Policy Based Routing: commands/network_security/status/policy_based_routing.md
+        - Segment: commands/network_security/status/segment.md
+        - Service Policy: commands/network_security/status/service_policy.md
+    - Nginx One:
+      - Nginx One Overview: commands/nginx_one/index.md
+      - Add Labels: commands/nginx_one/add-labels/index.md
+      - Apply: commands/nginx_one/apply/index.md
+      - Create: commands/nginx_one/create/index.md
+      - Delete: commands/nginx_one/delete/index.md
+      - Get: commands/nginx_one/get/index.md
+      - List: commands/nginx_one/list/index.md
+      - Patch: commands/nginx_one/patch/index.md
+      - Remove Labels: commands/nginx_one/remove-labels/index.md
+      - Replace: commands/nginx_one/replace/index.md
+      - Status: commands/nginx_one/status/index.md
+    - Object Storage:
+      - Object Storage Overview: commands/object_storage/index.md
+      - Add Labels: commands/object_storage/add-labels/index.md
+      - Apply: commands/object_storage/apply/index.md
+      - Create: commands/object_storage/create/index.md
+      - Delete: commands/object_storage/delete/index.md
+      - Get: commands/object_storage/get/index.md
+      - List: commands/object_storage/list/index.md
+      - Patch: commands/object_storage/patch/index.md
+      - Remove Labels: commands/object_storage/remove-labels/index.md
+      - Replace: commands/object_storage/replace/index.md
+      - Status: commands/object_storage/status/index.md
     - Observability:
       - Observability Overview: commands/observability/index.md
+      - Add Labels: commands/observability/add-labels/index.md
+      - Apply: commands/observability/apply/index.md
+      - Create: commands/observability/create/index.md
+      - Delete: commands/observability/delete/index.md
+      - Get: commands/observability/get/index.md
+      - List: commands/observability/list/index.md
+      - Patch: commands/observability/patch/index.md
+      - Remove Labels: commands/observability/remove-labels/index.md
+      - Replace: commands/observability/replace/index.md
+      - Status: commands/observability/status/index.md
+    - Rate Limiting:
+      - Rate Limiting Overview: commands/rate_limiting/index.md
       - Add Labels:
-        - Add Labels Overview: commands/observability/add-labels/index.md
-        - Alert Policy: commands/observability/add-labels/alert_policy.md
-        - Alert Receiver: commands/observability/add-labels/alert_receiver.md
-        - Global Log Receiver: commands/observability/add-labels/global_log_receiver.md
-        - Log Receiver: commands/observability/add-labels/log_receiver.md
-        - Report Config: commands/observability/add-labels/report_config.md
+        - Add Labels Overview: commands/rate_limiting/add-labels/index.md
+        - Policer: commands/rate_limiting/add-labels/policer.md
+        - Protocol Policer: commands/rate_limiting/add-labels/protocol_policer.md
+        - Rate Limiter: commands/rate_limiting/add-labels/rate_limiter.md
       - Apply:
-        - Apply Overview: commands/observability/apply/index.md
-        - Alert Policy: commands/observability/apply/alert_policy.md
-        - Alert Receiver: commands/observability/apply/alert_receiver.md
-        - Global Log Receiver: commands/observability/apply/global_log_receiver.md
-        - Log Receiver: commands/observability/apply/log_receiver.md
-        - Report Config: commands/observability/apply/report_config.md
+        - Apply Overview: commands/rate_limiting/apply/index.md
+        - Policer: commands/rate_limiting/apply/policer.md
+        - Protocol Policer: commands/rate_limiting/apply/protocol_policer.md
+        - Rate Limiter: commands/rate_limiting/apply/rate_limiter.md
       - Create:
-        - Create Overview: commands/observability/create/index.md
-        - Alert Policy: commands/observability/create/alert_policy.md
-        - Alert Receiver: commands/observability/create/alert_receiver.md
-        - Global Log Receiver: commands/observability/create/global_log_receiver.md
-        - Log Receiver: commands/observability/create/log_receiver.md
-        - Report Config: commands/observability/create/report_config.md
+        - Create Overview: commands/rate_limiting/create/index.md
+        - Policer: commands/rate_limiting/create/policer.md
+        - Protocol Policer: commands/rate_limiting/create/protocol_policer.md
+        - Rate Limiter: commands/rate_limiting/create/rate_limiter.md
       - Delete:
-        - Delete Overview: commands/observability/delete/index.md
-        - Alert Policy: commands/observability/delete/alert_policy.md
-        - Alert Receiver: commands/observability/delete/alert_receiver.md
-        - Global Log Receiver: commands/observability/delete/global_log_receiver.md
-        - Log Receiver: commands/observability/delete/log_receiver.md
-        - Report Config: commands/observability/delete/report_config.md
+        - Delete Overview: commands/rate_limiting/delete/index.md
+        - Policer: commands/rate_limiting/delete/policer.md
+        - Protocol Policer: commands/rate_limiting/delete/protocol_policer.md
+        - Rate Limiter: commands/rate_limiting/delete/rate_limiter.md
       - Get:
-        - Get Overview: commands/observability/get/index.md
-        - Alert Policy: commands/observability/get/alert_policy.md
-        - Alert Receiver: commands/observability/get/alert_receiver.md
-        - Global Log Receiver: commands/observability/get/global_log_receiver.md
-        - Log Receiver: commands/observability/get/log_receiver.md
-        - Report Config: commands/observability/get/report_config.md
+        - Get Overview: commands/rate_limiting/get/index.md
+        - Policer: commands/rate_limiting/get/policer.md
+        - Protocol Policer: commands/rate_limiting/get/protocol_policer.md
+        - Rate Limiter: commands/rate_limiting/get/rate_limiter.md
       - List:
-        - List Overview: commands/observability/list/index.md
-        - Alert Policy: commands/observability/list/alert_policy.md
-        - Alert Receiver: commands/observability/list/alert_receiver.md
-        - Global Log Receiver: commands/observability/list/global_log_receiver.md
-        - Log Receiver: commands/observability/list/log_receiver.md
-        - Report Config: commands/observability/list/report_config.md
+        - List Overview: commands/rate_limiting/list/index.md
+        - Policer: commands/rate_limiting/list/policer.md
+        - Protocol Policer: commands/rate_limiting/list/protocol_policer.md
+        - Rate Limiter: commands/rate_limiting/list/rate_limiter.md
       - Patch:
-        - Patch Overview: commands/observability/patch/index.md
-        - Alert Policy: commands/observability/patch/alert_policy.md
-        - Alert Receiver: commands/observability/patch/alert_receiver.md
-        - Global Log Receiver: commands/observability/patch/global_log_receiver.md
-        - Log Receiver: commands/observability/patch/log_receiver.md
-        - Report Config: commands/observability/patch/report_config.md
+        - Patch Overview: commands/rate_limiting/patch/index.md
+        - Policer: commands/rate_limiting/patch/policer.md
+        - Protocol Policer: commands/rate_limiting/patch/protocol_policer.md
+        - Rate Limiter: commands/rate_limiting/patch/rate_limiter.md
       - Remove Labels:
-        - Remove Labels Overview: commands/observability/remove-labels/index.md
-        - Alert Policy: commands/observability/remove-labels/alert_policy.md
-        - Alert Receiver: commands/observability/remove-labels/alert_receiver.md
-        - Global Log Receiver: commands/observability/remove-labels/global_log_receiver.md
-        - Log Receiver: commands/observability/remove-labels/log_receiver.md
-        - Report Config: commands/observability/remove-labels/report_config.md
+        - Remove Labels Overview: commands/rate_limiting/remove-labels/index.md
+        - Policer: commands/rate_limiting/remove-labels/policer.md
+        - Protocol Policer: commands/rate_limiting/remove-labels/protocol_policer.md
+        - Rate Limiter: commands/rate_limiting/remove-labels/rate_limiter.md
       - Replace:
-        - Replace Overview: commands/observability/replace/index.md
-        - Alert Policy: commands/observability/replace/alert_policy.md
-        - Alert Receiver: commands/observability/replace/alert_receiver.md
-        - Global Log Receiver: commands/observability/replace/global_log_receiver.md
-        - Log Receiver: commands/observability/replace/log_receiver.md
-        - Report Config: commands/observability/replace/report_config.md
+        - Replace Overview: commands/rate_limiting/replace/index.md
+        - Policer: commands/rate_limiting/replace/policer.md
+        - Protocol Policer: commands/rate_limiting/replace/protocol_policer.md
+        - Rate Limiter: commands/rate_limiting/replace/rate_limiter.md
       - Status:
-        - Status Overview: commands/observability/status/index.md
-        - Alert Policy: commands/observability/status/alert_policy.md
-        - Alert Receiver: commands/observability/status/alert_receiver.md
-        - Global Log Receiver: commands/observability/status/global_log_receiver.md
-        - Log Receiver: commands/observability/status/log_receiver.md
-        - Report Config: commands/observability/status/report_config.md
-    - Operations:
-      - Operations Overview: commands/operations/index.md
-      - Add Labels:
-        - Add Labels Overview: commands/operations/add-labels/index.md
-        - Customer Support: commands/operations/add-labels/customer_support.md
-      - Apply:
-        - Apply Overview: commands/operations/apply/index.md
-        - Customer Support: commands/operations/apply/customer_support.md
-      - Create:
-        - Create Overview: commands/operations/create/index.md
-        - Customer Support: commands/operations/create/customer_support.md
-      - Delete:
-        - Delete Overview: commands/operations/delete/index.md
-        - Customer Support: commands/operations/delete/customer_support.md
-      - Get:
-        - Get Overview: commands/operations/get/index.md
-        - Customer Support: commands/operations/get/customer_support.md
-      - List:
-        - List Overview: commands/operations/list/index.md
-        - Customer Support: commands/operations/list/customer_support.md
-      - Patch:
-        - Patch Overview: commands/operations/patch/index.md
-        - Customer Support: commands/operations/patch/customer_support.md
-      - Remove Labels:
-        - Remove Labels Overview: commands/operations/remove-labels/index.md
-        - Customer Support: commands/operations/remove-labels/customer_support.md
-      - Replace:
-        - Replace Overview: commands/operations/replace/index.md
-        - Customer Support: commands/operations/replace/customer_support.md
-      - Status:
-        - Status Overview: commands/operations/status/index.md
-        - Customer Support: commands/operations/status/customer_support.md
+        - Status Overview: commands/rate_limiting/status/index.md
+        - Policer: commands/rate_limiting/status/policer.md
+        - Protocol Policer: commands/rate_limiting/status/protocol_policer.md
+        - Rate Limiter: commands/rate_limiting/status/rate_limiter.md
     - Request:
       - Request Overview: commands/request/index.md
       - Command Sequence: commands/request/command-sequence/index.md
@@ -1566,354 +1607,180 @@ nav:
         - Get Policy Document: commands/request/secrets/get-policy-document.md
         - Get Public Key: commands/request/secrets/get-public-key.md
         - Secret Info: commands/request/secrets/secret-info.md
-    - Security:
-      - Security Overview: commands/security/index.md
+    - Secops And Incident Response:
+      - Secops And Incident Response Overview: commands/secops_and_incident_response/index.md
       - Add Labels:
-        - Add Labels Overview: commands/security/add-labels/index.md
-        - API Definition: commands/security/add-labels/api_definition.md
-        - App Firewall: commands/security/add-labels/app_firewall.md
-        - Bot Defense App Infrastructure: commands/security/add-labels/bot_defense_app_infrastructure.md
-        - CRL: commands/security/add-labels/crl.md
-        - Data Type: commands/security/add-labels/data_type.md
-        - Enhanced Firewall Policy: commands/security/add-labels/enhanced_firewall_policy.md
-        - Fast ACL: commands/security/add-labels/fast_acl.md
-        - Fast ACL Rule: commands/security/add-labels/fast_acl_rule.md
-        - Filter Set: commands/security/add-labels/filter_set.md
-        - Geo Location Set: commands/security/add-labels/geo_location_set.md
-        - Malicious User Mitigation: commands/security/add-labels/malicious_user_mitigation.md
-        - Policer: commands/security/add-labels/policer.md
-        - Protocol Inspection: commands/security/add-labels/protocol_inspection.md
-        - Protocol Policer: commands/security/add-labels/protocol_policer.md
-        - Rate Limiter: commands/security/add-labels/rate_limiter.md
-        - Rate Limiter Policy: commands/security/add-labels/rate_limiter_policy.md
-        - Secret Management Access: commands/security/add-labels/secret_management_access.md
-        - Secret Policy: commands/security/add-labels/secret_policy.md
-        - Secret Policy Rule: commands/security/add-labels/secret_policy_rule.md
-        - Service Policy: commands/security/add-labels/service_policy.md
-        - Service Policy Rule: commands/security/add-labels/service_policy_rule.md
-        - Trusted CA List: commands/security/add-labels/trusted_ca_list.md
-        - Voltshare Admin Policy: commands/security/add-labels/voltshare_admin_policy.md
-        - WAF Exclusion Policy: commands/security/add-labels/waf_exclusion_policy.md
+        - Add Labels Overview: commands/secops_and_incident_response/add-labels/index.md
+        - Malicious User Mitigation: commands/secops_and_incident_response/add-labels/malicious_user_mitigation.md
+        - Secret Management Access: commands/secops_and_incident_response/add-labels/secret_management_access.md
       - Apply:
-        - Apply Overview: commands/security/apply/index.md
-        - API Definition: commands/security/apply/api_definition.md
-        - App Firewall: commands/security/apply/app_firewall.md
-        - Bot Defense App Infrastructure: commands/security/apply/bot_defense_app_infrastructure.md
-        - CRL: commands/security/apply/crl.md
-        - Data Type: commands/security/apply/data_type.md
-        - Enhanced Firewall Policy: commands/security/apply/enhanced_firewall_policy.md
-        - Fast ACL: commands/security/apply/fast_acl.md
-        - Fast ACL Rule: commands/security/apply/fast_acl_rule.md
-        - Filter Set: commands/security/apply/filter_set.md
-        - Geo Location Set: commands/security/apply/geo_location_set.md
-        - Malicious User Mitigation: commands/security/apply/malicious_user_mitigation.md
-        - Policer: commands/security/apply/policer.md
-        - Protocol Inspection: commands/security/apply/protocol_inspection.md
-        - Protocol Policer: commands/security/apply/protocol_policer.md
-        - Rate Limiter: commands/security/apply/rate_limiter.md
-        - Rate Limiter Policy: commands/security/apply/rate_limiter_policy.md
-        - Secret Management Access: commands/security/apply/secret_management_access.md
-        - Secret Policy: commands/security/apply/secret_policy.md
-        - Secret Policy Rule: commands/security/apply/secret_policy_rule.md
-        - Service Policy: commands/security/apply/service_policy.md
-        - Service Policy Rule: commands/security/apply/service_policy_rule.md
-        - Trusted CA List: commands/security/apply/trusted_ca_list.md
-        - Voltshare Admin Policy: commands/security/apply/voltshare_admin_policy.md
-        - WAF Exclusion Policy: commands/security/apply/waf_exclusion_policy.md
+        - Apply Overview: commands/secops_and_incident_response/apply/index.md
+        - Malicious User Mitigation: commands/secops_and_incident_response/apply/malicious_user_mitigation.md
+        - Secret Management Access: commands/secops_and_incident_response/apply/secret_management_access.md
       - Create:
-        - Create Overview: commands/security/create/index.md
-        - API Definition: commands/security/create/api_definition.md
-        - App Firewall: commands/security/create/app_firewall.md
-        - Bot Defense App Infrastructure: commands/security/create/bot_defense_app_infrastructure.md
-        - CRL: commands/security/create/crl.md
-        - Data Type: commands/security/create/data_type.md
-        - Enhanced Firewall Policy: commands/security/create/enhanced_firewall_policy.md
-        - Fast ACL: commands/security/create/fast_acl.md
-        - Fast ACL Rule: commands/security/create/fast_acl_rule.md
-        - Filter Set: commands/security/create/filter_set.md
-        - Geo Location Set: commands/security/create/geo_location_set.md
-        - Malicious User Mitigation: commands/security/create/malicious_user_mitigation.md
-        - Policer: commands/security/create/policer.md
-        - Protocol Inspection: commands/security/create/protocol_inspection.md
-        - Protocol Policer: commands/security/create/protocol_policer.md
-        - Rate Limiter: commands/security/create/rate_limiter.md
-        - Rate Limiter Policy: commands/security/create/rate_limiter_policy.md
-        - Secret Management Access: commands/security/create/secret_management_access.md
-        - Secret Policy: commands/security/create/secret_policy.md
-        - Secret Policy Rule: commands/security/create/secret_policy_rule.md
-        - Service Policy: commands/security/create/service_policy.md
-        - Service Policy Rule: commands/security/create/service_policy_rule.md
-        - Trusted CA List: commands/security/create/trusted_ca_list.md
-        - Voltshare Admin Policy: commands/security/create/voltshare_admin_policy.md
-        - WAF Exclusion Policy: commands/security/create/waf_exclusion_policy.md
+        - Create Overview: commands/secops_and_incident_response/create/index.md
+        - Malicious User Mitigation: commands/secops_and_incident_response/create/malicious_user_mitigation.md
+        - Secret Management Access: commands/secops_and_incident_response/create/secret_management_access.md
       - Delete:
-        - Delete Overview: commands/security/delete/index.md
-        - API Definition: commands/security/delete/api_definition.md
-        - App Firewall: commands/security/delete/app_firewall.md
-        - Bot Defense App Infrastructure: commands/security/delete/bot_defense_app_infrastructure.md
-        - CRL: commands/security/delete/crl.md
-        - Data Type: commands/security/delete/data_type.md
-        - Enhanced Firewall Policy: commands/security/delete/enhanced_firewall_policy.md
-        - Fast ACL: commands/security/delete/fast_acl.md
-        - Fast ACL Rule: commands/security/delete/fast_acl_rule.md
-        - Filter Set: commands/security/delete/filter_set.md
-        - Geo Location Set: commands/security/delete/geo_location_set.md
-        - Malicious User Mitigation: commands/security/delete/malicious_user_mitigation.md
-        - Policer: commands/security/delete/policer.md
-        - Protocol Inspection: commands/security/delete/protocol_inspection.md
-        - Protocol Policer: commands/security/delete/protocol_policer.md
-        - Rate Limiter: commands/security/delete/rate_limiter.md
-        - Rate Limiter Policy: commands/security/delete/rate_limiter_policy.md
-        - Secret Management Access: commands/security/delete/secret_management_access.md
-        - Secret Policy: commands/security/delete/secret_policy.md
-        - Secret Policy Rule: commands/security/delete/secret_policy_rule.md
-        - Service Policy: commands/security/delete/service_policy.md
-        - Service Policy Rule: commands/security/delete/service_policy_rule.md
-        - Trusted CA List: commands/security/delete/trusted_ca_list.md
-        - Voltshare Admin Policy: commands/security/delete/voltshare_admin_policy.md
-        - WAF Exclusion Policy: commands/security/delete/waf_exclusion_policy.md
+        - Delete Overview: commands/secops_and_incident_response/delete/index.md
+        - Malicious User Mitigation: commands/secops_and_incident_response/delete/malicious_user_mitigation.md
+        - Secret Management Access: commands/secops_and_incident_response/delete/secret_management_access.md
       - Get:
-        - Get Overview: commands/security/get/index.md
-        - API Definition: commands/security/get/api_definition.md
-        - App Firewall: commands/security/get/app_firewall.md
-        - Bot Defense App Infrastructure: commands/security/get/bot_defense_app_infrastructure.md
-        - CRL: commands/security/get/crl.md
-        - Data Type: commands/security/get/data_type.md
-        - Enhanced Firewall Policy: commands/security/get/enhanced_firewall_policy.md
-        - Fast ACL: commands/security/get/fast_acl.md
-        - Fast ACL Rule: commands/security/get/fast_acl_rule.md
-        - Filter Set: commands/security/get/filter_set.md
-        - Geo Location Set: commands/security/get/geo_location_set.md
-        - Malicious User Mitigation: commands/security/get/malicious_user_mitigation.md
-        - Policer: commands/security/get/policer.md
-        - Protocol Inspection: commands/security/get/protocol_inspection.md
-        - Protocol Policer: commands/security/get/protocol_policer.md
-        - Rate Limiter: commands/security/get/rate_limiter.md
-        - Rate Limiter Policy: commands/security/get/rate_limiter_policy.md
-        - Secret Management Access: commands/security/get/secret_management_access.md
-        - Secret Policy: commands/security/get/secret_policy.md
-        - Secret Policy Rule: commands/security/get/secret_policy_rule.md
-        - Service Policy: commands/security/get/service_policy.md
-        - Service Policy Rule: commands/security/get/service_policy_rule.md
-        - Trusted CA List: commands/security/get/trusted_ca_list.md
-        - Voltshare Admin Policy: commands/security/get/voltshare_admin_policy.md
-        - WAF Exclusion Policy: commands/security/get/waf_exclusion_policy.md
+        - Get Overview: commands/secops_and_incident_response/get/index.md
+        - Malicious User Mitigation: commands/secops_and_incident_response/get/malicious_user_mitigation.md
+        - Secret Management Access: commands/secops_and_incident_response/get/secret_management_access.md
       - List:
-        - List Overview: commands/security/list/index.md
-        - API Definition: commands/security/list/api_definition.md
-        - App Firewall: commands/security/list/app_firewall.md
-        - Bot Defense App Infrastructure: commands/security/list/bot_defense_app_infrastructure.md
-        - CRL: commands/security/list/crl.md
-        - Data Type: commands/security/list/data_type.md
-        - Enhanced Firewall Policy: commands/security/list/enhanced_firewall_policy.md
-        - Fast ACL: commands/security/list/fast_acl.md
-        - Fast ACL Rule: commands/security/list/fast_acl_rule.md
-        - Filter Set: commands/security/list/filter_set.md
-        - Geo Location Set: commands/security/list/geo_location_set.md
-        - Malicious User Mitigation: commands/security/list/malicious_user_mitigation.md
-        - Policer: commands/security/list/policer.md
-        - Protocol Inspection: commands/security/list/protocol_inspection.md
-        - Protocol Policer: commands/security/list/protocol_policer.md
-        - Rate Limiter: commands/security/list/rate_limiter.md
-        - Rate Limiter Policy: commands/security/list/rate_limiter_policy.md
-        - Secret Management Access: commands/security/list/secret_management_access.md
-        - Secret Policy: commands/security/list/secret_policy.md
-        - Secret Policy Rule: commands/security/list/secret_policy_rule.md
-        - Service Policy: commands/security/list/service_policy.md
-        - Service Policy Rule: commands/security/list/service_policy_rule.md
-        - Trusted CA List: commands/security/list/trusted_ca_list.md
-        - Voltshare Admin Policy: commands/security/list/voltshare_admin_policy.md
-        - WAF Exclusion Policy: commands/security/list/waf_exclusion_policy.md
+        - List Overview: commands/secops_and_incident_response/list/index.md
+        - Malicious User Mitigation: commands/secops_and_incident_response/list/malicious_user_mitigation.md
+        - Secret Management Access: commands/secops_and_incident_response/list/secret_management_access.md
       - Patch:
-        - Patch Overview: commands/security/patch/index.md
-        - API Definition: commands/security/patch/api_definition.md
-        - App Firewall: commands/security/patch/app_firewall.md
-        - Bot Defense App Infrastructure: commands/security/patch/bot_defense_app_infrastructure.md
-        - CRL: commands/security/patch/crl.md
-        - Data Type: commands/security/patch/data_type.md
-        - Enhanced Firewall Policy: commands/security/patch/enhanced_firewall_policy.md
-        - Fast ACL: commands/security/patch/fast_acl.md
-        - Fast ACL Rule: commands/security/patch/fast_acl_rule.md
-        - Filter Set: commands/security/patch/filter_set.md
-        - Geo Location Set: commands/security/patch/geo_location_set.md
-        - Malicious User Mitigation: commands/security/patch/malicious_user_mitigation.md
-        - Policer: commands/security/patch/policer.md
-        - Protocol Inspection: commands/security/patch/protocol_inspection.md
-        - Protocol Policer: commands/security/patch/protocol_policer.md
-        - Rate Limiter: commands/security/patch/rate_limiter.md
-        - Rate Limiter Policy: commands/security/patch/rate_limiter_policy.md
-        - Secret Management Access: commands/security/patch/secret_management_access.md
-        - Secret Policy: commands/security/patch/secret_policy.md
-        - Secret Policy Rule: commands/security/patch/secret_policy_rule.md
-        - Service Policy: commands/security/patch/service_policy.md
-        - Service Policy Rule: commands/security/patch/service_policy_rule.md
-        - Trusted CA List: commands/security/patch/trusted_ca_list.md
-        - Voltshare Admin Policy: commands/security/patch/voltshare_admin_policy.md
-        - WAF Exclusion Policy: commands/security/patch/waf_exclusion_policy.md
+        - Patch Overview: commands/secops_and_incident_response/patch/index.md
+        - Malicious User Mitigation: commands/secops_and_incident_response/patch/malicious_user_mitigation.md
+        - Secret Management Access: commands/secops_and_incident_response/patch/secret_management_access.md
       - Remove Labels:
-        - Remove Labels Overview: commands/security/remove-labels/index.md
-        - API Definition: commands/security/remove-labels/api_definition.md
-        - App Firewall: commands/security/remove-labels/app_firewall.md
-        - Bot Defense App Infrastructure: commands/security/remove-labels/bot_defense_app_infrastructure.md
-        - CRL: commands/security/remove-labels/crl.md
-        - Data Type: commands/security/remove-labels/data_type.md
-        - Enhanced Firewall Policy: commands/security/remove-labels/enhanced_firewall_policy.md
-        - Fast ACL: commands/security/remove-labels/fast_acl.md
-        - Fast ACL Rule: commands/security/remove-labels/fast_acl_rule.md
-        - Filter Set: commands/security/remove-labels/filter_set.md
-        - Geo Location Set: commands/security/remove-labels/geo_location_set.md
-        - Malicious User Mitigation: commands/security/remove-labels/malicious_user_mitigation.md
-        - Policer: commands/security/remove-labels/policer.md
-        - Protocol Inspection: commands/security/remove-labels/protocol_inspection.md
-        - Protocol Policer: commands/security/remove-labels/protocol_policer.md
-        - Rate Limiter: commands/security/remove-labels/rate_limiter.md
-        - Rate Limiter Policy: commands/security/remove-labels/rate_limiter_policy.md
-        - Secret Management Access: commands/security/remove-labels/secret_management_access.md
-        - Secret Policy: commands/security/remove-labels/secret_policy.md
-        - Secret Policy Rule: commands/security/remove-labels/secret_policy_rule.md
-        - Service Policy: commands/security/remove-labels/service_policy.md
-        - Service Policy Rule: commands/security/remove-labels/service_policy_rule.md
-        - Trusted CA List: commands/security/remove-labels/trusted_ca_list.md
-        - Voltshare Admin Policy: commands/security/remove-labels/voltshare_admin_policy.md
-        - WAF Exclusion Policy: commands/security/remove-labels/waf_exclusion_policy.md
+        - Remove Labels Overview: commands/secops_and_incident_response/remove-labels/index.md
+        - Malicious User Mitigation: commands/secops_and_incident_response/remove-labels/malicious_user_mitigation.md
+        - Secret Management Access: commands/secops_and_incident_response/remove-labels/secret_management_access.md
       - Replace:
-        - Replace Overview: commands/security/replace/index.md
-        - API Definition: commands/security/replace/api_definition.md
-        - App Firewall: commands/security/replace/app_firewall.md
-        - Bot Defense App Infrastructure: commands/security/replace/bot_defense_app_infrastructure.md
-        - CRL: commands/security/replace/crl.md
-        - Data Type: commands/security/replace/data_type.md
-        - Enhanced Firewall Policy: commands/security/replace/enhanced_firewall_policy.md
-        - Fast ACL: commands/security/replace/fast_acl.md
-        - Fast ACL Rule: commands/security/replace/fast_acl_rule.md
-        - Filter Set: commands/security/replace/filter_set.md
-        - Geo Location Set: commands/security/replace/geo_location_set.md
-        - Malicious User Mitigation: commands/security/replace/malicious_user_mitigation.md
-        - Policer: commands/security/replace/policer.md
-        - Protocol Inspection: commands/security/replace/protocol_inspection.md
-        - Protocol Policer: commands/security/replace/protocol_policer.md
-        - Rate Limiter: commands/security/replace/rate_limiter.md
-        - Rate Limiter Policy: commands/security/replace/rate_limiter_policy.md
-        - Secret Management Access: commands/security/replace/secret_management_access.md
-        - Secret Policy: commands/security/replace/secret_policy.md
-        - Secret Policy Rule: commands/security/replace/secret_policy_rule.md
-        - Service Policy: commands/security/replace/service_policy.md
-        - Service Policy Rule: commands/security/replace/service_policy_rule.md
-        - Trusted CA List: commands/security/replace/trusted_ca_list.md
-        - Voltshare Admin Policy: commands/security/replace/voltshare_admin_policy.md
-        - WAF Exclusion Policy: commands/security/replace/waf_exclusion_policy.md
+        - Replace Overview: commands/secops_and_incident_response/replace/index.md
+        - Malicious User Mitigation: commands/secops_and_incident_response/replace/malicious_user_mitigation.md
+        - Secret Management Access: commands/secops_and_incident_response/replace/secret_management_access.md
       - Status:
-        - Status Overview: commands/security/status/index.md
-        - API Definition: commands/security/status/api_definition.md
-        - App Firewall: commands/security/status/app_firewall.md
-        - Bot Defense App Infrastructure: commands/security/status/bot_defense_app_infrastructure.md
-        - CRL: commands/security/status/crl.md
-        - Data Type: commands/security/status/data_type.md
-        - Enhanced Firewall Policy: commands/security/status/enhanced_firewall_policy.md
-        - Fast ACL: commands/security/status/fast_acl.md
-        - Fast ACL Rule: commands/security/status/fast_acl_rule.md
-        - Filter Set: commands/security/status/filter_set.md
-        - Geo Location Set: commands/security/status/geo_location_set.md
-        - Malicious User Mitigation: commands/security/status/malicious_user_mitigation.md
-        - Policer: commands/security/status/policer.md
-        - Protocol Inspection: commands/security/status/protocol_inspection.md
-        - Protocol Policer: commands/security/status/protocol_policer.md
-        - Rate Limiter: commands/security/status/rate_limiter.md
-        - Rate Limiter Policy: commands/security/status/rate_limiter_policy.md
-        - Secret Management Access: commands/security/status/secret_management_access.md
-        - Secret Policy: commands/security/status/secret_policy.md
-        - Secret Policy Rule: commands/security/status/secret_policy_rule.md
-        - Service Policy: commands/security/status/service_policy.md
-        - Service Policy Rule: commands/security/status/service_policy_rule.md
-        - Trusted CA List: commands/security/status/trusted_ca_list.md
-        - Voltshare Admin Policy: commands/security/status/voltshare_admin_policy.md
-        - WAF Exclusion Policy: commands/security/status/waf_exclusion_policy.md
+        - Status Overview: commands/secops_and_incident_response/status/index.md
+        - Malicious User Mitigation: commands/secops_and_incident_response/status/malicious_user_mitigation.md
+        - Secret Management Access: commands/secops_and_incident_response/status/secret_management_access.md
     - Service Mesh:
       - Service Mesh Overview: commands/service_mesh/index.md
       - Add Labels:
         - Add Labels Overview: commands/service_mesh/add-labels/index.md
-        - Cluster: commands/service_mesh/add-labels/cluster.md
-        - Container Registry: commands/service_mesh/add-labels/container_registry.md
+        - App Setting: commands/service_mesh/add-labels/app_setting.md
+        - App Type: commands/service_mesh/add-labels/app_type.md
         - Discovery: commands/service_mesh/add-labels/discovery.md
         - Endpoint: commands/service_mesh/add-labels/endpoint.md
+        - Fleet: commands/service_mesh/add-labels/fleet.md
         - Nfv Service: commands/service_mesh/add-labels/nfv_service.md
+        - Site Mesh Group: commands/service_mesh/add-labels/site_mesh_group.md
+        - Virtual Host: commands/service_mesh/add-labels/virtual_host.md
+        - Virtual Network: commands/service_mesh/add-labels/virtual_network.md
       - Apply:
         - Apply Overview: commands/service_mesh/apply/index.md
-        - Cluster: commands/service_mesh/apply/cluster.md
-        - Container Registry: commands/service_mesh/apply/container_registry.md
+        - App Setting: commands/service_mesh/apply/app_setting.md
+        - App Type: commands/service_mesh/apply/app_type.md
         - Discovery: commands/service_mesh/apply/discovery.md
         - Endpoint: commands/service_mesh/apply/endpoint.md
+        - Fleet: commands/service_mesh/apply/fleet.md
         - Nfv Service: commands/service_mesh/apply/nfv_service.md
+        - Site Mesh Group: commands/service_mesh/apply/site_mesh_group.md
+        - Virtual Host: commands/service_mesh/apply/virtual_host.md
+        - Virtual Network: commands/service_mesh/apply/virtual_network.md
       - Create:
         - Create Overview: commands/service_mesh/create/index.md
-        - Cluster: commands/service_mesh/create/cluster.md
-        - Container Registry: commands/service_mesh/create/container_registry.md
+        - App Setting: commands/service_mesh/create/app_setting.md
+        - App Type: commands/service_mesh/create/app_type.md
         - Discovery: commands/service_mesh/create/discovery.md
         - Endpoint: commands/service_mesh/create/endpoint.md
+        - Fleet: commands/service_mesh/create/fleet.md
         - Nfv Service: commands/service_mesh/create/nfv_service.md
+        - Site Mesh Group: commands/service_mesh/create/site_mesh_group.md
+        - Virtual Host: commands/service_mesh/create/virtual_host.md
+        - Virtual Network: commands/service_mesh/create/virtual_network.md
       - Delete:
         - Delete Overview: commands/service_mesh/delete/index.md
-        - Cluster: commands/service_mesh/delete/cluster.md
-        - Container Registry: commands/service_mesh/delete/container_registry.md
+        - App Setting: commands/service_mesh/delete/app_setting.md
+        - App Type: commands/service_mesh/delete/app_type.md
         - Discovery: commands/service_mesh/delete/discovery.md
         - Endpoint: commands/service_mesh/delete/endpoint.md
+        - Fleet: commands/service_mesh/delete/fleet.md
         - Nfv Service: commands/service_mesh/delete/nfv_service.md
+        - Site Mesh Group: commands/service_mesh/delete/site_mesh_group.md
+        - Virtual Host: commands/service_mesh/delete/virtual_host.md
+        - Virtual Network: commands/service_mesh/delete/virtual_network.md
       - Get:
         - Get Overview: commands/service_mesh/get/index.md
-        - Cluster: commands/service_mesh/get/cluster.md
-        - Container Registry: commands/service_mesh/get/container_registry.md
+        - App Setting: commands/service_mesh/get/app_setting.md
+        - App Type: commands/service_mesh/get/app_type.md
         - Discovery: commands/service_mesh/get/discovery.md
         - Endpoint: commands/service_mesh/get/endpoint.md
+        - Fleet: commands/service_mesh/get/fleet.md
         - Nfv Service: commands/service_mesh/get/nfv_service.md
+        - Site Mesh Group: commands/service_mesh/get/site_mesh_group.md
+        - Virtual Host: commands/service_mesh/get/virtual_host.md
+        - Virtual Network: commands/service_mesh/get/virtual_network.md
       - List:
         - List Overview: commands/service_mesh/list/index.md
-        - Cluster: commands/service_mesh/list/cluster.md
-        - Container Registry: commands/service_mesh/list/container_registry.md
+        - App Setting: commands/service_mesh/list/app_setting.md
+        - App Type: commands/service_mesh/list/app_type.md
         - Discovery: commands/service_mesh/list/discovery.md
         - Endpoint: commands/service_mesh/list/endpoint.md
+        - Fleet: commands/service_mesh/list/fleet.md
         - Nfv Service: commands/service_mesh/list/nfv_service.md
+        - Site Mesh Group: commands/service_mesh/list/site_mesh_group.md
+        - Virtual Host: commands/service_mesh/list/virtual_host.md
+        - Virtual Network: commands/service_mesh/list/virtual_network.md
       - Patch:
         - Patch Overview: commands/service_mesh/patch/index.md
-        - Cluster: commands/service_mesh/patch/cluster.md
-        - Container Registry: commands/service_mesh/patch/container_registry.md
+        - App Setting: commands/service_mesh/patch/app_setting.md
+        - App Type: commands/service_mesh/patch/app_type.md
         - Discovery: commands/service_mesh/patch/discovery.md
         - Endpoint: commands/service_mesh/patch/endpoint.md
+        - Fleet: commands/service_mesh/patch/fleet.md
         - Nfv Service: commands/service_mesh/patch/nfv_service.md
+        - Site Mesh Group: commands/service_mesh/patch/site_mesh_group.md
+        - Virtual Host: commands/service_mesh/patch/virtual_host.md
+        - Virtual Network: commands/service_mesh/patch/virtual_network.md
       - Remove Labels:
         - Remove Labels Overview: commands/service_mesh/remove-labels/index.md
-        - Cluster: commands/service_mesh/remove-labels/cluster.md
-        - Container Registry: commands/service_mesh/remove-labels/container_registry.md
+        - App Setting: commands/service_mesh/remove-labels/app_setting.md
+        - App Type: commands/service_mesh/remove-labels/app_type.md
         - Discovery: commands/service_mesh/remove-labels/discovery.md
         - Endpoint: commands/service_mesh/remove-labels/endpoint.md
+        - Fleet: commands/service_mesh/remove-labels/fleet.md
         - Nfv Service: commands/service_mesh/remove-labels/nfv_service.md
+        - Site Mesh Group: commands/service_mesh/remove-labels/site_mesh_group.md
+        - Virtual Host: commands/service_mesh/remove-labels/virtual_host.md
+        - Virtual Network: commands/service_mesh/remove-labels/virtual_network.md
       - Replace:
         - Replace Overview: commands/service_mesh/replace/index.md
-        - Cluster: commands/service_mesh/replace/cluster.md
-        - Container Registry: commands/service_mesh/replace/container_registry.md
+        - App Setting: commands/service_mesh/replace/app_setting.md
+        - App Type: commands/service_mesh/replace/app_type.md
         - Discovery: commands/service_mesh/replace/discovery.md
         - Endpoint: commands/service_mesh/replace/endpoint.md
+        - Fleet: commands/service_mesh/replace/fleet.md
         - Nfv Service: commands/service_mesh/replace/nfv_service.md
+        - Site Mesh Group: commands/service_mesh/replace/site_mesh_group.md
+        - Virtual Host: commands/service_mesh/replace/virtual_host.md
+        - Virtual Network: commands/service_mesh/replace/virtual_network.md
       - Status:
         - Status Overview: commands/service_mesh/status/index.md
-        - Cluster: commands/service_mesh/status/cluster.md
-        - Container Registry: commands/service_mesh/status/container_registry.md
+        - App Setting: commands/service_mesh/status/app_setting.md
+        - App Type: commands/service_mesh/status/app_type.md
         - Discovery: commands/service_mesh/status/discovery.md
         - Endpoint: commands/service_mesh/status/endpoint.md
+        - Fleet: commands/service_mesh/status/fleet.md
         - Nfv Service: commands/service_mesh/status/nfv_service.md
-    - Shape Security:
-      - Shape Security Overview: commands/shape_security/index.md
-      - Add Labels: commands/shape_security/add-labels/index.md
-      - Apply: commands/shape_security/apply/index.md
-      - Create: commands/shape_security/create/index.md
-      - Delete: commands/shape_security/delete/index.md
-      - Get: commands/shape_security/get/index.md
-      - List: commands/shape_security/list/index.md
-      - Patch: commands/shape_security/patch/index.md
-      - Remove Labels: commands/shape_security/remove-labels/index.md
-      - Replace: commands/shape_security/replace/index.md
-      - Status: commands/shape_security/status/index.md
+        - Site Mesh Group: commands/service_mesh/status/site_mesh_group.md
+        - Virtual Host: commands/service_mesh/status/virtual_host.md
+        - Virtual Network: commands/service_mesh/status/virtual_network.md
+    - Shape:
+      - Shape Overview: commands/shape/index.md
+      - Add Labels: commands/shape/add-labels/index.md
+      - Apply: commands/shape/apply/index.md
+      - Create: commands/shape/create/index.md
+      - Delete: commands/shape/delete/index.md
+      - Get: commands/shape/get/index.md
+      - List: commands/shape/list/index.md
+      - Patch: commands/shape/patch/index.md
+      - Remove Labels: commands/shape/remove-labels/index.md
+      - Replace: commands/shape/replace/index.md
+      - Status: commands/shape/status/index.md
     - Site:
       - Site Overview: commands/site/index.md
+      - Add Labels:
+        - Add Labels Overview: commands/site/add-labels/index.md
+        - Virtual K8S: commands/site/add-labels/virtual_k8s.md
+      - Apply:
+        - Apply Overview: commands/site/apply/index.md
+        - Virtual K8S: commands/site/apply/virtual_k8s.md
       - AWS VPC:
         - AWS VPC Overview: commands/site/aws_vpc/index.md
         - Create: commands/site/aws_vpc/create.md
@@ -1926,6 +1793,234 @@ nav:
         - Delete: commands/site/azure_vnet/delete.md
         - Replace: commands/site/azure_vnet/replace.md
         - Run: commands/site/azure_vnet/run.md
+      - Create:
+        - Create Overview: commands/site/create/index.md
+        - Virtual K8S: commands/site/create/virtual_k8s.md
+      - Delete:
+        - Delete Overview: commands/site/delete/index.md
+        - Virtual K8S: commands/site/delete/virtual_k8s.md
+      - Get:
+        - Get Overview: commands/site/get/index.md
+        - Virtual K8S: commands/site/get/virtual_k8s.md
+      - List:
+        - List Overview: commands/site/list/index.md
+        - Virtual K8S: commands/site/list/virtual_k8s.md
+      - Patch:
+        - Patch Overview: commands/site/patch/index.md
+        - Virtual K8S: commands/site/patch/virtual_k8s.md
+      - Remove Labels:
+        - Remove Labels Overview: commands/site/remove-labels/index.md
+        - Virtual K8S: commands/site/remove-labels/virtual_k8s.md
+      - Replace:
+        - Replace Overview: commands/site/replace/index.md
+        - Virtual K8S: commands/site/replace/virtual_k8s.md
+      - Status:
+        - Status Overview: commands/site/status/index.md
+        - Virtual K8S: commands/site/status/virtual_k8s.md
+    - Site Management:
+      - Site Management Overview: commands/site_management/index.md
+      - Add Labels:
+        - Add Labels Overview: commands/site_management/add-labels/index.md
+        - AWS TGW Site: commands/site_management/add-labels/aws_tgw_site.md
+        - AWS VPC Site: commands/site_management/add-labels/aws_vpc_site.md
+        - Azure VNET Site: commands/site_management/add-labels/azure_vnet_site.md
+        - GCP VPC Site: commands/site_management/add-labels/gcp_vpc_site.md
+        - K8S Cluster: commands/site_management/add-labels/k8s_cluster.md
+        - K8S Cluster Role: commands/site_management/add-labels/k8s_cluster_role.md
+        - K8S Cluster Role Binding: commands/site_management/add-labels/k8s_cluster_role_binding.md
+        - Securemesh Site: commands/site_management/add-labels/securemesh_site.md
+        - Securemesh Site V2: commands/site_management/add-labels/securemesh_site_v2.md
+        - Virtual Site: commands/site_management/add-labels/virtual_site.md
+        - Voltstack Site: commands/site_management/add-labels/voltstack_site.md
+      - Apply:
+        - Apply Overview: commands/site_management/apply/index.md
+        - AWS TGW Site: commands/site_management/apply/aws_tgw_site.md
+        - AWS VPC Site: commands/site_management/apply/aws_vpc_site.md
+        - Azure VNET Site: commands/site_management/apply/azure_vnet_site.md
+        - GCP VPC Site: commands/site_management/apply/gcp_vpc_site.md
+        - K8S Cluster: commands/site_management/apply/k8s_cluster.md
+        - K8S Cluster Role: commands/site_management/apply/k8s_cluster_role.md
+        - K8S Cluster Role Binding: commands/site_management/apply/k8s_cluster_role_binding.md
+        - Securemesh Site: commands/site_management/apply/securemesh_site.md
+        - Securemesh Site V2: commands/site_management/apply/securemesh_site_v2.md
+        - Virtual Site: commands/site_management/apply/virtual_site.md
+        - Voltstack Site: commands/site_management/apply/voltstack_site.md
+      - Create:
+        - Create Overview: commands/site_management/create/index.md
+        - AWS TGW Site: commands/site_management/create/aws_tgw_site.md
+        - AWS VPC Site: commands/site_management/create/aws_vpc_site.md
+        - Azure VNET Site: commands/site_management/create/azure_vnet_site.md
+        - GCP VPC Site: commands/site_management/create/gcp_vpc_site.md
+        - K8S Cluster: commands/site_management/create/k8s_cluster.md
+        - K8S Cluster Role: commands/site_management/create/k8s_cluster_role.md
+        - K8S Cluster Role Binding: commands/site_management/create/k8s_cluster_role_binding.md
+        - Securemesh Site: commands/site_management/create/securemesh_site.md
+        - Securemesh Site V2: commands/site_management/create/securemesh_site_v2.md
+        - Virtual Site: commands/site_management/create/virtual_site.md
+        - Voltstack Site: commands/site_management/create/voltstack_site.md
+      - Delete:
+        - Delete Overview: commands/site_management/delete/index.md
+        - AWS TGW Site: commands/site_management/delete/aws_tgw_site.md
+        - AWS VPC Site: commands/site_management/delete/aws_vpc_site.md
+        - Azure VNET Site: commands/site_management/delete/azure_vnet_site.md
+        - GCP VPC Site: commands/site_management/delete/gcp_vpc_site.md
+        - K8S Cluster: commands/site_management/delete/k8s_cluster.md
+        - K8S Cluster Role: commands/site_management/delete/k8s_cluster_role.md
+        - K8S Cluster Role Binding: commands/site_management/delete/k8s_cluster_role_binding.md
+        - Securemesh Site: commands/site_management/delete/securemesh_site.md
+        - Securemesh Site V2: commands/site_management/delete/securemesh_site_v2.md
+        - Virtual Site: commands/site_management/delete/virtual_site.md
+        - Voltstack Site: commands/site_management/delete/voltstack_site.md
+      - Get:
+        - Get Overview: commands/site_management/get/index.md
+        - AWS TGW Site: commands/site_management/get/aws_tgw_site.md
+        - AWS VPC Site: commands/site_management/get/aws_vpc_site.md
+        - Azure VNET Site: commands/site_management/get/azure_vnet_site.md
+        - GCP VPC Site: commands/site_management/get/gcp_vpc_site.md
+        - K8S Cluster: commands/site_management/get/k8s_cluster.md
+        - K8S Cluster Role: commands/site_management/get/k8s_cluster_role.md
+        - K8S Cluster Role Binding: commands/site_management/get/k8s_cluster_role_binding.md
+        - Securemesh Site: commands/site_management/get/securemesh_site.md
+        - Securemesh Site V2: commands/site_management/get/securemesh_site_v2.md
+        - Virtual Site: commands/site_management/get/virtual_site.md
+        - Voltstack Site: commands/site_management/get/voltstack_site.md
+      - List:
+        - List Overview: commands/site_management/list/index.md
+        - AWS TGW Site: commands/site_management/list/aws_tgw_site.md
+        - AWS VPC Site: commands/site_management/list/aws_vpc_site.md
+        - Azure VNET Site: commands/site_management/list/azure_vnet_site.md
+        - GCP VPC Site: commands/site_management/list/gcp_vpc_site.md
+        - K8S Cluster: commands/site_management/list/k8s_cluster.md
+        - K8S Cluster Role: commands/site_management/list/k8s_cluster_role.md
+        - K8S Cluster Role Binding: commands/site_management/list/k8s_cluster_role_binding.md
+        - Securemesh Site: commands/site_management/list/securemesh_site.md
+        - Securemesh Site V2: commands/site_management/list/securemesh_site_v2.md
+        - Virtual Site: commands/site_management/list/virtual_site.md
+        - Voltstack Site: commands/site_management/list/voltstack_site.md
+      - Patch:
+        - Patch Overview: commands/site_management/patch/index.md
+        - AWS TGW Site: commands/site_management/patch/aws_tgw_site.md
+        - AWS VPC Site: commands/site_management/patch/aws_vpc_site.md
+        - Azure VNET Site: commands/site_management/patch/azure_vnet_site.md
+        - GCP VPC Site: commands/site_management/patch/gcp_vpc_site.md
+        - K8S Cluster: commands/site_management/patch/k8s_cluster.md
+        - K8S Cluster Role: commands/site_management/patch/k8s_cluster_role.md
+        - K8S Cluster Role Binding: commands/site_management/patch/k8s_cluster_role_binding.md
+        - Securemesh Site: commands/site_management/patch/securemesh_site.md
+        - Securemesh Site V2: commands/site_management/patch/securemesh_site_v2.md
+        - Virtual Site: commands/site_management/patch/virtual_site.md
+        - Voltstack Site: commands/site_management/patch/voltstack_site.md
+      - Remove Labels:
+        - Remove Labels Overview: commands/site_management/remove-labels/index.md
+        - AWS TGW Site: commands/site_management/remove-labels/aws_tgw_site.md
+        - AWS VPC Site: commands/site_management/remove-labels/aws_vpc_site.md
+        - Azure VNET Site: commands/site_management/remove-labels/azure_vnet_site.md
+        - GCP VPC Site: commands/site_management/remove-labels/gcp_vpc_site.md
+        - K8S Cluster: commands/site_management/remove-labels/k8s_cluster.md
+        - K8S Cluster Role: commands/site_management/remove-labels/k8s_cluster_role.md
+        - K8S Cluster Role Binding: commands/site_management/remove-labels/k8s_cluster_role_binding.md
+        - Securemesh Site: commands/site_management/remove-labels/securemesh_site.md
+        - Securemesh Site V2: commands/site_management/remove-labels/securemesh_site_v2.md
+        - Virtual Site: commands/site_management/remove-labels/virtual_site.md
+        - Voltstack Site: commands/site_management/remove-labels/voltstack_site.md
+      - Replace:
+        - Replace Overview: commands/site_management/replace/index.md
+        - AWS TGW Site: commands/site_management/replace/aws_tgw_site.md
+        - AWS VPC Site: commands/site_management/replace/aws_vpc_site.md
+        - Azure VNET Site: commands/site_management/replace/azure_vnet_site.md
+        - GCP VPC Site: commands/site_management/replace/gcp_vpc_site.md
+        - K8S Cluster: commands/site_management/replace/k8s_cluster.md
+        - K8S Cluster Role: commands/site_management/replace/k8s_cluster_role.md
+        - K8S Cluster Role Binding: commands/site_management/replace/k8s_cluster_role_binding.md
+        - Securemesh Site: commands/site_management/replace/securemesh_site.md
+        - Securemesh Site V2: commands/site_management/replace/securemesh_site_v2.md
+        - Virtual Site: commands/site_management/replace/virtual_site.md
+        - Voltstack Site: commands/site_management/replace/voltstack_site.md
+      - Status:
+        - Status Overview: commands/site_management/status/index.md
+        - AWS TGW Site: commands/site_management/status/aws_tgw_site.md
+        - AWS VPC Site: commands/site_management/status/aws_vpc_site.md
+        - Azure VNET Site: commands/site_management/status/azure_vnet_site.md
+        - GCP VPC Site: commands/site_management/status/gcp_vpc_site.md
+        - K8S Cluster: commands/site_management/status/k8s_cluster.md
+        - K8S Cluster Role: commands/site_management/status/k8s_cluster_role.md
+        - K8S Cluster Role Binding: commands/site_management/status/k8s_cluster_role_binding.md
+        - Securemesh Site: commands/site_management/status/securemesh_site.md
+        - Securemesh Site V2: commands/site_management/status/securemesh_site_v2.md
+        - Virtual Site: commands/site_management/status/virtual_site.md
+        - Voltstack Site: commands/site_management/status/voltstack_site.md
+    - Statistics:
+      - Statistics Overview: commands/statistics/index.md
+      - Add Labels:
+        - Add Labels Overview: commands/statistics/add-labels/index.md
+        - Alert Policy: commands/statistics/add-labels/alert_policy.md
+        - Alert Receiver: commands/statistics/add-labels/alert_receiver.md
+        - Global Log Receiver: commands/statistics/add-labels/global_log_receiver.md
+        - Log Receiver: commands/statistics/add-labels/log_receiver.md
+        - Report Config: commands/statistics/add-labels/report_config.md
+      - Apply:
+        - Apply Overview: commands/statistics/apply/index.md
+        - Alert Policy: commands/statistics/apply/alert_policy.md
+        - Alert Receiver: commands/statistics/apply/alert_receiver.md
+        - Global Log Receiver: commands/statistics/apply/global_log_receiver.md
+        - Log Receiver: commands/statistics/apply/log_receiver.md
+        - Report Config: commands/statistics/apply/report_config.md
+      - Create:
+        - Create Overview: commands/statistics/create/index.md
+        - Alert Policy: commands/statistics/create/alert_policy.md
+        - Alert Receiver: commands/statistics/create/alert_receiver.md
+        - Global Log Receiver: commands/statistics/create/global_log_receiver.md
+        - Log Receiver: commands/statistics/create/log_receiver.md
+        - Report Config: commands/statistics/create/report_config.md
+      - Delete:
+        - Delete Overview: commands/statistics/delete/index.md
+        - Alert Policy: commands/statistics/delete/alert_policy.md
+        - Alert Receiver: commands/statistics/delete/alert_receiver.md
+        - Global Log Receiver: commands/statistics/delete/global_log_receiver.md
+        - Log Receiver: commands/statistics/delete/log_receiver.md
+        - Report Config: commands/statistics/delete/report_config.md
+      - Get:
+        - Get Overview: commands/statistics/get/index.md
+        - Alert Policy: commands/statistics/get/alert_policy.md
+        - Alert Receiver: commands/statistics/get/alert_receiver.md
+        - Global Log Receiver: commands/statistics/get/global_log_receiver.md
+        - Log Receiver: commands/statistics/get/log_receiver.md
+        - Report Config: commands/statistics/get/report_config.md
+      - List:
+        - List Overview: commands/statistics/list/index.md
+        - Alert Policy: commands/statistics/list/alert_policy.md
+        - Alert Receiver: commands/statistics/list/alert_receiver.md
+        - Global Log Receiver: commands/statistics/list/global_log_receiver.md
+        - Log Receiver: commands/statistics/list/log_receiver.md
+        - Report Config: commands/statistics/list/report_config.md
+      - Patch:
+        - Patch Overview: commands/statistics/patch/index.md
+        - Alert Policy: commands/statistics/patch/alert_policy.md
+        - Alert Receiver: commands/statistics/patch/alert_receiver.md
+        - Global Log Receiver: commands/statistics/patch/global_log_receiver.md
+        - Log Receiver: commands/statistics/patch/log_receiver.md
+        - Report Config: commands/statistics/patch/report_config.md
+      - Remove Labels:
+        - Remove Labels Overview: commands/statistics/remove-labels/index.md
+        - Alert Policy: commands/statistics/remove-labels/alert_policy.md
+        - Alert Receiver: commands/statistics/remove-labels/alert_receiver.md
+        - Global Log Receiver: commands/statistics/remove-labels/global_log_receiver.md
+        - Log Receiver: commands/statistics/remove-labels/log_receiver.md
+        - Report Config: commands/statistics/remove-labels/report_config.md
+      - Replace:
+        - Replace Overview: commands/statistics/replace/index.md
+        - Alert Policy: commands/statistics/replace/alert_policy.md
+        - Alert Receiver: commands/statistics/replace/alert_receiver.md
+        - Global Log Receiver: commands/statistics/replace/global_log_receiver.md
+        - Log Receiver: commands/statistics/replace/log_receiver.md
+        - Report Config: commands/statistics/replace/report_config.md
+      - Status:
+        - Status Overview: commands/statistics/status/index.md
+        - Alert Policy: commands/statistics/status/alert_policy.md
+        - Alert Receiver: commands/statistics/status/alert_receiver.md
+        - Global Log Receiver: commands/statistics/status/global_log_receiver.md
+        - Log Receiver: commands/statistics/status/log_receiver.md
+        - Report Config: commands/statistics/status/report_config.md
     - Subscription:
       - Subscription Overview: commands/subscription/index.md
       - Activate: commands/subscription/activate/index.md
@@ -1934,122 +2029,392 @@ nav:
       - Quota: commands/subscription/quota/index.md
       - Show: commands/subscription/show/index.md
       - Validate: commands/subscription/validate/index.md
-    - Subscriptions:
-      - Subscriptions Overview: commands/subscriptions/index.md
-      - Add Labels: commands/subscriptions/add-labels/index.md
-      - Apply: commands/subscriptions/apply/index.md
-      - Create: commands/subscriptions/create/index.md
-      - Delete: commands/subscriptions/delete/index.md
-      - Get: commands/subscriptions/get/index.md
-      - List: commands/subscriptions/list/index.md
-      - Patch: commands/subscriptions/patch/index.md
-      - Remove Labels: commands/subscriptions/remove-labels/index.md
-      - Replace: commands/subscriptions/replace/index.md
-      - Status: commands/subscriptions/status/index.md
-    - Tenant Management:
-      - Tenant Management Overview: commands/tenant_management/index.md
+    - Support:
+      - Support Overview: commands/support/index.md
       - Add Labels:
-        - Add Labels Overview: commands/tenant_management/add-labels/index.md
-        - Tenant Configuration: commands/tenant_management/add-labels/tenant_configuration.md
+        - Add Labels Overview: commands/support/add-labels/index.md
+        - Customer Support: commands/support/add-labels/customer_support.md
       - Apply:
-        - Apply Overview: commands/tenant_management/apply/index.md
-        - Tenant Configuration: commands/tenant_management/apply/tenant_configuration.md
+        - Apply Overview: commands/support/apply/index.md
+        - Customer Support: commands/support/apply/customer_support.md
       - Create:
-        - Create Overview: commands/tenant_management/create/index.md
-        - Tenant Configuration: commands/tenant_management/create/tenant_configuration.md
+        - Create Overview: commands/support/create/index.md
+        - Customer Support: commands/support/create/customer_support.md
       - Delete:
-        - Delete Overview: commands/tenant_management/delete/index.md
-        - Tenant Configuration: commands/tenant_management/delete/tenant_configuration.md
+        - Delete Overview: commands/support/delete/index.md
+        - Customer Support: commands/support/delete/customer_support.md
       - Get:
-        - Get Overview: commands/tenant_management/get/index.md
-        - Tenant Configuration: commands/tenant_management/get/tenant_configuration.md
+        - Get Overview: commands/support/get/index.md
+        - Customer Support: commands/support/get/customer_support.md
       - List:
-        - List Overview: commands/tenant_management/list/index.md
-        - Tenant Configuration: commands/tenant_management/list/tenant_configuration.md
+        - List Overview: commands/support/list/index.md
+        - Customer Support: commands/support/list/customer_support.md
       - Patch:
-        - Patch Overview: commands/tenant_management/patch/index.md
-        - Tenant Configuration: commands/tenant_management/patch/tenant_configuration.md
+        - Patch Overview: commands/support/patch/index.md
+        - Customer Support: commands/support/patch/customer_support.md
       - Remove Labels:
-        - Remove Labels Overview: commands/tenant_management/remove-labels/index.md
-        - Tenant Configuration: commands/tenant_management/remove-labels/tenant_configuration.md
+        - Remove Labels Overview: commands/support/remove-labels/index.md
+        - Customer Support: commands/support/remove-labels/customer_support.md
       - Replace:
-        - Replace Overview: commands/tenant_management/replace/index.md
-        - Tenant Configuration: commands/tenant_management/replace/tenant_configuration.md
+        - Replace Overview: commands/support/replace/index.md
+        - Customer Support: commands/support/replace/customer_support.md
       - Status:
-        - Status Overview: commands/tenant_management/status/index.md
-        - Tenant Configuration: commands/tenant_management/status/tenant_configuration.md
-    - VPN:
-      - VPN Overview: commands/vpn/index.md
+        - Status Overview: commands/support/status/index.md
+        - Customer Support: commands/support/status/customer_support.md
+    - Telemetry And Insights:
+      - Telemetry And Insights Overview: commands/telemetry_and_insights/index.md
+      - Add Labels: commands/telemetry_and_insights/add-labels/index.md
+      - Apply: commands/telemetry_and_insights/apply/index.md
+      - Create: commands/telemetry_and_insights/create/index.md
+      - Delete: commands/telemetry_and_insights/delete/index.md
+      - Get: commands/telemetry_and_insights/get/index.md
+      - List: commands/telemetry_and_insights/list/index.md
+      - Patch: commands/telemetry_and_insights/patch/index.md
+      - Remove Labels: commands/telemetry_and_insights/remove-labels/index.md
+      - Replace: commands/telemetry_and_insights/replace/index.md
+      - Status: commands/telemetry_and_insights/status/index.md
+    - Tenant And Identity:
+      - Tenant And Identity Overview: commands/tenant_and_identity/index.md
       - Add Labels:
-        - Add Labels Overview: commands/vpn/add-labels/index.md
-        - Ike1: commands/vpn/add-labels/ike1.md
-        - Ike2: commands/vpn/add-labels/ike2.md
-        - IKE Phase1 Profile: commands/vpn/add-labels/ike_phase1_profile.md
-        - IKE Phase2 Profile: commands/vpn/add-labels/ike_phase2_profile.md
-        - Tunnel: commands/vpn/add-labels/tunnel.md
+        - Add Labels Overview: commands/tenant_and_identity/add-labels/index.md
+        - Authentication: commands/tenant_and_identity/add-labels/authentication.md
+        - Contact: commands/tenant_and_identity/add-labels/contact.md
+        - Namespace: commands/tenant_and_identity/add-labels/namespace.md
+        - Role: commands/tenant_and_identity/add-labels/role.md
+        - Tenant Configuration: commands/tenant_and_identity/add-labels/tenant_configuration.md
+        - User Identification: commands/tenant_and_identity/add-labels/user_identification.md
       - Apply:
-        - Apply Overview: commands/vpn/apply/index.md
-        - Ike1: commands/vpn/apply/ike1.md
-        - Ike2: commands/vpn/apply/ike2.md
-        - IKE Phase1 Profile: commands/vpn/apply/ike_phase1_profile.md
-        - IKE Phase2 Profile: commands/vpn/apply/ike_phase2_profile.md
-        - Tunnel: commands/vpn/apply/tunnel.md
+        - Apply Overview: commands/tenant_and_identity/apply/index.md
+        - Authentication: commands/tenant_and_identity/apply/authentication.md
+        - Contact: commands/tenant_and_identity/apply/contact.md
+        - Namespace: commands/tenant_and_identity/apply/namespace.md
+        - Role: commands/tenant_and_identity/apply/role.md
+        - Tenant Configuration: commands/tenant_and_identity/apply/tenant_configuration.md
+        - User Identification: commands/tenant_and_identity/apply/user_identification.md
       - Create:
-        - Create Overview: commands/vpn/create/index.md
-        - Ike1: commands/vpn/create/ike1.md
-        - Ike2: commands/vpn/create/ike2.md
-        - IKE Phase1 Profile: commands/vpn/create/ike_phase1_profile.md
-        - IKE Phase2 Profile: commands/vpn/create/ike_phase2_profile.md
-        - Tunnel: commands/vpn/create/tunnel.md
+        - Create Overview: commands/tenant_and_identity/create/index.md
+        - Authentication: commands/tenant_and_identity/create/authentication.md
+        - Contact: commands/tenant_and_identity/create/contact.md
+        - Namespace: commands/tenant_and_identity/create/namespace.md
+        - Role: commands/tenant_and_identity/create/role.md
+        - Tenant Configuration: commands/tenant_and_identity/create/tenant_configuration.md
+        - User Identification: commands/tenant_and_identity/create/user_identification.md
       - Delete:
-        - Delete Overview: commands/vpn/delete/index.md
-        - Ike1: commands/vpn/delete/ike1.md
-        - Ike2: commands/vpn/delete/ike2.md
-        - IKE Phase1 Profile: commands/vpn/delete/ike_phase1_profile.md
-        - IKE Phase2 Profile: commands/vpn/delete/ike_phase2_profile.md
-        - Tunnel: commands/vpn/delete/tunnel.md
+        - Delete Overview: commands/tenant_and_identity/delete/index.md
+        - Authentication: commands/tenant_and_identity/delete/authentication.md
+        - Contact: commands/tenant_and_identity/delete/contact.md
+        - Namespace: commands/tenant_and_identity/delete/namespace.md
+        - Role: commands/tenant_and_identity/delete/role.md
+        - Tenant Configuration: commands/tenant_and_identity/delete/tenant_configuration.md
+        - User Identification: commands/tenant_and_identity/delete/user_identification.md
       - Get:
-        - Get Overview: commands/vpn/get/index.md
-        - Ike1: commands/vpn/get/ike1.md
-        - Ike2: commands/vpn/get/ike2.md
-        - IKE Phase1 Profile: commands/vpn/get/ike_phase1_profile.md
-        - IKE Phase2 Profile: commands/vpn/get/ike_phase2_profile.md
-        - Tunnel: commands/vpn/get/tunnel.md
+        - Get Overview: commands/tenant_and_identity/get/index.md
+        - Authentication: commands/tenant_and_identity/get/authentication.md
+        - Contact: commands/tenant_and_identity/get/contact.md
+        - Namespace: commands/tenant_and_identity/get/namespace.md
+        - Role: commands/tenant_and_identity/get/role.md
+        - Tenant Configuration: commands/tenant_and_identity/get/tenant_configuration.md
+        - User Identification: commands/tenant_and_identity/get/user_identification.md
       - List:
-        - List Overview: commands/vpn/list/index.md
-        - Ike1: commands/vpn/list/ike1.md
-        - Ike2: commands/vpn/list/ike2.md
-        - IKE Phase1 Profile: commands/vpn/list/ike_phase1_profile.md
-        - IKE Phase2 Profile: commands/vpn/list/ike_phase2_profile.md
-        - Tunnel: commands/vpn/list/tunnel.md
+        - List Overview: commands/tenant_and_identity/list/index.md
+        - Authentication: commands/tenant_and_identity/list/authentication.md
+        - Contact: commands/tenant_and_identity/list/contact.md
+        - Namespace: commands/tenant_and_identity/list/namespace.md
+        - Role: commands/tenant_and_identity/list/role.md
+        - Tenant Configuration: commands/tenant_and_identity/list/tenant_configuration.md
+        - User Identification: commands/tenant_and_identity/list/user_identification.md
       - Patch:
-        - Patch Overview: commands/vpn/patch/index.md
-        - Ike1: commands/vpn/patch/ike1.md
-        - Ike2: commands/vpn/patch/ike2.md
-        - IKE Phase1 Profile: commands/vpn/patch/ike_phase1_profile.md
-        - IKE Phase2 Profile: commands/vpn/patch/ike_phase2_profile.md
-        - Tunnel: commands/vpn/patch/tunnel.md
+        - Patch Overview: commands/tenant_and_identity/patch/index.md
+        - Authentication: commands/tenant_and_identity/patch/authentication.md
+        - Contact: commands/tenant_and_identity/patch/contact.md
+        - Namespace: commands/tenant_and_identity/patch/namespace.md
+        - Role: commands/tenant_and_identity/patch/role.md
+        - Tenant Configuration: commands/tenant_and_identity/patch/tenant_configuration.md
+        - User Identification: commands/tenant_and_identity/patch/user_identification.md
       - Remove Labels:
-        - Remove Labels Overview: commands/vpn/remove-labels/index.md
-        - Ike1: commands/vpn/remove-labels/ike1.md
-        - Ike2: commands/vpn/remove-labels/ike2.md
-        - IKE Phase1 Profile: commands/vpn/remove-labels/ike_phase1_profile.md
-        - IKE Phase2 Profile: commands/vpn/remove-labels/ike_phase2_profile.md
-        - Tunnel: commands/vpn/remove-labels/tunnel.md
+        - Remove Labels Overview: commands/tenant_and_identity/remove-labels/index.md
+        - Authentication: commands/tenant_and_identity/remove-labels/authentication.md
+        - Contact: commands/tenant_and_identity/remove-labels/contact.md
+        - Namespace: commands/tenant_and_identity/remove-labels/namespace.md
+        - Role: commands/tenant_and_identity/remove-labels/role.md
+        - Tenant Configuration: commands/tenant_and_identity/remove-labels/tenant_configuration.md
+        - User Identification: commands/tenant_and_identity/remove-labels/user_identification.md
       - Replace:
-        - Replace Overview: commands/vpn/replace/index.md
-        - Ike1: commands/vpn/replace/ike1.md
-        - Ike2: commands/vpn/replace/ike2.md
-        - IKE Phase1 Profile: commands/vpn/replace/ike_phase1_profile.md
-        - IKE Phase2 Profile: commands/vpn/replace/ike_phase2_profile.md
-        - Tunnel: commands/vpn/replace/tunnel.md
+        - Replace Overview: commands/tenant_and_identity/replace/index.md
+        - Authentication: commands/tenant_and_identity/replace/authentication.md
+        - Contact: commands/tenant_and_identity/replace/contact.md
+        - Namespace: commands/tenant_and_identity/replace/namespace.md
+        - Role: commands/tenant_and_identity/replace/role.md
+        - Tenant Configuration: commands/tenant_and_identity/replace/tenant_configuration.md
+        - User Identification: commands/tenant_and_identity/replace/user_identification.md
       - Status:
-        - Status Overview: commands/vpn/status/index.md
-        - Ike1: commands/vpn/status/ike1.md
-        - Ike2: commands/vpn/status/ike2.md
-        - IKE Phase1 Profile: commands/vpn/status/ike_phase1_profile.md
-        - IKE Phase2 Profile: commands/vpn/status/ike_phase2_profile.md
-        - Tunnel: commands/vpn/status/tunnel.md
+        - Status Overview: commands/tenant_and_identity/status/index.md
+        - Authentication: commands/tenant_and_identity/status/authentication.md
+        - Contact: commands/tenant_and_identity/status/contact.md
+        - Namespace: commands/tenant_and_identity/status/namespace.md
+        - Role: commands/tenant_and_identity/status/role.md
+        - Tenant Configuration: commands/tenant_and_identity/status/tenant_configuration.md
+        - User Identification: commands/tenant_and_identity/status/user_identification.md
+    - Threat Campaign:
+      - Threat Campaign Overview: commands/threat_campaign/index.md
+      - Add Labels: commands/threat_campaign/add-labels/index.md
+      - Apply: commands/threat_campaign/apply/index.md
+      - Create: commands/threat_campaign/create/index.md
+      - Delete: commands/threat_campaign/delete/index.md
+      - Get: commands/threat_campaign/get/index.md
+      - List: commands/threat_campaign/list/index.md
+      - Patch: commands/threat_campaign/patch/index.md
+      - Remove Labels: commands/threat_campaign/remove-labels/index.md
+      - Replace: commands/threat_campaign/replace/index.md
+      - Status: commands/threat_campaign/status/index.md
+    - Users:
+      - Users Overview: commands/users/index.md
+      - Add Labels:
+        - Add Labels Overview: commands/users/add-labels/index.md
+        - Known Label: commands/users/add-labels/known_label.md
+        - Known Label Key: commands/users/add-labels/known_label_key.md
+        - Token: commands/users/add-labels/token.md
+      - Apply:
+        - Apply Overview: commands/users/apply/index.md
+        - Known Label: commands/users/apply/known_label.md
+        - Known Label Key: commands/users/apply/known_label_key.md
+        - Token: commands/users/apply/token.md
+      - Create:
+        - Create Overview: commands/users/create/index.md
+        - Known Label: commands/users/create/known_label.md
+        - Known Label Key: commands/users/create/known_label_key.md
+        - Token: commands/users/create/token.md
+      - Delete:
+        - Delete Overview: commands/users/delete/index.md
+        - Known Label: commands/users/delete/known_label.md
+        - Known Label Key: commands/users/delete/known_label_key.md
+        - Token: commands/users/delete/token.md
+      - Get:
+        - Get Overview: commands/users/get/index.md
+        - Known Label: commands/users/get/known_label.md
+        - Known Label Key: commands/users/get/known_label_key.md
+        - Token: commands/users/get/token.md
+      - List:
+        - List Overview: commands/users/list/index.md
+        - Known Label: commands/users/list/known_label.md
+        - Known Label Key: commands/users/list/known_label_key.md
+        - Token: commands/users/list/token.md
+      - Patch:
+        - Patch Overview: commands/users/patch/index.md
+        - Known Label: commands/users/patch/known_label.md
+        - Known Label Key: commands/users/patch/known_label_key.md
+        - Token: commands/users/patch/token.md
+      - Remove Labels:
+        - Remove Labels Overview: commands/users/remove-labels/index.md
+        - Known Label: commands/users/remove-labels/known_label.md
+        - Known Label Key: commands/users/remove-labels/known_label_key.md
+        - Token: commands/users/remove-labels/token.md
+      - Replace:
+        - Replace Overview: commands/users/replace/index.md
+        - Known Label: commands/users/replace/known_label.md
+        - Known Label Key: commands/users/replace/known_label_key.md
+        - Token: commands/users/replace/token.md
+      - Status:
+        - Status Overview: commands/users/status/index.md
+        - Known Label: commands/users/status/known_label.md
+        - Known Label Key: commands/users/status/known_label_key.md
+        - Token: commands/users/status/token.md
+    - Virtual:
+      - Virtual Overview: commands/virtual/index.md
+      - Add Labels:
+        - Add Labels Overview: commands/virtual/add-labels/index.md
+        - Geo Location Set: commands/virtual/add-labels/geo_location_set.md
+        - Health Check: commands/virtual/add-labels/healthcheck.md
+        - HTTP Load Balancer: commands/virtual/add-labels/http_loadbalancer.md
+        - Origin Pool: commands/virtual/add-labels/origin_pool.md
+        - Proxy: commands/virtual/add-labels/proxy.md
+        - Rate Limiter Policy: commands/virtual/add-labels/rate_limiter_policy.md
+        - Service Policy: commands/virtual/add-labels/service_policy.md
+        - Service Policy Rule: commands/virtual/add-labels/service_policy_rule.md
+        - TCP Load Balancer: commands/virtual/add-labels/tcp_loadbalancer.md
+        - UDP Load Balancer: commands/virtual/add-labels/udp_loadbalancer.md
+      - Apply:
+        - Apply Overview: commands/virtual/apply/index.md
+        - Geo Location Set: commands/virtual/apply/geo_location_set.md
+        - Health Check: commands/virtual/apply/healthcheck.md
+        - HTTP Load Balancer: commands/virtual/apply/http_loadbalancer.md
+        - Origin Pool: commands/virtual/apply/origin_pool.md
+        - Proxy: commands/virtual/apply/proxy.md
+        - Rate Limiter Policy: commands/virtual/apply/rate_limiter_policy.md
+        - Service Policy: commands/virtual/apply/service_policy.md
+        - Service Policy Rule: commands/virtual/apply/service_policy_rule.md
+        - TCP Load Balancer: commands/virtual/apply/tcp_loadbalancer.md
+        - UDP Load Balancer: commands/virtual/apply/udp_loadbalancer.md
+      - Create:
+        - Create Overview: commands/virtual/create/index.md
+        - Geo Location Set: commands/virtual/create/geo_location_set.md
+        - Health Check: commands/virtual/create/healthcheck.md
+        - HTTP Load Balancer: commands/virtual/create/http_loadbalancer.md
+        - Origin Pool: commands/virtual/create/origin_pool.md
+        - Proxy: commands/virtual/create/proxy.md
+        - Rate Limiter Policy: commands/virtual/create/rate_limiter_policy.md
+        - Service Policy: commands/virtual/create/service_policy.md
+        - Service Policy Rule: commands/virtual/create/service_policy_rule.md
+        - TCP Load Balancer: commands/virtual/create/tcp_loadbalancer.md
+        - UDP Load Balancer: commands/virtual/create/udp_loadbalancer.md
+      - Delete:
+        - Delete Overview: commands/virtual/delete/index.md
+        - Geo Location Set: commands/virtual/delete/geo_location_set.md
+        - Health Check: commands/virtual/delete/healthcheck.md
+        - HTTP Load Balancer: commands/virtual/delete/http_loadbalancer.md
+        - Origin Pool: commands/virtual/delete/origin_pool.md
+        - Proxy: commands/virtual/delete/proxy.md
+        - Rate Limiter Policy: commands/virtual/delete/rate_limiter_policy.md
+        - Service Policy: commands/virtual/delete/service_policy.md
+        - Service Policy Rule: commands/virtual/delete/service_policy_rule.md
+        - TCP Load Balancer: commands/virtual/delete/tcp_loadbalancer.md
+        - UDP Load Balancer: commands/virtual/delete/udp_loadbalancer.md
+      - Get:
+        - Get Overview: commands/virtual/get/index.md
+        - Geo Location Set: commands/virtual/get/geo_location_set.md
+        - Health Check: commands/virtual/get/healthcheck.md
+        - HTTP Load Balancer: commands/virtual/get/http_loadbalancer.md
+        - Origin Pool: commands/virtual/get/origin_pool.md
+        - Proxy: commands/virtual/get/proxy.md
+        - Rate Limiter Policy: commands/virtual/get/rate_limiter_policy.md
+        - Service Policy: commands/virtual/get/service_policy.md
+        - Service Policy Rule: commands/virtual/get/service_policy_rule.md
+        - TCP Load Balancer: commands/virtual/get/tcp_loadbalancer.md
+        - UDP Load Balancer: commands/virtual/get/udp_loadbalancer.md
+      - List:
+        - List Overview: commands/virtual/list/index.md
+        - Geo Location Set: commands/virtual/list/geo_location_set.md
+        - Health Check: commands/virtual/list/healthcheck.md
+        - HTTP Load Balancer: commands/virtual/list/http_loadbalancer.md
+        - Origin Pool: commands/virtual/list/origin_pool.md
+        - Proxy: commands/virtual/list/proxy.md
+        - Rate Limiter Policy: commands/virtual/list/rate_limiter_policy.md
+        - Service Policy: commands/virtual/list/service_policy.md
+        - Service Policy Rule: commands/virtual/list/service_policy_rule.md
+        - TCP Load Balancer: commands/virtual/list/tcp_loadbalancer.md
+        - UDP Load Balancer: commands/virtual/list/udp_loadbalancer.md
+      - Patch:
+        - Patch Overview: commands/virtual/patch/index.md
+        - Geo Location Set: commands/virtual/patch/geo_location_set.md
+        - Health Check: commands/virtual/patch/healthcheck.md
+        - HTTP Load Balancer: commands/virtual/patch/http_loadbalancer.md
+        - Origin Pool: commands/virtual/patch/origin_pool.md
+        - Proxy: commands/virtual/patch/proxy.md
+        - Rate Limiter Policy: commands/virtual/patch/rate_limiter_policy.md
+        - Service Policy: commands/virtual/patch/service_policy.md
+        - Service Policy Rule: commands/virtual/patch/service_policy_rule.md
+        - TCP Load Balancer: commands/virtual/patch/tcp_loadbalancer.md
+        - UDP Load Balancer: commands/virtual/patch/udp_loadbalancer.md
+      - Remove Labels:
+        - Remove Labels Overview: commands/virtual/remove-labels/index.md
+        - Geo Location Set: commands/virtual/remove-labels/geo_location_set.md
+        - Health Check: commands/virtual/remove-labels/healthcheck.md
+        - HTTP Load Balancer: commands/virtual/remove-labels/http_loadbalancer.md
+        - Origin Pool: commands/virtual/remove-labels/origin_pool.md
+        - Proxy: commands/virtual/remove-labels/proxy.md
+        - Rate Limiter Policy: commands/virtual/remove-labels/rate_limiter_policy.md
+        - Service Policy: commands/virtual/remove-labels/service_policy.md
+        - Service Policy Rule: commands/virtual/remove-labels/service_policy_rule.md
+        - TCP Load Balancer: commands/virtual/remove-labels/tcp_loadbalancer.md
+        - UDP Load Balancer: commands/virtual/remove-labels/udp_loadbalancer.md
+      - Replace:
+        - Replace Overview: commands/virtual/replace/index.md
+        - Geo Location Set: commands/virtual/replace/geo_location_set.md
+        - Health Check: commands/virtual/replace/healthcheck.md
+        - HTTP Load Balancer: commands/virtual/replace/http_loadbalancer.md
+        - Origin Pool: commands/virtual/replace/origin_pool.md
+        - Proxy: commands/virtual/replace/proxy.md
+        - Rate Limiter Policy: commands/virtual/replace/rate_limiter_policy.md
+        - Service Policy: commands/virtual/replace/service_policy.md
+        - Service Policy Rule: commands/virtual/replace/service_policy_rule.md
+        - TCP Load Balancer: commands/virtual/replace/tcp_loadbalancer.md
+        - UDP Load Balancer: commands/virtual/replace/udp_loadbalancer.md
+      - Status:
+        - Status Overview: commands/virtual/status/index.md
+        - Geo Location Set: commands/virtual/status/geo_location_set.md
+        - Health Check: commands/virtual/status/healthcheck.md
+        - HTTP Load Balancer: commands/virtual/status/http_loadbalancer.md
+        - Origin Pool: commands/virtual/status/origin_pool.md
+        - Proxy: commands/virtual/status/proxy.md
+        - Rate Limiter Policy: commands/virtual/status/rate_limiter_policy.md
+        - Service Policy: commands/virtual/status/service_policy.md
+        - Service Policy Rule: commands/virtual/status/service_policy_rule.md
+        - TCP Load Balancer: commands/virtual/status/tcp_loadbalancer.md
+        - UDP Load Balancer: commands/virtual/status/udp_loadbalancer.md
+    - Vpm And Node Management:
+      - Vpm And Node Management Overview: commands/vpm_and_node_management/index.md
+      - Add Labels: commands/vpm_and_node_management/add-labels/index.md
+      - Apply: commands/vpm_and_node_management/apply/index.md
+      - Create: commands/vpm_and_node_management/create/index.md
+      - Delete: commands/vpm_and_node_management/delete/index.md
+      - Get: commands/vpm_and_node_management/get/index.md
+      - List: commands/vpm_and_node_management/list/index.md
+      - Patch: commands/vpm_and_node_management/patch/index.md
+      - Remove Labels: commands/vpm_and_node_management/remove-labels/index.md
+      - Replace: commands/vpm_and_node_management/replace/index.md
+      - Status: commands/vpm_and_node_management/status/index.md
+    - WAF:
+      - WAF Overview: commands/waf/index.md
+      - Add Labels:
+        - Add Labels Overview: commands/waf/add-labels/index.md
+        - App Firewall: commands/waf/add-labels/app_firewall.md
+        - Enhanced Firewall Policy: commands/waf/add-labels/enhanced_firewall_policy.md
+        - Protocol Inspection: commands/waf/add-labels/protocol_inspection.md
+        - WAF Exclusion Policy: commands/waf/add-labels/waf_exclusion_policy.md
+      - Apply:
+        - Apply Overview: commands/waf/apply/index.md
+        - App Firewall: commands/waf/apply/app_firewall.md
+        - Enhanced Firewall Policy: commands/waf/apply/enhanced_firewall_policy.md
+        - Protocol Inspection: commands/waf/apply/protocol_inspection.md
+        - WAF Exclusion Policy: commands/waf/apply/waf_exclusion_policy.md
+      - Create:
+        - Create Overview: commands/waf/create/index.md
+        - App Firewall: commands/waf/create/app_firewall.md
+        - Enhanced Firewall Policy: commands/waf/create/enhanced_firewall_policy.md
+        - Protocol Inspection: commands/waf/create/protocol_inspection.md
+        - WAF Exclusion Policy: commands/waf/create/waf_exclusion_policy.md
+      - Delete:
+        - Delete Overview: commands/waf/delete/index.md
+        - App Firewall: commands/waf/delete/app_firewall.md
+        - Enhanced Firewall Policy: commands/waf/delete/enhanced_firewall_policy.md
+        - Protocol Inspection: commands/waf/delete/protocol_inspection.md
+        - WAF Exclusion Policy: commands/waf/delete/waf_exclusion_policy.md
+      - Get:
+        - Get Overview: commands/waf/get/index.md
+        - App Firewall: commands/waf/get/app_firewall.md
+        - Enhanced Firewall Policy: commands/waf/get/enhanced_firewall_policy.md
+        - Protocol Inspection: commands/waf/get/protocol_inspection.md
+        - WAF Exclusion Policy: commands/waf/get/waf_exclusion_policy.md
+      - List:
+        - List Overview: commands/waf/list/index.md
+        - App Firewall: commands/waf/list/app_firewall.md
+        - Enhanced Firewall Policy: commands/waf/list/enhanced_firewall_policy.md
+        - Protocol Inspection: commands/waf/list/protocol_inspection.md
+        - WAF Exclusion Policy: commands/waf/list/waf_exclusion_policy.md
+      - Patch:
+        - Patch Overview: commands/waf/patch/index.md
+        - App Firewall: commands/waf/patch/app_firewall.md
+        - Enhanced Firewall Policy: commands/waf/patch/enhanced_firewall_policy.md
+        - Protocol Inspection: commands/waf/patch/protocol_inspection.md
+        - WAF Exclusion Policy: commands/waf/patch/waf_exclusion_policy.md
+      - Remove Labels:
+        - Remove Labels Overview: commands/waf/remove-labels/index.md
+        - App Firewall: commands/waf/remove-labels/app_firewall.md
+        - Enhanced Firewall Policy: commands/waf/remove-labels/enhanced_firewall_policy.md
+        - Protocol Inspection: commands/waf/remove-labels/protocol_inspection.md
+        - WAF Exclusion Policy: commands/waf/remove-labels/waf_exclusion_policy.md
+      - Replace:
+        - Replace Overview: commands/waf/replace/index.md
+        - App Firewall: commands/waf/replace/app_firewall.md
+        - Enhanced Firewall Policy: commands/waf/replace/enhanced_firewall_policy.md
+        - Protocol Inspection: commands/waf/replace/protocol_inspection.md
+        - WAF Exclusion Policy: commands/waf/replace/waf_exclusion_policy.md
+      - Status:
+        - Status Overview: commands/waf/status/index.md
+        - App Firewall: commands/waf/status/app_firewall.md
+        - Enhanced Firewall Policy: commands/waf/status/enhanced_firewall_policy.md
+        - Protocol Inspection: commands/waf/status/protocol_inspection.md
+        - WAF Exclusion Policy: commands/waf/status/waf_exclusion_policy.md
   - Guides:
     - guides/index.md
     - Load Balancers: guides/load-balancer.md


### PR DESCRIPTION
## Summary

Fix the Documentation workflow failure (issue #274) by correcting nav paths and syncing with API v1.0.46.

### Root Cause
The mkdocs.yml nav configuration referenced paths that don't match the actual cloudstatus doc structure:
- Nav expected: `commands/cloudstatus/status/index.md`
- Actual file: `commands/cloudstatus/status.md`

Additionally, the nav still referenced domains removed in earlier API spec updates (vpn, tenant_management, infrastructure_protection, etc.)

### Changes
- Fix cloudstatus status/summary/watch nav paths (`.md` vs `/index.md`)
- Update mkdocs.yml nav to match current 39 domains
- Remove stale domain references from nav
- Update docs.yml workflow validation paths to match

### Files Changed
- `.github/workflows/docs.yml` - validation paths
- `mkdocs.yml` - nav structure synced with current domains
- `docs/install/homebrew.md` - version update
- `docs/install/source.md` - version update

## Test Plan
- [x] Local `mkdocs build --strict` passes
- [ ] CI Documentation workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #274