### PR TITLE
feat: REPL namespace persistence and slash escape command syntax

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -68,7 +68,8 @@ Available keys:
   - cert: Path to client certificate
   - key: Path to client key
   - api-token: Enable API token auth (true/false)
-  - output: Default output format (json, yaml, table)`,
+  - output: Default output format (json, yaml, table)
+  - default-namespace: Default namespace for CRUD operations`,
 	Example: `  # Set the server URL
   xcsh configure set server-url https://example-tenant.console.ves.volterra.io/api
 
@@ -98,22 +99,24 @@ func init() {
 
 // ConfigFile represents the configuration file structure
 type ConfigFile struct {
-	ServerURL string `yaml:"server-url,omitempty"`
-	P12Bundle string `yaml:"p12-bundle,omitempty"`
-	Cert      string `yaml:"cert,omitempty"`
-	Key       string `yaml:"key,omitempty"`
-	Output    string `yaml:"output,omitempty"`
-	APIToken  bool   `yaml:"api-token,omitempty"`
+	ServerURL        string `yaml:"server-url,omitempty"`
+	P12Bundle        string `yaml:"p12-bundle,omitempty"`
+	Cert             string `yaml:"cert,omitempty"`
+	Key              string `yaml:"key,omitempty"`
+	Output           string `yaml:"output,omitempty"`
+	APIToken         bool   `yaml:"api-token,omitempty"`
+	DefaultNamespace string `yaml:"default-namespace,omitempty"`
 }
 
 // rawConfigFile is used for YAML parsing
 type rawConfigFile struct {
-	ServerURL string `yaml:"server-url"`
-	P12Bundle string `yaml:"p12-bundle"`
-	Cert      string `yaml:"cert"`
-	Key       string `yaml:"key"`
-	Output    string `yaml:"output"`
-	APIToken  bool   `yaml:"api-token"`
+	ServerURL        string `yaml:"server-url"`
+	P12Bundle        string `yaml:"p12-bundle"`
+	Cert             string `yaml:"cert"`
+	Key              string `yaml:"key"`
+	Output           string `yaml:"output"`
+	APIToken         bool   `yaml:"api-token"`
+	DefaultNamespace string `yaml:"default-namespace"`
 }
 
 // parseConfigFile parses a config file
@@ -124,12 +127,13 @@ func parseConfigFile(data []byte) (*ConfigFile, error) {
 	}
 
 	cfg := &ConfigFile{
-		ServerURL: raw.ServerURL,
-		P12Bundle: raw.P12Bundle,
-		Cert:      raw.Cert,
-		Key:       raw.Key,
-		Output:    raw.Output,
-		APIToken:  raw.APIToken,
+		ServerURL:        raw.ServerURL,
+		P12Bundle:        raw.P12Bundle,
+		Cert:             raw.Cert,
+		Key:              raw.Key,
+		Output:           raw.Output,
+		APIToken:         raw.APIToken,
+		DefaultNamespace: raw.DefaultNamespace,
 	}
 
 	return cfg, nil
@@ -281,6 +285,9 @@ func runConfigureShow(cmd *cobra.Command, args []string) error {
 	if config.APIToken {
 		displayConfig["api_token"] = "enabled (token from F5XC_API_TOKEN)"
 	}
+	if config.DefaultNamespace != "" {
+		displayConfig["default_namespace"] = config.DefaultNamespace
+	}
 
 	return output.Print(displayConfig, GetOutputFormat())
 }
@@ -323,6 +330,8 @@ func runConfigureSet(cmd *cobra.Command, args []string) error {
 		} else {
 			config.APIToken = false
 		}
+	case "default-namespace":
+		config.DefaultNamespace = value
 	default:
 		return fmt.Errorf("unknown configuration key: %s", key)
 	}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -209,6 +209,13 @@ func runLogin(cmd *cobra.Command, args []string) error {
 	output.PrintInfo(fmt.Sprintf("Successfully logged in to %s", tenant))
 	output.PrintInfo(fmt.Sprintf("Configuration saved to %s", configPath))
 
+	// Warm the namespace completion cache in background for faster first completion
+	go func() {
+		warmCtx, warmCancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer warmCancel()
+		_, _ = client.ListNamespaces(warmCtx)
+	}()
+
 	return nil
 }
 

--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -1,0 +1,189 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/robinmordasiewicz/xcsh/pkg/output"
+)
+
+var namespaceCmd = &cobra.Command{
+	Use:   "namespace [name]",
+	Short: "Show or set the default namespace",
+	Long: `Show or set the default namespace for CRUD operations.
+
+If no namespace is provided, displays the current default.
+If a namespace is provided, sets it as the new default.
+
+Priority order:
+  1. F5XC_DEFAULT_NAMESPACE environment variable
+  2. Config file default-namespace setting
+  3. Fallback to "default"`,
+	Args: cobra.MaximumNArgs(1),
+	Example: `  # Show current default namespace
+  xcsh namespace
+
+  # Set default namespace to 'shared'
+  xcsh namespace shared
+
+  # Use environment variable (highest priority)
+  export F5XC_DEFAULT_NAMESPACE=production
+  xcsh namespace`,
+	RunE:              runNamespace,
+	ValidArgsFunction: completeNamespaceArg,
+}
+
+func init() {
+	rootCmd.AddCommand(namespaceCmd)
+}
+
+func runNamespace(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		// Show current default namespace
+		ns := GetDefaultNamespace()
+		source := getNamespaceSource()
+		fmt.Printf("Default namespace: %s\n", ns)
+		fmt.Printf("Source: %s\n", source)
+
+		// Validate and warn if namespace doesn't exist
+		if ns != "default" && !NamespaceExists(ns) {
+			output.PrintWarning(fmt.Sprintf("Namespace '%s' does not exist in tenant", ns))
+		}
+		return nil
+	}
+
+	// Set new default namespace
+	newNamespace := args[0]
+
+	// Validate namespace exists before setting
+	if !NamespaceExists(newNamespace) {
+		return fmt.Errorf("namespace '%s' does not exist", newNamespace)
+	}
+
+	if err := setDefaultNamespace(newNamespace); err != nil {
+		return err
+	}
+
+	// Clear cache so next GetValidatedDefaultNamespace() picks up the change
+	ClearNamespaceCache()
+
+	output.PrintInfo(fmt.Sprintf("Default namespace set to: %s", newNamespace))
+	return nil
+}
+
+// getNamespaceSource returns the source of the current default namespace
+func getNamespaceSource() string {
+	if ns := os.Getenv("F5XC_DEFAULT_NAMESPACE"); ns != "" {
+		return "environment variable (F5XC_DEFAULT_NAMESPACE)"
+	}
+
+	configPath := getConfigPath()
+	if data, err := os.ReadFile(configPath); err == nil {
+		if config, err := parseConfigFile(data); err == nil {
+			if config.DefaultNamespace != "" {
+				return fmt.Sprintf("config file (%s)", configPath)
+			}
+		}
+	}
+
+	return "default fallback"
+}
+
+// setDefaultNamespace saves the namespace to the config file
+func setDefaultNamespace(namespace string) error {
+	configPath := getConfigPath()
+
+	// Load existing config or create new one
+	config := &ConfigFile{}
+	if data, err := os.ReadFile(configPath); err == nil {
+		if parsed, err := parseConfigFile(data); err == nil {
+			config = parsed
+		}
+	}
+
+	// Update namespace
+	config.DefaultNamespace = namespace
+
+	// Save configuration
+	return saveConfig(config, configPath)
+}
+
+// validatedNamespaceCache stores the result of namespace validation
+// to avoid repeated API calls and duplicate warnings
+var validatedNamespaceCache string
+
+// NamespaceExists checks if a namespace exists in the tenant
+func NamespaceExists(namespace string) bool {
+	client := GetClient()
+	if client == nil {
+		// Can't validate without a client, assume it exists
+		return true
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	path := fmt.Sprintf("/api/web/namespaces/%s", namespace)
+	resp, err := client.Get(ctx, path, nil)
+	if err != nil {
+		// Network error, assume namespace exists
+		return true
+	}
+
+	return resp.StatusCode == 200
+}
+
+// GetValidatedDefaultNamespace returns the default namespace, validating it exists
+// If the configured namespace doesn't exist, falls back to "default" and warns
+// Results are cached to avoid repeated API calls and duplicate warnings
+func GetValidatedDefaultNamespace() string {
+	// Return cached result if available
+	if validatedNamespaceCache != "" {
+		return validatedNamespaceCache
+	}
+
+	ns := GetDefaultNamespace()
+
+	// Skip validation if we don't have a client
+	client := GetClient()
+	if client == nil {
+		return ns
+	}
+
+	// "default" namespace always exists, no need to validate
+	if ns == "default" {
+		validatedNamespaceCache = ns
+		return ns
+	}
+
+	// Validate the namespace exists
+	if !NamespaceExists(ns) {
+		source := getNamespaceSource()
+		output.PrintWarning(fmt.Sprintf("Namespace '%s' (from %s) does not exist, using 'default'", ns, source))
+		validatedNamespaceCache = "default"
+		return "default"
+	}
+
+	validatedNamespaceCache = ns
+	return ns
+}
+
+// ClearNamespaceCache clears the validated namespace cache
+// Used when namespace is changed via the namespace command
+func ClearNamespaceCache() {
+	validatedNamespaceCache = ""
+}
+
+// completeNamespaceArg provides shell completion for the namespace command argument
+func completeNamespaceArg(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	// Only complete first argument (namespace name)
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	// Reuse existing namespace completion logic
+	return completeNamespace(cmd, args, toComplete)
+}

--- a/cmd/repl.go
+++ b/cmd/repl.go
@@ -41,14 +41,14 @@ func StartREPL() error {
 	// This ensures viper has loaded config file and environment variables
 	initConfig()
 
-	// Display welcome banner
-	printWelcomeBanner()
-
-	// Initialize session
+	// Initialize session first (this sets up apiClient)
 	session, err := initREPLSession()
 	if err != nil {
 		return fmt.Errorf("failed to initialize REPL: %w", err)
 	}
+
+	// Display welcome banner after session init so we have apiClient for user info
+	printWelcomeBanner()
 
 	// Create prompt
 	p := prompt.New(
@@ -62,10 +62,6 @@ func StartREPL() error {
 		prompt.OptionSelectedSuggestionBGColor(prompt.LightGray),
 		prompt.OptionSuggestionBGColor(prompt.DarkGray),
 		prompt.OptionMaxSuggestion(10),
-		prompt.OptionAddKeyBind(prompt.KeyBind{
-			Key: prompt.ControlD,
-			Fn:  func(*prompt.Buffer) { handleExit(session) },
-		}),
 		prompt.OptionAddKeyBind(prompt.KeyBind{
 			Key: prompt.ControlC,
 			Fn:  func(*prompt.Buffer) { handleCtrlC(session) },

--- a/cmd/repl_banner.go
+++ b/cmd/repl_banner.go
@@ -1,20 +1,71 @@
 package cmd
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
+	"time"
 
 	"github.com/mattn/go-runewidth"
 	"github.com/robinmordasiewicz/xcsh/pkg/branding"
 	"github.com/robinmordasiewicz/xcsh/pkg/client"
 )
 
+// Padding constants for banner layout
+const (
+	logoPadLeft   = 2 // Left padding for logo column
+	logoPadRight  = 2 // Right padding for logo column
+	logoPadTop    = 1 // Empty rows above logo
+	logoPadBottom = 1 // Empty rows below logo
+	textPadLeft   = 2 // Left padding for text column
+	textPadRight  = 2 // Right padding for text column
+)
+
 // renderWelcomeBanner creates the modern CLI welcome banner with F5 logo in a dark red frame
-// Vertical layout: logo centered on top, info text below
+// Two-column layout: logo on left, help text on right, connection info in bottom row
 func renderWelcomeBanner() string {
 	var sb strings.Builder
-	const frameWidth = 80
-	const innerWidth = frameWidth - 2 // Account for left and right borders
+
+	// Get logo lines first to calculate widths
+	logoLines := strings.Split(branding.F5Logo, "\n")
+	logoHeight := len(logoLines)
+
+	// Define text content (3 lines)
+	textLines := []string{
+		"Type 'help' for documentation.",
+		"Run 'namespace' to set namespace.",
+		"Press Ctrl+C twice to quit.",
+	}
+
+	// Calculate logo content width based on widest logo line
+	logoContentWidth := 0
+	for _, line := range logoLines {
+		if w := runeWidth(line); w > logoContentWidth {
+			logoContentWidth = w
+		}
+	}
+
+	// Calculate text content width based on longest text line
+	textContentWidth := 0
+	for _, line := range textLines {
+		if w := runeWidth(line); w > textContentWidth {
+			textContentWidth = w
+		}
+	}
+
+	// Calculate column widths including padding
+	logoColWidth := logoPadLeft + logoContentWidth + logoPadRight
+	textColWidth := textPadLeft + textContentWidth + textPadRight
+
+	// Calculate frame dimensions based on content
+	// innerWidth = logoColWidth + divider(1) + textColWidth
+	innerWidth := logoColWidth + 1 + textColWidth
+	frameWidth := innerWidth + 2 // Add 2 for left and right borders
+
+	// Total content rows including padding
+	totalRows := logoPadTop + logoHeight + logoPadBottom
 
 	// Add leading newline for visual separation
 	sb.WriteString("\n")
@@ -29,50 +80,77 @@ func renderWelcomeBanner() string {
 	sb.WriteString(branding.ColorBoldWhite + title + branding.ColorReset)
 	sb.WriteString(branding.ColorDarkRed + strings.Repeat("─", dashesAfterTitle) + "╮" + branding.ColorReset + "\n")
 
-	// Get logo lines
-	logoLines := strings.Split(branding.F5Logo, "\n")
+	// Calculate vertical centering for text within total height
+	textStartRow := (totalRows - len(textLines)) / 2
 
-	// Render logo lines using embedded spacing from branding.go
-	for _, line := range logoLines {
-		coloredLine := colorizeLogoLine(line)
-		lineWidth := runeWidth(line)
+	// Two-column rows: logo on left (with padding), text on right (with padding)
+	for i := 0; i < totalRows; i++ {
+		// Left border (dark red)
+		sb.WriteString(branding.ColorDarkRed + "│" + branding.ColorReset)
 
-		// Use logo's embedded spacing, only right-pad to fill frame
-		rightPad := innerWidth - lineWidth
-		if rightPad < 0 {
-			rightPad = 0
+		// Logo column: leftPad + content/empty + rightPad
+		sb.WriteString(strings.Repeat(" ", logoPadLeft))
+
+		// Determine if this row has logo content
+		logoRowIdx := i - logoPadTop
+		if logoRowIdx >= 0 && logoRowIdx < logoHeight {
+			logoLine := logoLines[logoRowIdx]
+			coloredLogo := colorizeLogoLine(logoLine)
+			logoLineWidth := runeWidth(logoLine)
+			logoPad := logoContentWidth - logoLineWidth
+			if logoPad < 0 {
+				logoPad = 0
+			}
+			sb.WriteString(coloredLogo)
+			sb.WriteString(strings.Repeat(" ", logoPad))
+		} else {
+			// Empty row (top or bottom padding)
+			sb.WriteString(strings.Repeat(" ", logoContentWidth))
 		}
 
-		sb.WriteString(branding.ColorDarkRed + "│" + branding.ColorReset)
-		sb.WriteString(coloredLine)
-		sb.WriteString(strings.Repeat(" ", rightPad))
+		sb.WriteString(strings.Repeat(" ", logoPadRight))
+
+		// Inner divider (red, not bold)
+		sb.WriteString(branding.ColorRed + "│" + branding.ColorReset)
+
+		// Text column: leftPad + content/empty + rightPad
+		sb.WriteString(strings.Repeat(" ", textPadLeft))
+
+		// Determine if this row has text content
+		textLineIdx := i - textStartRow
+		if textLineIdx >= 0 && textLineIdx < len(textLines) {
+			text := textLines[textLineIdx]
+			textLineWidth := runeWidth(text)
+			textPad := textContentWidth - textLineWidth
+			if textPad < 0 {
+				textPad = 0
+			}
+			sb.WriteString(branding.ColorBoldWhite + text + branding.ColorReset)
+			sb.WriteString(strings.Repeat(" ", textPad))
+		} else {
+			sb.WriteString(strings.Repeat(" ", textContentWidth))
+		}
+
+		sb.WriteString(strings.Repeat(" ", textPadRight))
+
+		// Right border (dark red)
 		sb.WriteString(branding.ColorDarkRed + "│" + branding.ColorReset + "\n")
 	}
 
-	// Add separator line
+	// Full-width separator before connection info
 	sb.WriteString(branding.ColorDarkRed + "├" + strings.Repeat("─", innerWidth) + "┤" + branding.ColorReset + "\n")
 
-	// Info content below logo
-	infoLines := []string{
-		"Type 'help' for commands. Press Ctrl+C twice or Ctrl+D to quit.",
-		buildConnectionInfo(),
-	}
-
-	for _, line := range infoLines {
-		lineWidth := runeWidth(line)
-		// Center info text
-		leftPad := (innerWidth - lineWidth) / 2
-		rightPad := innerWidth - lineWidth - leftPad
-		if leftPad < 0 {
-			leftPad = 0
-		}
+	// Connection info rows (full width, left-aligned with padding)
+	connLines := buildConnectionInfo()
+	for _, connLine := range connLines {
+		connLineWidth := runeWidth(connLine)
+		rightPad := innerWidth - connLineWidth - 2 // 2 for left padding
 		if rightPad < 0 {
 			rightPad = 0
 		}
-
 		sb.WriteString(branding.ColorDarkRed + "│" + branding.ColorReset)
-		sb.WriteString(strings.Repeat(" ", leftPad))
-		sb.WriteString(branding.ColorBoldWhite + line + branding.ColorReset)
+		sb.WriteString("  ") // Left padding
+		sb.WriteString(branding.ColorBoldWhite + connLine + branding.ColorReset)
 		sb.WriteString(strings.Repeat(" ", rightPad))
 		sb.WriteString(branding.ColorDarkRed + "│" + branding.ColorReset + "\n")
 	}
@@ -141,27 +219,78 @@ func colorizeLogoLine(line string) string {
 	return result.String()
 }
 
-// buildConnectionInfo returns tenant and API info string
-func buildConnectionInfo() string {
+// getUserInfo calls the whoami endpoint to get the logged-in user's name
+func getUserInfo() string {
+	if apiClient == nil {
+		return ""
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := apiClient.Get(ctx, "/api/web/custom/namespaces/system/whoami", nil)
+	if err != nil || resp.StatusCode >= 400 {
+		return ""
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(resp.Body, &result); err != nil {
+		return ""
+	}
+
+	// Extract user name/email from response
+	if name, ok := result["name"].(string); ok {
+		return name
+	}
+	return ""
+}
+
+// hasAuthConfig checks if any authentication method is configured
+func hasAuthConfig() bool {
+	// Check for API token in environment
+	if os.Getenv("F5XC_API_TOKEN") != "" {
+		return true
+	}
+	// Check for certificate paths
+	if cert != "" || p12Bundle != "" {
+		return true
+	}
+	// Check if apiClient was successfully initialized
+	return apiClient != nil
+}
+
+// buildConnectionInfo returns connection detail lines for the banner
+func buildConnectionInfo() []string {
+	// No API URL configured
 	if serverURL == "" {
-		return "Not connected · Set F5XC_API_URL to connect"
+		return []string{
+			"Not connected · Set F5XC_API_URL to connect",
+			fmt.Sprintf("• Namespace: %s", GetDefaultNamespace()),
+		}
+	}
+
+	// API URL set but no authentication configured
+	if !hasAuthConfig() {
+		return []string{
+			"To authenticate type: /login",
+			fmt.Sprintf("• Namespace: %s", GetDefaultNamespace()),
+		}
 	}
 
 	tenant := client.ExtractTenant(serverURL)
-	// Extract domain from URL for display
-	domain := extractDomain(serverURL)
+	username := getUserInfo()
 
-	return fmt.Sprintf("Tenant: %s · API: %s", tenant, domain)
-}
+	lines := []string{
+		fmt.Sprintf("• Tenant: %s", tenant),
+	}
 
-// extractDomain extracts the domain from a URL for compact display
-func extractDomain(url string) string {
-	// Remove protocol
-	url = strings.TrimPrefix(url, "https://")
-	url = strings.TrimPrefix(url, "http://")
-	// Remove trailing slashes
-	url = strings.TrimSuffix(url, "/")
-	return url
+	if username != "" {
+		lines = append(lines, fmt.Sprintf("• User: %s", username))
+	}
+
+	// Use validated namespace (already validated during session init)
+	lines = append(lines, fmt.Sprintf("• Namespace: %s", GetValidatedDefaultNamespace()))
+
+	return lines
 }
 
 // runeWidth returns the display width of a string in terminal columns

--- a/cmd/repl_prompt.go
+++ b/cmd/repl_prompt.go
@@ -5,44 +5,17 @@ import (
 )
 
 // buildPlainPrompt constructs the prompt string
-// Format: tenant:domain/action@namespace>
+// Format: <xc.domain.action>
 func buildPlainPrompt(session *REPLSession) string {
-	var parts []string
-
-	tenant := session.GetTenant()
-	if tenant != "" && tenant != "unknown" && tenant != "local" {
-		parts = append(parts, tenant)
-	}
+	parts := []string{"xc"}
 
 	ctx := session.GetContextPath()
 	if ctx.Domain != "" {
-		contextStr := ctx.Domain
+		parts = append(parts, ctx.Domain)
 		if ctx.Action != "" {
-			contextStr += "/" + ctx.Action
-		}
-		parts = append(parts, contextStr)
-	}
-
-	ns := session.GetNamespace()
-	if ns != "" {
-		parts = append(parts, "@"+ns)
-	}
-
-	if len(parts) == 0 {
-		return "xcsh> "
-	}
-
-	// Join parts with colons, but namespace uses @ prefix
-	prompt := ""
-	for i, part := range parts {
-		if i == 0 {
-			prompt = part
-		} else if strings.HasPrefix(part, "@") {
-			prompt += part
-		} else {
-			prompt += ":" + part
+			parts = append(parts, ctx.Action)
 		}
 	}
 
-	return prompt + "> "
+	return "<" + strings.Join(parts, ".") + "> "
 }

--- a/cmd/repl_session.go
+++ b/cmd/repl_session.go
@@ -20,6 +20,7 @@ type REPLSession struct {
 	// Contextual navigation state
 	contextPath *ContextPath      // Current navigation context
 	tenant      string            // Extracted tenant name from API URL
+	username    string            // Logged-in user's name/email
 	validator   *ContextValidator // Domain/action validator
 
 	// Exit handling
@@ -29,7 +30,7 @@ type REPLSession struct {
 // initREPLSession creates a new REPL session with initialized state
 func initREPLSession() (*REPLSession, error) {
 	session := &REPLSession{
-		namespace:   "",
+		namespace:   GetValidatedDefaultNamespace(),
 		contextPath: &ContextPath{},
 	}
 
@@ -85,6 +86,8 @@ func initREPLSession() (*REPLSession, error) {
 		} else {
 			session.client = apiClient
 		}
+		// Fetch username for prompt display
+		session.username = getUserInfo()
 	} else {
 		fmt.Fprintln(os.Stderr, "Warning: No API URL configured.")
 		fmt.Fprintln(os.Stderr, "Run 'configure' or set F5XC_API_URL environment variable.")
@@ -131,6 +134,11 @@ func (s *REPLSession) GetContextPath() *ContextPath {
 // GetTenant returns the current tenant name
 func (s *REPLSession) GetTenant() string {
 	return s.tenant
+}
+
+// GetUsername returns the logged-in user's name/email
+func (s *REPLSession) GetUsername() string {
+	return s.username
 }
 
 // GetValidator returns the context validator

--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -75,8 +75,7 @@ func buildListCommand(rt *types.ResourceType) *cobra.Command {
 	}
 
 	if rt.SupportsNamespace {
-		cmd.Flags().StringVarP(&flags.namespace, "namespace", "n", "", "Namespace (required)")
-		_ = cmd.MarkFlagRequired("namespace")
+		cmd.Flags().StringVarP(&flags.namespace, "namespace", "n", GetDefaultNamespace(), "Namespace")
 	}
 
 	return cmd
@@ -104,8 +103,7 @@ func buildShowCommand(rt *types.ResourceType) *cobra.Command {
 	}
 
 	if rt.SupportsNamespace {
-		cmd.Flags().StringVarP(&flags.namespace, "namespace", "n", "", "Namespace (required)")
-		_ = cmd.MarkFlagRequired("namespace")
+		cmd.Flags().StringVarP(&flags.namespace, "namespace", "n", GetDefaultNamespace(), "Namespace")
 	}
 
 	return cmd
@@ -134,7 +132,7 @@ func buildCreateCommand(rt *types.ResourceType) *cobra.Command {
 	_ = cmd.MarkFlagRequired("file")
 
 	if rt.SupportsNamespace {
-		cmd.Flags().StringVarP(&flags.namespace, "namespace", "n", "", "Namespace (overrides file)")
+		cmd.Flags().StringVarP(&flags.namespace, "namespace", "n", GetDefaultNamespace(), "Namespace (overrides file)")
 	}
 
 	return cmd
@@ -164,7 +162,7 @@ func buildUpdateCommand(rt *types.ResourceType) *cobra.Command {
 	_ = cmd.MarkFlagRequired("file")
 
 	if rt.SupportsNamespace {
-		cmd.Flags().StringVarP(&flags.namespace, "namespace", "n", "", "Namespace (overrides file)")
+		cmd.Flags().StringVarP(&flags.namespace, "namespace", "n", GetDefaultNamespace(), "Namespace (overrides file)")
 	}
 
 	return cmd
@@ -192,8 +190,7 @@ func buildDeleteCommand(rt *types.ResourceType) *cobra.Command {
 	}
 
 	if rt.SupportsNamespace {
-		cmd.Flags().StringVarP(&flags.namespace, "namespace", "n", "", "Namespace (required)")
-		_ = cmd.MarkFlagRequired("namespace")
+		cmd.Flags().StringVarP(&flags.namespace, "namespace", "n", GetDefaultNamespace(), "Namespace")
 	}
 
 	cmd.Flags().BoolVarP(&flags.yes, "yes", "y", false, "Skip confirmation prompt")
@@ -221,8 +218,7 @@ func buildStatusCommand(rt *types.ResourceType) *cobra.Command {
 	}
 
 	if rt.SupportsNamespace {
-		cmd.Flags().StringVarP(&flags.namespace, "namespace", "n", "", "Namespace (required)")
-		_ = cmd.MarkFlagRequired("namespace")
+		cmd.Flags().StringVarP(&flags.namespace, "namespace", "n", GetDefaultNamespace(), "Namespace")
 	}
 
 	return cmd

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -180,6 +180,8 @@ func init() {
 	_ = viper.BindEnv("p12-bundle", "F5XC_P12_FILE")
 	_ = viper.BindEnv("output-format", "F5XC_OUTPUT")
 	_ = viper.BindEnv("server-url", "F5XC_API_URL")
+	_ = viper.BindEnv("default-namespace", "F5XC_DEFAULT_NAMESPACE")
+	viper.SetDefault("default-namespace", "default")
 
 	// Register --spec flag for machine-readable CLI specification
 	RegisterSpecFlag(rootCmd)
@@ -360,6 +362,23 @@ func expandPath(path string) string {
 // GetClient returns the initialized API client
 func GetClient() *client.Client {
 	return apiClient
+}
+
+// GetDefaultNamespace returns the default namespace with priority:
+// 1. F5XC_DEFAULT_NAMESPACE environment variable
+// 2. Config file default-namespace setting
+// 3. Fallback to "default"
+func GetDefaultNamespace() string {
+	// Check environment variable first (highest priority)
+	if ns := os.Getenv("F5XC_DEFAULT_NAMESPACE"); ns != "" {
+		return ns
+	}
+	// Check viper (config file)
+	if ns := viper.GetString("default-namespace"); ns != "" {
+		return ns
+	}
+	// Fallback to "default"
+	return "default"
 }
 
 // GetOutputFormat returns the current output format (defaults to table for list operations)


### PR DESCRIPTION
## Summary

Add kubectl-style namespace management to xcsh REPL with persistent configuration, plus slash-prefixed escape syntax for cross-context command access.

## Changes

### Namespace Management
- Add `namespace` command (kubens-style) for viewing/setting default namespace
- Add `F5XC_DEFAULT_NAMESPACE` environment variable support
- Add persistence to config file (`~/.f5xcconfig`) via `default-namespace` key
- Add namespace validation - checks if namespace exists before setting
- Add namespace completion with `ValidArgsFunction`
- Fix REPL `ns` builtin to persist namespace changes to config file

### Slash Escape Syntax
- Add `/command` prefix to access fully-qualified command paths from any context
- Example: While in `<xc.virtual.list>` context, type `/http_loadbalancer list` to run that command
- Tab completion works with slash prefix to show root-level commands

### Prompt Updates
- Simplified prompt format to `<xc.domain.action>`
- Added username field to session for future use

### Other Improvements
- Improved `clear` command to match bash/zsh behavior (clears scrollback buffer)
- Updated banner layout with two-column design
- Cache warming for namespace completion on login

## Files Changed
- `cmd/namespace.go` (new) - Standalone namespace command
- `cmd/repl_completer.go` - Slash escape completion support
- `cmd/repl_executor.go` - Slash escape execution, namespace persistence
- `cmd/repl_prompt.go` - Simplified prompt format
- `cmd/repl_session.go` - Username field, validated namespace init
- `cmd/configure.go` - Default namespace config support
- `cmd/login.go` - Namespace cache warming
- `cmd/repl.go` - Session init order fix
- `cmd/repl_banner.go` - Banner layout improvements
- `cmd/resource.go`, `cmd/root.go` - Minor updates

## Test Plan
- [x] Build succeeds with `go build`
- [x] All pre-commit hooks pass
- [x] Namespace command shows/sets default namespace
- [x] Slash prefix bypasses current context for commands
- [x] Clear command clears terminal including scrollback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #306