### PR TITLE
fix: use double quotes for VERSION expansion in checksums step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -343,7 +343,7 @@ jobs:
 
           # Download all release assets with retry
           echo "Downloading all release assets..."
-          retry_with_backoff sh -c 'GH_TOKEN="$GITHUB_TOKEN" gh release download "v${VERSION}" --repo "${{ github.repository }}"'
+          retry_with_backoff sh -c "GH_TOKEN=\"\$GITHUB_TOKEN\" gh release download \"v${VERSION}\" --repo \"${{ github.repository }}\""
 
           # Generate new checksums.txt
           echo "Computing SHA256 checksums..."


### PR DESCRIPTION
## Summary

Fix the shell quoting bug that caused checksums.txt to not be regenerated after macOS signing, resulting in Homebrew SHA-256 mismatch errors.

### Root Cause
Line 346 used single quotes:
```bash
retry_with_backoff sh -c 'GH_TOKEN="$GITHUB_TOKEN" gh release download "v${VERSION}" ...'
```

With single quotes, `${VERSION}` is passed literally to `sh -c`. Since VERSION is not exported, the subshell can't access it, causing `"release not found"` errors.

### Fix
Use double quotes with proper escaping (matching the pattern on line 398):
```bash
retry_with_backoff sh -c "GH_TOKEN=\"\$GITHUB_TOKEN\" gh release download \"v${VERSION}\" ..."
```

### Impact
This bug caused:
- checksums.txt to contain pre-signing hashes instead of post-signing hashes
- Homebrew cask to be updated with incorrect checksums
- Users to get SHA-256 mismatch errors when running `brew upgrade`

## Test Plan
- [x] Pre-commit hooks pass (YAML validation, GitHub workflow validation)
- [ ] Next release should complete without "release not found" errors
- [ ] Homebrew install should succeed without checksum mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #312