### PR TITLE
chore: bump version to 6.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xcsh",
-  "version": "6.0.0",
+  "version": "6.3.0",
   "description": "F5 Distributed Cloud Shell - Interactive CLI for F5 XC",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Bump version to 6.3.0 to trigger release workflow and test Bun binary builds.

## Changes

- Updated package.json version from 6.0.0 to 6.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)