### PR TITLE
fix: build binaries on native platforms instead of cross-compilation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,12 +102,12 @@ jobs:
           git tag -a "v${{ steps.bump.outputs.version }}" -m "Release v${{ steps.bump.outputs.version }}"
           git push origin "v${{ steps.bump.outputs.version }}"
 
-  build:
-    name: Build Binaries
+  # Build binaries on native platforms to avoid cross-compilation issues
+  # Bun cross-compilation does not work reliably (especially for macOS)
+  build-linux:
+    name: Build Linux Binaries
     runs-on: ubuntu-latest
     needs: version
-    outputs:
-      version: ${{ needs.version.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -134,10 +134,114 @@ jobs:
         with:
           bun-version: latest
 
-      - name: Build standalone binaries
-        run: npm run build:binaries
+      - name: Build Linux binaries
+        run: ./scripts/build-binaries.sh --platform linux
 
-      - name: List built binaries
+      - name: Upload Linux binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: binaries-linux
+          path: binaries/
+          retention-days: 1
+
+  build-macos:
+    name: Build macOS Binaries
+    runs-on: macos-latest
+    needs: version
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download enriched API specifications
+        run: ./scripts/download-specs.sh
+
+      - name: Build TypeScript
+        run: XCSH_VERSION=${{ needs.version.outputs.version }} npm run build
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Build macOS binaries
+        run: ./scripts/build-binaries.sh --platform darwin
+
+      - name: Upload macOS binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: binaries-macos
+          path: binaries/
+          retention-days: 1
+
+  build-windows:
+    name: Build Windows Binaries
+    runs-on: windows-latest
+    needs: version
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download enriched API specifications
+        shell: bash
+        run: ./scripts/download-specs.sh
+
+      - name: Build TypeScript
+        run: npm run build
+        env:
+          XCSH_VERSION: ${{ needs.version.outputs.version }}
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Build Windows binaries
+        shell: bash
+        run: ./scripts/build-binaries.sh --platform windows
+
+      - name: Upload Windows binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: binaries-windows
+          path: binaries/
+          retention-days: 1
+
+  create-release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    needs: [version, build-linux, build-macos, build-windows]
+    outputs:
+      version: ${{ needs.version.outputs.version }}
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: binaries
+          merge-multiple: true
+
+      - name: List downloaded binaries
         run: ls -la binaries/
 
       - name: Create release archives
@@ -244,9 +348,6 @@ jobs:
           **Windows (amd64)**
           Download `xcsh_${VERSION}_windows_amd64.zip` and extract to your PATH.
 
-          **Windows (arm64)**
-          Download `xcsh_${VERSION}_windows_arm64.zip` and extract to your PATH.
-
           **npm (requires Node.js)**
           ```bash
           npm install -g xcsh
@@ -265,7 +366,7 @@ jobs:
   sign-macos:
     name: Sign macOS Binaries
     runs-on: macos-latest
-    needs: build
+    needs: create-release
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -327,7 +428,7 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
-          VERSION="${{ needs.build.outputs.version }}"
+          VERSION="${{ needs.create-release.outputs.version }}"
           echo "Signing version: $VERSION"
 
           # Retry function with exponential backoff
@@ -425,7 +526,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          VERSION="${{ needs.build.outputs.version }}"
+          VERSION="${{ needs.create-release.outputs.version }}"
           echo "Regenerating checksums.txt for version $VERSION..."
 
           # Retry function with exponential backoff
@@ -474,7 +575,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
-          VERSION="${{ needs.build.outputs.version }}"
+          VERSION="${{ needs.create-release.outputs.version }}"
 
           echo "Computing SHA256 hashes for all release assets..."
 

--- a/scripts/build-binaries.sh
+++ b/scripts/build-binaries.sh
@@ -2,6 +2,11 @@
 # Build standalone binaries using Bun
 # ink v5+ requires ESM with top-level await, which pkg doesn't support
 # Bun's compile feature handles ESM natively
+#
+# IMPORTANT: Bun cross-compilation does NOT work reliably!
+# macOS binaries must be built on macOS, Linux on Linux, etc.
+# This script builds only for the current platform by default.
+# Use --platform to specify which platforms to build.
 set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -9,9 +14,42 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 DIST_DIR="$PROJECT_ROOT/binaries"
 ENTRY="$PROJECT_ROOT/dist/index.js"
 
+# Parse arguments
+PLATFORMS=""
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --platform)
+      PLATFORMS="$2"
+      shift 2
+      ;;
+    --all)
+      PLATFORMS="all"
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1"
+      echo "Usage: $0 [--platform linux|darwin|windows|all] [--all]"
+      exit 1
+      ;;
+  esac
+done
+
+# Detect current platform if not specified
+if [[ -z "$PLATFORMS" ]]; then
+  case "$(uname -s)" in
+    Linux*) PLATFORMS="linux" ;;
+    Darwin*) PLATFORMS="darwin" ;;
+    MINGW* | MSYS* | CYGWIN*) PLATFORMS="windows" ;;
+    *)
+      echo "Unknown platform: $(uname -s)"
+      exit 1
+      ;;
+  esac
+  echo "Auto-detected platform: $PLATFORMS"
+fi
+
 # Check for Bun
 if ! command -v bun &>/dev/null; then
-  # Try common install locations
   if [[ -x "$HOME/.bun/bin/bun" ]]; then
     BUN="$HOME/.bun/bin/bun"
   else
@@ -34,31 +72,62 @@ fi
 mkdir -p "$DIST_DIR"
 
 echo ""
-echo "Building binaries for all platforms..."
+echo "Building binaries for: $PLATFORMS"
 echo ""
 
-# Build for each target
+# Build for a specific target
 build_target() {
   local target="$1"
   local output="$2"
   echo "Building: $output (target: bun-$target)"
   if $BUN build "$ENTRY" --compile --target "bun-$target" --outfile "$DIST_DIR/$output" 2>&1; then
     echo "  ✓ Built successfully"
+    return 0
   else
-    echo "  ⚠ Failed (may require cross-compilation support)"
+    echo "  ✗ Failed to build"
+    return 1
   fi
 }
 
-# Linux
-build_target "linux-x64" "xcsh-linux-x64"
-build_target "linux-arm64" "xcsh-linux-arm64"
+# Build based on platform selection
+build_linux() {
+  echo "=== Building Linux binaries ==="
+  build_target "linux-x64" "xcsh-linux-x64"
+  build_target "linux-arm64" "xcsh-linux-arm64"
+}
 
-# macOS
-build_target "darwin-x64" "xcsh-macos-x64"
-build_target "darwin-arm64" "xcsh-macos-arm64"
+build_darwin() {
+  echo "=== Building macOS binaries ==="
+  build_target "darwin-x64" "xcsh-macos-x64"
+  build_target "darwin-arm64" "xcsh-macos-arm64"
+}
 
-# Windows
-build_target "windows-x64" "xcsh-win-x64.exe"
+build_windows() {
+  echo "=== Building Windows binaries ==="
+  build_target "windows-x64" "xcsh-win-x64.exe"
+}
+
+# Execute builds
+case "$PLATFORMS" in
+  all)
+    build_linux
+    build_darwin
+    build_windows
+    ;;
+  linux)
+    build_linux
+    ;;
+  darwin)
+    build_darwin
+    ;;
+  windows)
+    build_windows
+    ;;
+  *)
+    echo "Unknown platform: $PLATFORMS"
+    exit 1
+    ;;
+esac
 
 echo ""
 echo "Build complete. Binaries:"


### PR DESCRIPTION
## Summary

Bun cross-compilation does not work reliably - macOS binaries built on Linux fail with "Ran out of executable memory" errors when executed.

## Changes

- **Platform-specific build jobs**: Split the single build job into `build-linux`, `build-macos`, and `build-windows` jobs
- **Native runners**: Each platform builds on its native runner (ubuntu-latest, macos-latest, windows-latest)
- **Artifact sharing**: Use GitHub artifacts to share binaries between build jobs and the release creation job
- **Build script update**: Enhanced `build-binaries.sh` to support `--platform` flag for selective platform builds
- **Release job**: New `create-release` job downloads all artifacts and creates the GitHub release

## Why This Fixes the Issue

The v6.4.0 release built macOS binaries on Linux using Bun's cross-compilation, which produced non-functional binaries. Building on native platforms ensures the binaries work correctly.

## Test Plan

- [x] Build script works locally with `--platform darwin`
- [x] Local macOS arm64 binary runs correctly
- [ ] CI builds all platforms successfully
- [ ] Release workflow produces working binaries
- [ ] macOS binary from release can be downloaded and executed

🤖 Generated with [Claude Code](https://claude.com/claude-code)