### PR TITLE
fix: remove duplicate site command from help output

### DIFF
--- a/cmd/domains.go
+++ b/cmd/domains.go
@@ -11,10 +11,20 @@ import (
 	"github.com/robinmordasiewicz/xcsh/pkg/validation"
 )
 
+// customDomainCommands lists domains that have custom implementations
+// and should not be auto-registered from DomainRegistry
+var customDomainCommands = map[string]bool{
+	"site": true, // Custom implementation in site.go with Terraform automation
+}
+
 // init registers all domain commands dynamically
 func init() {
 	// Register domain commands for all domains in DomainRegistry
 	for domain := range types.DomainRegistry {
+		// Skip domains with custom implementations
+		if customDomainCommands[domain] {
+			continue
+		}
 		rootCmd.AddCommand(buildDomainCmd(domain))
 	}
 }


### PR DESCRIPTION
## Summary

Fix duplicate `site` command appearing in `xcsh --help` output.

### Problem
When running `xcsh --help`, the `site` command appeared twice:
```
  site                         Manage Site resources
  site                         Deploy and manage F5 XC sites on public cloud providers.
```

### Root Cause
The `site` command was being registered twice:
1. **Auto-generated**: From `DomainRegistry` in `cmd/domains.go` init()
2. **Custom**: From `cmd/site.go` init() with Terraform automation features

### Solution
Added `customDomainCommands` map in `cmd/domains.go` to skip domains that have custom implementations during auto-registration. This follows the same pattern as `customResourceCommands` in `cmd/resource.go`.

### After Fix
```
  site                         Deploy and manage F5 XC sites on public cloud providers.
  site_management              Manage Site Management resources
```

## Test Plan
- [x] Build succeeds
- [x] All tests pass
- [x] Only one `site` command in `--help` output
- [x] `site` command works correctly with custom implementation
- [ ] CI passes

Fixes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)