### PR TITLE
feat: add modern CLI welcome banner with F5 circular logo

### DIFF
--- a/cmd/repl.go
+++ b/cmd/repl.go
@@ -9,6 +9,11 @@ import (
 	"github.com/robinmordasiewicz/xcsh/pkg/branding"
 )
 
+// printWelcomeBanner displays the modern welcome banner when entering REPL mode
+func printWelcomeBanner() {
+	fmt.Print(renderWelcomeBanner())
+}
+
 // shouldEnterREPL determines if the CLI should enter interactive REPL mode
 func shouldEnterREPL() bool {
 	// No subcommand provided
@@ -66,18 +71,6 @@ func StartREPL() error {
 	p.Run()
 
 	return nil
-}
-
-// printWelcomeBanner displays the welcome message when entering REPL mode
-func printWelcomeBanner() {
-	fmt.Printf(`
-%s - Interactive Mode
-Version: %s
-
-Type 'help' for available commands, 'exit' or Ctrl+D to quit.
-Tab completion is available for commands and arguments.
-
-`, branding.CLIFullName, Version)
 }
 
 // buildPrompt constructs the prompt string based on session state

--- a/cmd/repl_banner.go
+++ b/cmd/repl_banner.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/robinmordasiewicz/xcsh/pkg/branding"
+	"github.com/robinmordasiewicz/xcsh/pkg/client"
+)
+
+// logoDisplayWidth is the visual width of the F5 logo in terminal columns
+// The circular logo is 21 characters wide
+const logoDisplayWidth = 21
+
+// renderWelcomeBanner creates the modern CLI welcome banner with F5 logo
+func renderWelcomeBanner() string {
+	var sb strings.Builder
+
+	// Add leading newline for visual separation
+	sb.WriteString("\n")
+
+	// Get logo lines
+	logoLines := strings.Split(branding.F5Logo, "\n")
+
+	// Build info lines to display next to logo
+	infoLines := []string{
+		fmt.Sprintf("%s v%s", branding.CLIFullName, Version),
+		buildConnectionInfo(),
+		"",
+		"Type 'help' for commands, 'exit' or Ctrl+D to quit.",
+		"Tab completion available.",
+		"",
+		"",
+	}
+
+	// Combine logo and info side by side with colors
+	for i := 0; i < maxInt(len(logoLines), len(infoLines)); i++ {
+		logoLine := ""
+		if i < len(logoLines) {
+			logoLine = logoLines[i]
+		}
+
+		infoLine := ""
+		if i < len(infoLines) {
+			infoLine = infoLines[i]
+		}
+
+		// Pad logo line to consistent visual width
+		// Use rune count for proper Unicode handling
+		runeCount := utf8.RuneCountInString(logoLine)
+		padding := logoDisplayWidth - runeCount
+		if padding < 0 {
+			padding = 0
+		}
+		paddedLogo := logoLine + strings.Repeat(" ", padding)
+
+		// Apply colors: red for logo, bold white for info
+		coloredLogo := branding.ColorRed + paddedLogo + branding.ColorReset
+		coloredInfo := branding.ColorBoldWhite + infoLine + branding.ColorReset
+
+		sb.WriteString(fmt.Sprintf("%s   %s\n", coloredLogo, coloredInfo))
+	}
+
+	// Add separator line in red
+	sb.WriteString(branding.ColorRed + strings.Repeat("─", 80) + branding.ColorReset + "\n")
+
+	return sb.String()
+}
+
+// buildConnectionInfo returns tenant and API info string
+func buildConnectionInfo() string {
+	if serverURL == "" {
+		return "Not connected · Set F5XC_API_URL to connect"
+	}
+
+	tenant := client.ExtractTenant(serverURL)
+	// Extract domain from URL for display
+	domain := extractDomain(serverURL)
+
+	return fmt.Sprintf("Tenant: %s · API: %s", tenant, domain)
+}
+
+// extractDomain extracts the domain from a URL for compact display
+func extractDomain(url string) string {
+	// Remove protocol
+	url = strings.TrimPrefix(url, "https://")
+	url = strings.TrimPrefix(url, "http://")
+	// Remove trailing slashes
+	url = strings.TrimSuffix(url, "/")
+	return url
+}
+
+// maxInt returns the larger of two integers
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/pkg/branding/branding.go
+++ b/pkg/branding/branding.go
@@ -7,6 +7,27 @@ const (
 	// CLIName is the current name of the CLI tool
 	CLIName = "xcsh"
 
+	// F5Logo is the ASCII art logo with circular frame
+	// Used in the interactive REPL welcome banner
+	// Designed to evoke the F5 red circle logo
+	F5Logo = `       ●●●●●●●●
+     ●●        ●●
+   ●●            ●●
+  ●    ███  ███    ●
+  ●    █    █      ●
+ ●     ██   ███     ●
+ ●     █       █    ●
+  ●    █    ███    ●
+  ●                ●
+   ●●            ●●
+     ●●        ●●
+       ●●●●●●●●`
+
+	// ANSI color codes for terminal output
+	ColorRed       = "\033[91m"   // Bright red (like GitHub diff removed)
+	ColorBoldWhite = "\033[1;97m" // Bold bright white
+	ColorReset     = "\033[0m"    // Reset to default
+
 	// CLIFullName is the full descriptive name
 	CLIFullName = "F5 Distributed Cloud Shell"
 


### PR DESCRIPTION
## Summary
Add a professional welcome screen to xcsh interactive mode inspired by Claude Code and Gemini CLI.

- F5 logo designed as circular ASCII art with filled dots (●) evoking the F5 brand's red circle
- Side-by-side layout with logo and session info
- Bright red color for logo (GitHub diff style)
- Bold white text for version and connection info
- Dynamic tenant and API endpoint display

## Files Changed
- **NEW** `cmd/repl_banner.go`: Banner rendering logic with color support
- **MOD** `pkg/branding/branding.go`: Added F5Logo constant and ANSI color codes
- **MOD** `cmd/repl.go`: Simplified to use new banner renderer

## Test Plan
- [x] Build succeeds with `go build`
- [x] Banner renders correctly with proper alignment
- [x] Colors display correctly (bright red logo, bold white text)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #297