### PR TITLE
feat: add double Ctrl+C exit and update welcome screen

### DIFF
--- a/cmd/repl.go
+++ b/cmd/repl.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/c-bata/go-prompt"
 	"github.com/mattn/go-isatty"
@@ -65,6 +66,10 @@ func StartREPL() error {
 			Key: prompt.ControlD,
 			Fn:  func(*prompt.Buffer) { handleExit(session) },
 		}),
+		prompt.OptionAddKeyBind(prompt.KeyBind{
+			Key: prompt.ControlC,
+			Fn:  func(*prompt.Buffer) { handleCtrlC(session) },
+		}),
 	)
 
 	// Run the REPL
@@ -89,4 +94,16 @@ func handleExit(session *REPLSession) {
 
 	fmt.Println("\nGoodbye!")
 	os.Exit(0)
+}
+
+// handleCtrlC handles Ctrl+C with double-press to exit
+func handleCtrlC(session *REPLSession) {
+	now := time.Now()
+	// 500ms window for double-press detection
+	if now.Sub(session.lastCtrlCTime) < 500*time.Millisecond {
+		handleExit(session)
+	}
+	session.lastCtrlCTime = now
+	// Show hint message
+	fmt.Print("\nPress Ctrl+C again to exit, or continue typing\n")
 }

--- a/cmd/repl_banner.go
+++ b/cmd/repl_banner.go
@@ -54,7 +54,7 @@ func renderWelcomeBanner() string {
 
 	// Info content below logo
 	infoLines := []string{
-		"Type 'help' for commands, 'exit' or Ctrl+D to quit. Tab completion available.",
+		"Type 'help' for commands. Press Ctrl+C twice or Ctrl+D to quit.",
 		buildConnectionInfo(),
 	}
 

--- a/cmd/repl_session.go
+++ b/cmd/repl_session.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/c-bata/go-prompt"
 	"github.com/robinmordasiewicz/xcsh/pkg/client"
@@ -20,6 +21,9 @@ type REPLSession struct {
 	contextPath *ContextPath      // Current navigation context
 	tenant      string            // Extracted tenant name from API URL
 	validator   *ContextValidator // Domain/action validator
+
+	// Exit handling
+	lastCtrlCTime time.Time // Track last Ctrl+C for double-press detection
 }
 
 // initREPLSession creates a new REPL session with initialized state


### PR DESCRIPTION
## Summary
Add support for exiting the interactive shell by pressing Ctrl+C twice in a row, matching the UX pattern used by modern AI assistants.

## Changes
- Add `lastCtrlCTime` field to REPLSession for double-press detection
- Add `handleCtrlC` function with 500ms detection window  
- Add ControlC key binding alongside existing ControlD
- Update welcome banner to show "Press Ctrl+C twice or Ctrl+D to quit"

## Behavior
- **First Ctrl+C**: Shows "Press Ctrl+C again to exit, or continue typing"
- **Second Ctrl+C within 500ms**: Exits gracefully with "Goodbye!"
- **Ctrl+D**: Still works as immediate exit (unchanged)

## Files Changed
- `cmd/repl_session.go` - Added time tracking field
- `cmd/repl.go` - Added handler function and key binding
- `cmd/repl_banner.go` - Updated help text

Closes #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)