### PR TITLE
fix: add GITHUB_TOKEN for spec downloads in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,8 @@ jobs:
         run: npm ci
 
       - name: Download enriched API specifications
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/download-specs.sh
 
       - name: Build TypeScript
@@ -164,6 +166,8 @@ jobs:
         run: npm ci
 
       - name: Download enriched API specifications
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/download-specs.sh
 
       - name: Build TypeScript
@@ -205,6 +209,8 @@ jobs:
 
       - name: Download enriched API specifications
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/download-specs.sh
 
       - name: Build TypeScript


### PR DESCRIPTION
Fixes macOS build failure caused by GitHub API rate limiting.

The download-specs.sh script requires authentication to avoid API rate limits. This PR adds GITHUB_TOKEN environment variable to all build jobs (Linux, macOS, Windows).

The script already has robust retry logic with exponential backoff (5 retries, 2-60s backoff), but without the token, rate limits could cause timeouts.