### PR TITLE
chore: release v6.4.1 with native platform builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xcsh",
-  "version": "2.0.0",
+  "version": "6.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xcsh",
-      "version": "2.0.0",
+      "version": "6.4.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xcsh",
-  "version": "6.3.0",
+  "version": "6.4.1",
   "description": "F5 Distributed Cloud Shell - Interactive CLI for F5 XC",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Bump version to 6.4.1 for release with native platform binary builds.

This release fixes the broken binaries in v6.4.0 by building on native platforms instead of cross-compiling.