### PR TITLE
feat!: major version 6.0.0 - TypeScript rewrite

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,14 +72,25 @@ jobs:
           LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
           echo "Latest tag: $LATEST_TAG"
 
-          # Extract version numbers
-          VERSION=${LATEST_TAG#v}
-          MAJOR=$(echo $VERSION | cut -d. -f1)
-          MINOR=$(echo $VERSION | cut -d. -f2)
+          # Extract version numbers from tag
+          TAG_VERSION=${LATEST_TAG#v}
+          TAG_MAJOR=$(echo $TAG_VERSION | cut -d. -f1)
+          TAG_MINOR=$(echo $TAG_VERSION | cut -d. -f2)
 
-          # Increment minor version
-          NEW_MINOR=$((MINOR + 1))
-          NEW_VERSION="${MAJOR}.${NEW_MINOR}.0"
+          # Read major version from package.json (source of truth for major versions)
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          PKG_MAJOR=$(echo $PKG_VERSION | cut -d. -f1)
+          echo "Package.json version: $PKG_VERSION (major: $PKG_MAJOR)"
+
+          # If package.json major version is higher, use it (major version bump)
+          if [ "$PKG_MAJOR" -gt "$TAG_MAJOR" ]; then
+            echo "Major version bump detected from package.json"
+            NEW_VERSION="${PKG_MAJOR}.0.0"
+          else
+            # Normal minor version increment
+            NEW_MINOR=$((TAG_MINOR + 1))
+            NEW_VERSION="${TAG_MAJOR}.${NEW_MINOR}.0"
+          fi
 
           echo "New version: v$NEW_VERSION"
           echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xcsh",
-  "version": "2.0.0",
+  "version": "6.0.0",
   "description": "F5 Distributed Cloud Shell - Interactive CLI for F5 XC",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Major version bump to v6.0.0 marking the complete TypeScript rewrite of xcsh.

### BREAKING CHANGE

Complete rewrite from Go to TypeScript with Ink framework. This is a major architectural change warranting a major version bump.

### Changes

- **package.json**: Updated version to 6.0.0
- **release.yml**: Enhanced version bump logic to detect major versions
  - Reads major version from package.json as source of truth
  - If `package.json major > latest tag major`, triggers major version release
  - Otherwise continues with normal minor version increment

### v6 Stack
- TypeScript + React (Ink) for interactive CLI
- `@yao-pkg/pkg` for standalone cross-platform binaries
- Modern ESM module architecture
- tsup for bundling

## Test Plan

- [x] All 48 unit tests pass
- [x] TypeScript validation passes
- [x] ESLint passes (warnings only)
- [x] Prettier formatting validated
- [ ] Release workflow will create v6.0.0 tag and release

🤖 Generated with [Claude Code](https://claude.com/claude-code)