### PR TITLE
fix: update artifact actions to eliminate Node.js deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,7 +315,7 @@ jobs:
         run: ls -la dist/
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: binaries
           path: dist/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -249,7 +249,7 @@ jobs:
           echo "✅ All required cloudstatus documentation files present"
 
       - name: Upload generated docs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: generated-docs
           path: docs/
@@ -409,7 +409,7 @@ jobs:
             --output docs/install/windows.md
 
       - name: Upload Windows docs artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: windows-docs
           path: docs/install/windows.md
@@ -429,14 +429,14 @@ jobs:
 
       - name: Download generated docs
         if: needs.generate.result == 'success'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: generated-docs
           path: docs/
 
       - name: Download Windows docs
         if: needs.build-windows-docs.result == 'success'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: windows-docs
           path: docs/install/


### PR DESCRIPTION
## Summary

Update GitHub Actions artifact actions to latest versions to eliminate Node.js deprecation warnings observed in workflow runs.

### Changes
- `actions/upload-artifact`: v4 → v6 (ci.yml, docs.yml)
- `actions/download-artifact`: v4 → v7 (docs.yml)

### Warnings Resolved
```
(node:1052) [DEP0005] DeprecationWarning: Buffer() is deprecated
(node:1063) [DEP0040] DeprecationWarning: The punycode module is deprecated
```

These warnings appeared during artifact upload/download operations due to outdated action versions.

## Test Plan
- [x] Pre-commit hooks pass
- [ ] CI workflow completes without deprecation warnings
- [ ] Documentation workflow completes without deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)