### PR TITLE
feat: implement contextual help system for REPL commands

### DIFF
--- a/cmd/domains.go
+++ b/cmd/domains.go
@@ -102,6 +102,9 @@ Run 'xcsh %s --help' for more information.`, info.DisplayName, info.Description,
 		Aliases: info.Aliases,
 		Short:   shortDesc,
 		Long:    longDesc,
+		Annotations: map[string]string{
+			"help-level": string(LevelDomain),
+		},
 	}
 
 	// Wrap the RunE with tier validation and preview warnings
@@ -162,6 +165,9 @@ func buildDomainListCmd(domain string) *cobra.Command {
 
 Returns a list of configurations with names, namespaces, and metadata.
 Use --namespace to filter by namespace, or --output-format to control output format.`, domainInfo.DisplayName, domainInfo.Description),
+		Annotations: map[string]string{
+			"help-level": string(LevelAction),
+		},
 	}
 
 	cmd.PersistentFlags().StringVarP(&flags.namespace, "namespace", "n", "default", "Target namespace for the operation.")
@@ -223,6 +229,9 @@ func buildDomainGetCmd(domain string) *cobra.Command {
 
 Returns the full configuration including metadata and spec.
 Use --response-format replace-request to get output suitable for editing and replacing.`, domainInfo.DisplayName, domainInfo.Description),
+		Annotations: map[string]string{
+			"help-level": string(LevelAction),
+		},
 	}
 
 	cmd.PersistentFlags().StringVarP(&flags.namespace, "namespace", "n", "default", "Target namespace for the operation.")
@@ -288,6 +297,9 @@ func buildDomainCreateCmd(domain string) *cobra.Command {
 %s
 
 Provide a YAML or JSON file with the resource configuration using --input-file.`, domainInfo.DisplayName, domainInfo.Description),
+		Annotations: map[string]string{
+			"help-level": string(LevelAction),
+		},
 	}
 
 	cmd.PersistentFlags().StringVarP(&flags.namespace, "namespace", "n", "default", "Target namespace for the operation.")
@@ -352,6 +364,9 @@ func buildDomainDeleteCmd(domain string) *cobra.Command {
 %s
 
 Requires confirmation unless --yes is specified.`, domainInfo.DisplayName, domainInfo.Description),
+		Annotations: map[string]string{
+			"help-level": string(LevelAction),
+		},
 	}
 
 	cmd.PersistentFlags().StringVarP(&flags.namespace, "namespace", "n", "default", "Target namespace for the operation.")
@@ -419,6 +434,9 @@ func buildDomainReplaceCmd(domain string) *cobra.Command {
 
 This performs a complete replacement of the resource with the provided configuration.
 Use apply for create-or-update semantics.`, domainInfo.DisplayName, domainInfo.Description),
+		Annotations: map[string]string{
+			"help-level": string(LevelAction),
+		},
 	}
 
 	cmd.PersistentFlags().StringVarP(&flags.namespace, "namespace", "n", "default", "Target namespace for the operation.")
@@ -481,6 +499,9 @@ func buildDomainStatusCmd(domain string) *cobra.Command {
 %s
 
 Returns the current operational state and any relevant status information.`, domainInfo.DisplayName, domainInfo.Description),
+		Annotations: map[string]string{
+			"help-level": string(LevelAction),
+		},
 	}
 
 	cmd.PersistentFlags().StringVarP(&flags.namespace, "namespace", "n", "default", "Target namespace for the operation.")
@@ -542,6 +563,9 @@ func buildDomainApplyCmd(domain string) *cobra.Command {
 %s
 
 If the resource exists, it will be updated. If it doesn't exist, it will be created.`, domainInfo.DisplayName, domainInfo.Description),
+		Annotations: map[string]string{
+			"help-level": string(LevelAction),
+		},
 	}
 
 	cmd.PersistentFlags().StringVarP(&flags.namespace, "namespace", "n", "default", "Target namespace for the operation.")
@@ -602,6 +626,9 @@ func buildDomainPatchCmd(domain string) *cobra.Command {
 %s
 
 Only specified fields will be updated. Other fields remain unchanged.`, domainInfo.DisplayName, domainInfo.Description),
+		Annotations: map[string]string{
+			"help-level": string(LevelAction),
+		},
 	}
 
 	cmd.PersistentFlags().StringVarP(&flags.namespace, "namespace", "n", "default", "Target namespace for the operation.")
@@ -665,6 +692,9 @@ func buildDomainAddLabelsCmd(domain string) *cobra.Command {
 %s
 
 Specify label key-value pairs using --label-key and --label-value flags.`, domainInfo.DisplayName, domainInfo.Description),
+		Annotations: map[string]string{
+			"help-level": string(LevelAction),
+		},
 	}
 
 	cmd.PersistentFlags().StringVarP(&flags.namespace, "namespace", "n", "default", "Target namespace for the operation.")
@@ -726,6 +756,9 @@ func buildDomainRemoveLabelsCmd(domain string) *cobra.Command {
 %s
 
 Specify the label keys to remove using --label-key flags.`, domainInfo.DisplayName, domainInfo.Description),
+		Annotations: map[string]string{
+			"help-level": string(LevelAction),
+		},
 	}
 
 	cmd.PersistentFlags().StringVarP(&flags.namespace, "namespace", "n", "default", "Target namespace for the operation.")

--- a/cmd/help_templates.go
+++ b/cmd/help_templates.go
@@ -1,0 +1,155 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/robinmordasiewicz/xcsh/pkg/types"
+)
+
+// CommandLevel represents the depth/type of a command in the hierarchy
+type CommandLevel string
+
+const (
+	// LevelRoot is the top-level xcsh command
+	LevelRoot CommandLevel = "root"
+	// LevelDomain is a domain command (e.g., virtual, load_balancer)
+	LevelDomain CommandLevel = "domain"
+	// LevelAction is an action command (e.g., list, get, create)
+	LevelAction CommandLevel = "action"
+	// LevelResource is a resource type command (e.g., http_loadbalancer)
+	LevelResource CommandLevel = "resource"
+	// LevelCustom is for custom top-level commands (e.g., site, subscription)
+	LevelCustom CommandLevel = "custom"
+)
+
+// getCommandLevel determines the help level for a command
+// Uses annotations for O(1) lookup, falls back to parent chain analysis
+func getCommandLevel(cmd *cobra.Command) CommandLevel {
+	// Check for explicit annotation override (fastest path)
+	if cmd.Annotations != nil {
+		if level, ok := cmd.Annotations["help-level"]; ok {
+			return CommandLevel(level)
+		}
+	}
+
+	// Fall back to depth-based detection
+	depth := countParents(cmd)
+
+	switch depth {
+	case 0:
+		return LevelRoot
+	case 1:
+		// Check if it's a domain command
+		if _, isDomain := types.GetDomainInfo(cmd.Name()); isDomain {
+			return LevelDomain
+		}
+		return LevelCustom
+	case 2:
+		// Check if parent is a domain
+		if parent := cmd.Parent(); parent != nil {
+			if _, isDomain := types.GetDomainInfo(parent.Name()); isDomain {
+				return LevelAction
+			}
+		}
+		return LevelCustom
+	default:
+		return LevelResource
+	}
+}
+
+// countParents counts the number of parent commands
+func countParents(cmd *cobra.Command) int {
+	depth := 0
+	parent := cmd.Parent()
+	for parent != nil {
+		depth++
+		parent = parent.Parent()
+	}
+	return depth
+}
+
+// getHelpTemplateForLevel returns the appropriate help template for a command level
+func getHelpTemplateForLevel(level CommandLevel) string {
+	switch level {
+	case LevelRoot:
+		return rootHelpTemplate()
+	case LevelDomain:
+		return domainHelpTemplate()
+	case LevelAction:
+		return actionHelpTemplate()
+	case LevelResource:
+		return resourceHelpTemplate()
+	case LevelCustom:
+		return customHelpTemplate()
+	default:
+		return defaultHelpTemplate()
+	}
+}
+
+// rootHelpTemplate returns the full verbose help template for the root command
+// Includes environment variables, examples, and configuration sections
+func rootHelpTemplate() string {
+	return `{{with (or .Long .Short)}}{{. | trimTrailingWhitespaces}}
+
+{{end}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`
+}
+
+// domainHelpTemplate returns a focused template for domain commands
+// Shows domain info and available actions without global env vars
+func domainHelpTemplate() string {
+	return `{{with (or .Long .Short)}}{{. | trimTrailingWhitespaces}}
+
+{{end}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}
+Use "{{.CommandPath}} [action] --help" for action-specific help.
+`
+}
+
+// actionHelpTemplate returns a focused template for action commands
+// Shows flags and available resource types
+func actionHelpTemplate() string {
+	return `{{with (or .Long .Short)}}{{. | trimTrailingWhitespaces}}
+
+{{end}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}
+Use "{{.CommandPath}} [resource-type] --help" for resource-specific help.
+`
+}
+
+// resourceHelpTemplate returns a focused template for resource type commands
+// Shows resource-specific examples and flags (included via UsageString)
+func resourceHelpTemplate() string {
+	return `{{with (or .Long .Short)}}{{. | trimTrailingWhitespaces}}
+
+{{end}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}
+`
+}
+
+// customHelpTemplate returns a template for custom top-level commands
+// Similar to domain but without domain-specific assumptions
+func customHelpTemplate() string {
+	return `{{with (or .Long .Short)}}{{. | trimTrailingWhitespaces}}
+
+{{end}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}{{if .HasAvailableSubCommands}}
+
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+`
+}
+
+// defaultHelpTemplate returns Cobra's default-like template as fallback
+func defaultHelpTemplate() string {
+	return `{{with (or .Long .Short)}}{{. | trimTrailingWhitespaces}}
+
+{{end}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}
+`
+}
+
+// applyContextualHelpSystem applies appropriate help templates based on command level
+// This replaces the uniform applyHelpTemplateRecursively function
+func applyContextualHelpSystem(cmd *cobra.Command) {
+	level := getCommandLevel(cmd)
+	template := getHelpTemplateForLevel(level)
+	cmd.SetHelpTemplate(template)
+
+	for _, subCmd := range cmd.Commands() {
+		applyContextualHelpSystem(subCmd)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -535,8 +535,14 @@ func initHelpSystem() {
 	// Apply custom usage template that properly filters hidden commands
 	applyUsageTemplateRecursively(rootCmd, usageTemplateWithHiddenFilter())
 
-	// Apply custom help template to all commands recursively
-	applyHelpTemplateRecursively(rootCmd, helpTemplateWithEnvVars())
+	// Apply contextual help templates based on command level
+	// Root command gets the full verbose template with env vars
+	rootCmd.SetHelpTemplate(helpTemplateWithEnvVars())
+
+	// Apply contextual templates to all subcommands
+	for _, subCmd := range rootCmd.Commands() {
+		applyContextualHelpSystem(subCmd)
+	}
 }
 
 // usageTemplateWithHiddenFilter returns a usage template that properly filters hidden commands
@@ -572,16 +578,6 @@ func applyUsageTemplateRecursively(cmd *cobra.Command, template string) {
 	cmd.SetUsageTemplate(template)
 	for _, subCmd := range cmd.Commands() {
 		applyUsageTemplateRecursively(subCmd, template)
-	}
-}
-
-// applyHelpTemplateRecursively applies custom help template to all commands
-// in the command tree. This ensures consistent help formatting with environment
-// variables section across all subcommands.
-func applyHelpTemplateRecursively(cmd *cobra.Command, template string) {
-	cmd.SetHelpTemplate(template)
-	for _, subCmd := range cmd.Commands() {
-		applyHelpTemplateRecursively(subCmd, template)
 	}
 }
 


### PR DESCRIPTION
## Summary

Implement hierarchical contextual help system where help output is appropriate to the command depth:

| Command Level | Example | Help Content |
|---------------|---------|--------------|
| Root | `xcsh --help` | Full global help: env vars, config priority, examples |
| Domain | `xcsh virtual --help` | Domain info + available actions (NO global env vars) |
| Action | `xcsh virtual create --help` | Action flags + available resource types |
| Resource | `xcsh virtual create http_loadbalancer --help` | Resource-specific examples + flags |

### Implementation
- Add `CommandLevel` type with annotations for O(1) level detection
- Create contextual templates for each command depth
- Apply templates recursively via `applyContextualHelpSystem()`
- Remove duplicate sections from resource-level help

### Files Changed
- **NEW**: `cmd/help_templates.go` (155 lines) - Template definitions and level detection
- **MODIFIED**: `cmd/root.go` - Use contextual help system
- **MODIFIED**: `cmd/domains.go` - Add help-level annotations

## Test Plan
- [x] `xcsh --help` shows Environment Variables section
- [x] `xcsh virtual --help` does NOT show Environment Variables
- [x] `xcsh virtual create --help` shows flags and resource types
- [x] `xcsh virtual create http_loadbalancer --help` shows resource examples (no duplication)
- [x] All pre-commit hooks pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #295