### PR TITLE
fix: add checkout step to create-release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,6 +241,11 @@ jobs:
     outputs:
       version: ${{ needs.version.outputs.version }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
gh release create requires a git repository context to work properly. Without a checkout step, the job fails with:

```
fatal: not a git repository (or any of the parent directories): .git
```

This PR adds the missing checkout step to the create-release job.