### PR TITLE
feat: add automated npm publishing to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -361,7 +361,12 @@ jobs:
 
           **npm (requires Node.js)**
           ```bash
-          npm install -g xcsh
+          npm install -g @robinmordasiewicz/xcsh
+          ```
+
+          **npx (no installation)**
+          ```bash
+          npx @robinmordasiewicz/xcsh
           ```
           RELEASE_EOF
 
@@ -373,6 +378,41 @@ jobs:
             --title "xcsh v${VERSION}" \
             --notes-file release-notes.md \
             release-archives/*
+
+  publish-npm:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    needs: create-release
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download enriched API specifications
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./scripts/download-specs.sh
+
+      - name: Build
+        run: npm run build
+        env:
+          XCSH_VERSION: ${{ needs.create-release.outputs.version }}
+
+      - name: Set package version
+        run: npm version ${{ needs.create-release.outputs.version }} --no-git-tag-version
+
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   sign-macos:
     name: Sign macOS Binaries

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "xcsh",
+  "name": "@robinmordasiewicz/xcsh",
   "version": "6.4.1",
   "description": "F5 Distributed Cloud Shell - Interactive CLI for F5 XC",
   "type": "module",
@@ -7,6 +7,19 @@
     "xcsh": "./dist/index.js"
   },
   "main": "./dist/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/robinmordasiewicz/xcsh.git"
+  },
+  "homepage": "https://robinmordasiewicz.github.io/xcsh",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "files": [
+    "dist/",
+    "completions/"
+  ],
   "scripts": {
     "build": "tsup",
     "build:binaries": "./scripts/build-binaries.sh",


### PR DESCRIPTION
## Summary

Add automated npm publishing to the GitHub release workflow so users can install xcsh via npm.

### Changes
- Rename package to scoped `@robinmordasiewicz/xcsh` for npm registry
- Add `publishConfig` with public access for scoped package
- Add `files` field to control npm package contents (dist/, completions/)
- Add `repository` and `homepage` fields for npm metadata
- Add `publish-npm` job to release.yml that runs after `create-release`
- Update release notes to show npm and npx installation options

### New Installation Methods
```bash
# npm global install
npm install -g @robinmordasiewicz/xcsh

# npx (no installation)
npx @robinmordasiewicz/xcsh
```

### Release Flow
```
create-release → publish-npm (parallel with sign-macos)
```

## Test Plan
- [x] Pre-commit hooks pass
- [x] GitHub workflow validation passes
- [x] NPM_TOKEN secret already configured
- [ ] Merge triggers release pipeline
- [ ] npm publish job completes successfully
- [ ] Package available on npmjs.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)