### PR TITLE
fix: correct cloudstatus nav paths to match generated structure

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -252,9 +252,9 @@ jobs:
 
           # Define required files matching mkdocs.yml navigation
           REQUIRED_FILES=(
-            "docs/commands/cloudstatus/status.md"
-            "docs/commands/cloudstatus/summary.md"
-            "docs/commands/cloudstatus/watch.md"
+            "docs/commands/cloudstatus/status/index.md"
+            "docs/commands/cloudstatus/summary/index.md"
+            "docs/commands/cloudstatus/watch/index.md"
             "docs/commands/cloudstatus/components/index.md"
             "docs/commands/cloudstatus/incidents/index.md"
             "docs/commands/cloudstatus/maintenance/index.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -586,9 +586,9 @@ nav:
         - Pops Overview: commands/cloudstatus/pops/index.md
         - List: commands/cloudstatus/pops/list.md
         - Status: commands/cloudstatus/pops/status.md
-      - Status: commands/cloudstatus/status.md
-      - Summary: commands/cloudstatus/summary.md
-      - Watch: commands/cloudstatus/watch.md
+      - Status: commands/cloudstatus/status/index.md
+      - Summary: commands/cloudstatus/summary/index.md
+      - Watch: commands/cloudstatus/watch/index.md
     - Completion: commands/completion/index.md
     - Data And Privacy Security:
       - Data And Privacy Security Overview: commands/data_and_privacy_security/index.md


### PR DESCRIPTION
## Summary

Fixes #274 - Documentation workflow failing due to mkdocs nav configuration mismatch.

### Problem

The previous fix (PR #278) incorrectly changed cloudstatus nav paths from subdirectory format to flat file format. However, `generate-docs.py` (used in CI) creates subdirectory structure:

- `docs/commands/cloudstatus/status/index.md` ✅ (what CI generates)
- `docs/commands/cloudstatus/status.md` ❌ (what PR #278 expected)

### Fix

Revert to correct subdirectory paths:
- `commands/cloudstatus/status/index.md`
- `commands/cloudstatus/summary/index.md`
- `commands/cloudstatus/watch/index.md`

### Files Changed
- `mkdocs.yml` - Fix cloudstatus nav paths
- `.github/workflows/docs.yml` - Fix validation to match nav

## Test Plan
- [x] Local `mkdocs build --strict` passes
- [ ] Documentation workflow passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)