### PR TITLE
feat: move REPL completions below prompt and hide statusbar

### DIFF
--- a/src/repl/App.tsx
+++ b/src/repl/App.tsx
@@ -435,19 +435,6 @@ export function App(): React.ReactElement {
 				))}
 			</Box>
 
-			{/* Suggestions popup */}
-			{completion.isShowing && completion.suggestions.length > 0 && (
-				<Suggestions
-					suggestions={toUISuggestions(completion.suggestions)}
-					selectedIndex={completion.selectedIndex}
-					onSelect={handleSuggestionSelect}
-					onNavigate={handleSuggestionNavigate}
-					onCancel={completion.hide}
-					maxVisible={10}
-					isActive={false} // Let App handle keyboard
-				/>
-			)}
-
 			{/* Input box */}
 			<InputBox
 				prompt={prompt}
@@ -459,8 +446,20 @@ export function App(): React.ReactElement {
 				inputKey={inputKey}
 			/>
 
-			{/* Status bar */}
-			<StatusBar gitInfo={gitInfo} width={width} hint={statusHint} />
+			{/* Suggestions popup OR Status bar - mutually exclusive to conserve space */}
+			{completion.isShowing && completion.suggestions.length > 0 ? (
+				<Suggestions
+					suggestions={toUISuggestions(completion.suggestions)}
+					selectedIndex={completion.selectedIndex}
+					onSelect={handleSuggestionSelect}
+					onNavigate={handleSuggestionNavigate}
+					onCancel={completion.hide}
+					maxVisible={10}
+					isActive={false} // Let App handle keyboard
+				/>
+			) : (
+				<StatusBar gitInfo={gitInfo} width={width} hint={statusHint} />
+			)}
 		</Box>
 	);
 }


### PR DESCRIPTION
## Summary

Refactor the interactive REPL completion display to improve usability:
- Move completions from above the prompt to below the prompt
- Hide the statusbar when completions are active to conserve vertical space

## Changes

- **`src/repl/App.tsx`**: Reorder JSX layout
  - Move `<Suggestions>` component after `<InputBox>` (completions appear below prompt)
  - Make StatusBar and Suggestions mutually exclusive using ternary operator

## New Layout

```
Banner (conditional)
Output area
InputBox                         ← Prompt stays fixed
Suggestions OR StatusBar         ← Mutually exclusive below prompt
```

## Test Plan

- [x] Build succeeds with `npm run build`
- [x] All pre-commit hooks pass
- [ ] Tab triggers completions below prompt
- [ ] StatusBar disappears when completions show
- [ ] StatusBar reappears on Escape or selection
- [ ] Up/Down arrows navigate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #338