### PR TITLE
feat: use F5 Brand Red for REPL banner frame

### DIFF
--- a/cmd/repl_banner.go
+++ b/cmd/repl_banner.go
@@ -76,9 +76,9 @@ func renderWelcomeBanner() string {
 	dashesAfterTitle := frameWidth - 5 - titleLen
 
 	// Top border: ╭─── Title ───...─╮ with title in bold white
-	sb.WriteString(branding.ColorDarkRed + "╭───" + branding.ColorReset)
+	sb.WriteString(branding.ColorRed + "╭───" + branding.ColorReset)
 	sb.WriteString(branding.ColorBoldWhite + title + branding.ColorReset)
-	sb.WriteString(branding.ColorDarkRed + strings.Repeat("─", dashesAfterTitle) + "╮" + branding.ColorReset + "\n")
+	sb.WriteString(branding.ColorRed + strings.Repeat("─", dashesAfterTitle) + "╮" + branding.ColorReset + "\n")
 
 	// Calculate vertical centering for text within total height
 	textStartRow := (totalRows - len(textLines)) / 2
@@ -86,7 +86,7 @@ func renderWelcomeBanner() string {
 	// Two-column rows: logo on left (with padding), text on right (with padding)
 	for i := 0; i < totalRows; i++ {
 		// Left border (dark red)
-		sb.WriteString(branding.ColorDarkRed + "│" + branding.ColorReset)
+		sb.WriteString(branding.ColorRed + "│" + branding.ColorReset)
 
 		// Logo column: leftPad + content/empty + rightPad
 		sb.WriteString(strings.Repeat(" ", logoPadLeft))
@@ -134,11 +134,11 @@ func renderWelcomeBanner() string {
 		sb.WriteString(strings.Repeat(" ", textPadRight))
 
 		// Right border (dark red)
-		sb.WriteString(branding.ColorDarkRed + "│" + branding.ColorReset + "\n")
+		sb.WriteString(branding.ColorRed + "│" + branding.ColorReset + "\n")
 	}
 
 	// Full-width separator before connection info
-	sb.WriteString(branding.ColorDarkRed + "├" + strings.Repeat("─", innerWidth) + "┤" + branding.ColorReset + "\n")
+	sb.WriteString(branding.ColorRed + "├" + strings.Repeat("─", innerWidth) + "┤" + branding.ColorReset + "\n")
 
 	// Connection info rows (full width, left-aligned with padding)
 	connLines := buildConnectionInfo()
@@ -148,16 +148,16 @@ func renderWelcomeBanner() string {
 		if rightPad < 0 {
 			rightPad = 0
 		}
-		sb.WriteString(branding.ColorDarkRed + "│" + branding.ColorReset)
+		sb.WriteString(branding.ColorRed + "│" + branding.ColorReset)
 		sb.WriteString("  ") // Left padding
 		sb.WriteString(branding.ColorBoldWhite + connLine + branding.ColorReset)
 		sb.WriteString(strings.Repeat(" ", rightPad))
-		sb.WriteString(branding.ColorDarkRed + "│" + branding.ColorReset + "\n")
+		sb.WriteString(branding.ColorRed + "│" + branding.ColorReset + "\n")
 	}
 
 	// Bottom border: ╰───...───╯
 	bottomBorder := "╰" + strings.Repeat("─", innerWidth) + "╯"
-	sb.WriteString(branding.ColorDarkRed + bottomBorder + branding.ColorReset + "\n")
+	sb.WriteString(branding.ColorRed + bottomBorder + branding.ColorReset + "\n")
 
 	return sb.String()
 }

--- a/pkg/branding/branding.go
+++ b/pkg/branding/branding.go
@@ -34,7 +34,6 @@ const (
 
 	// ANSI color codes for terminal output
 	ColorRed       = "\033[38;2;228;0;43m" // F5 Brand Red (#E4002B)
-	ColorDarkRed   = "\033[38;2;139;0;0m"  // Dark Red (#8B0000) for frame
 	ColorBoldWhite = "\033[1;97m"          // Bold bright white
 	ColorReset     = "\033[0m"             // Reset to default
 


### PR DESCRIPTION
## Summary

Update the REPL banner frame color from dark red (#8B0000) to F5 Brand Red (#E4002B) for consistent branding.

### Changes
- Replace `ColorDarkRed` with `ColorRed` in frame border rendering (8 occurrences in `cmd/repl_banner.go`)
- Remove unused `ColorDarkRed` constant from `pkg/branding/branding.go`

### Before/After
- **Before**: Frame borders used dark red (#8B0000), logo used brand red (#E4002B)
- **After**: Both frame and logo use official F5 Brand Red (#E4002B)

## Test Plan
- [x] Build succeeds with `go build`
- [x] All pre-commit hooks pass
- [x] Visual verification of consistent branding

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #310