### PR TITLE
fix: add JIT entitlements for macOS hardened runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -495,7 +495,7 @@ jobs:
             BINARY_PATH="$RUNNER_TEMP/sign_${ARCH}/xcsh"
             echo "Signing $BINARY_PATH..."
 
-            codesign --force --options runtime --sign "$SIGNING_IDENTITY" --timestamp "$BINARY_PATH"
+            codesign --force --options runtime --entitlements scripts/entitlements.plist --sign "$SIGNING_IDENTITY" --timestamp "$BINARY_PATH"
 
             # Verify signature
             codesign --verify --verbose "$BINARY_PATH"

--- a/scripts/entitlements.plist
+++ b/scripts/entitlements.plist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Allow JIT compilation for Bun's JavaScript engine -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <!-- Allow unsigned executable memory for JIT-compiled code -->
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <!-- Disable library validation to allow bundled dependencies -->
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

Fixes the 'Ran out of executable memory' error when running signed macOS binaries.

### Root Cause
Bun-compiled binaries require JIT (Just-In-Time compilation) to run their JavaScript engine. When codesigning with hardened runtime (`--options runtime`), JIT is disabled by default, causing the binary to fail with:
```
Ran out of executable memory while allocating 128 bytes.
```

### Fix
Added `scripts/entitlements.plist` with the following capabilities:
- `com.apple.security.cs.allow-jit` - Allow JIT compilation
- `com.apple.security.cs.allow-unsigned-executable-memory` - Allow unsigned executable memory for JIT-compiled code
- `com.apple.security.cs.disable-library-validation` - Disable library validation for bundled dependencies

Updated the codesign command in release.yml to use `--entitlements scripts/entitlements.plist`.

### Verification
Locally built binaries without hardened runtime work correctly. This fix allows signed binaries to retain JIT capabilities while still having Developer ID signing and notarization.

## Test Plan
- [ ] Release workflow creates properly signed binaries
- [ ] macOS arm64 binary runs without memory errors
- [ ] `xcsh version` returns expected output

🤖 Generated with [Claude Code](https://claude.com/claude-code)