### PR TITLE
fix: completion generator produces trailing whitespace

### DIFF
--- a/src/domains/completion/generators.ts
+++ b/src/domains/completion/generators.ts
@@ -222,16 +222,19 @@ export function generateZshCompletion(): string {
 		const { commands, subcommands } = getCustomDomainCommands(domain.name);
 
 		if (commands.length > 0 || subcommands.size > 0) {
-			const cmdDescriptions = commands
-				.map((c) => `'${c}:Command'`)
-				.join(" ");
-			const subDescriptions = Array.from(subcommands.keys())
-				.map((s) => `'${s}:Subcommand group'`)
+			const cmdDescriptions = commands.map((c) => `'${c}:Command'`);
+			const subDescriptions = Array.from(subcommands.keys()).map(
+				(s) => `'${s}:Subcommand group'`,
+			);
+
+			// Combine non-empty descriptions to avoid trailing whitespace
+			const allDescriptions = [...cmdDescriptions, ...subDescriptions]
+				.filter((d) => d.length > 0)
 				.join(" ");
 
 			customDomainCompletions.push(
 				`        (${domain.name})`,
-				`            _values 'command' ${cmdDescriptions} ${subDescriptions}`,
+				`            _values 'command' ${allDescriptions}`,
 				`            ;;`,
 			);
 		}


### PR DESCRIPTION
## Summary

Fix zsh completion generator to produce clean output without trailing whitespace.

## Problem

When `subDescriptions` is empty, the template `${cmdDescriptions} ${subDescriptions}` produces trailing whitespace, causing pre-commit hooks to report "Fixing completions/_xcsh" on every generation cycle.

## Solution

Combine arrays first, filter empty entries, then join with a single space - ensuring no trailing whitespace regardless of which array is empty.

## Files Changed
- `src/domains/completion/generators.ts` - Fix array concatenation

## Test Plan
- [x] Delete generated completion files
- [x] Run `npm run generate` from scratch
- [x] Run `pre-commit run --all-files`
- [x] Verify no files are modified by pre-commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #342