### PR TITLE
feat: add ink REPL infrastructure components

### DIFF
--- a/src/config/envvars.ts
+++ b/src/config/envvars.ts
@@ -1,0 +1,85 @@
+/**
+ * Environment Variable Registry for xcsh.
+ * Centralized registry matching the Go version's professional structure.
+ * Used for dynamic help generation with column alignment and flag notation.
+ */
+
+import { ENV_PREFIX, CONFIG_FILE_NAME, DOCS_URL } from "../branding/index.js";
+
+export interface EnvVar {
+	name: string;
+	description: string;
+	relatedFlag: string; // Empty string if no related flag
+	required?: boolean;
+}
+
+/**
+ * Registry of all environment variables used by the CLI.
+ * This is the single source of truth for environment variable documentation.
+ */
+export const EnvVarRegistry: EnvVar[] = [
+	{
+		name: `${ENV_PREFIX}_API_URL`,
+		description: "API endpoint URL",
+		relatedFlag: "",
+		required: true,
+	},
+	{
+		name: `${ENV_PREFIX}_API_TOKEN`,
+		description: "API authentication token",
+		relatedFlag: "",
+		required: true,
+	},
+	{
+		name: `${ENV_PREFIX}_NAMESPACE`,
+		description: "Default namespace",
+		relatedFlag: "-ns",
+	},
+	{
+		name: `${ENV_PREFIX}_OUTPUT_FORMAT`,
+		description: "Output format (json, yaml, table)",
+		relatedFlag: "-o",
+	},
+	{
+		name: `${ENV_PREFIX}_SUBSCRIPTION_TIER`,
+		description: "Subscription tier for feature validation",
+		relatedFlag: "",
+	},
+	{
+		name: "NO_COLOR",
+		description: "Disable color output",
+		relatedFlag: "--no-color",
+	},
+];
+
+/**
+ * Format environment variables section with dynamic column alignment.
+ * Matches the Go version's professional formatting with [flag] notation.
+ */
+export function formatEnvVarsSection(): string[] {
+	const maxLen = Math.max(...EnvVarRegistry.map((e) => e.name.length));
+	const lines: string[] = ["ENVIRONMENT VARIABLES"];
+
+	for (const env of EnvVarRegistry) {
+		const padding = " ".repeat(maxLen - env.name.length + 3);
+		const flagNote = env.relatedFlag ? ` [${env.relatedFlag}]` : "";
+		lines.push(`  ${env.name}${padding}${env.description}${flagNote}`);
+	}
+
+	return lines;
+}
+
+/**
+ * Format configuration section with precedence order.
+ * Matches the Go version's layout.
+ */
+export function formatConfigSection(): string[] {
+	return [
+		"CONFIGURATION",
+		`  Config file:  ~/${CONFIG_FILE_NAME}`,
+		"  Priority:     CLI flags > environment variables > config file > defaults",
+		"",
+		"DOCUMENTATION",
+		`  ${DOCS_URL}`,
+	];
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Configuration module exports.
+ */
+
+export {
+	EnvVarRegistry,
+	formatEnvVarsSection,
+	formatConfigSection,
+	type EnvVar,
+} from "./envvars.js";

--- a/src/domains/completion/generators.ts
+++ b/src/domains/completion/generators.ts
@@ -110,9 +110,9 @@ export function generateBashCompletion(): string {
 			];
 			customDomainCompletions.push(
 				`        ${domain.name})`,
-				`            COMPREPLY=( $(compgen -W "${allCommands.join(" ")}" -- "\${cur}") )`,
-				`            return 0`,
-				`            ;;`,
+				`          COMPREPLY=($(compgen -W "${allCommands.join(" ")}" -- "\${cur}"))`,
+				`          return 0`,
+				`          ;;`,
 			);
 		}
 
@@ -120,9 +120,9 @@ export function generateBashCompletion(): string {
 		for (const [groupName, groupCommands] of subcommands) {
 			customDomainCompletions.push(
 				`        ${domain.name}/${groupName})`,
-				`            COMPREPLY=( $(compgen -W "${groupCommands.join(" ")}" -- "\${cur}") )`,
-				`            return 0`,
-				`            ;;`,
+				`          COMPREPLY=($(compgen -W "${groupCommands.join(" ")}" -- "\${cur}"))`,
+				`          return 0`,
+				`          ;;`,
 			);
 		}
 	}
@@ -132,49 +132,49 @@ export function generateBashCompletion(): string {
 # shellcheck disable=SC2034,SC2207
 
 _xcsh_completions() {
-    local cur prev words cword
-    _init_completion || return
+  local cur prev words cword
+  _init_completion || return
 
-    local commands="${domainNames} ${allAliases} help quit exit clear history"
-    local actions="${actions}"
-    local builtins="help quit exit clear history context ctx"
-    local global_flags="--help -h --version -v --interactive -i --no-color --output -o --namespace -ns"
+  local commands="${domainNames} ${allAliases} help quit exit clear history"
+  local actions="${actions}"
+  local builtins="help quit exit clear history context ctx"
+  local global_flags="--help -h --version -v --interactive -i --no-color --output -o --namespace -ns"
 
-    # Handle completion based on position
-    case \${cword} in
-        1)
-            # First word: domains, builtins, or flags
-            if [[ "\${cur}" == -* ]]; then
-                COMPREPLY=( $(compgen -W "\${global_flags}" -- "\${cur}") )
-            else
-                COMPREPLY=( $(compgen -W "\${commands} \${builtins}" -- "\${cur}") )
-            fi
-            return 0
-            ;;
-        2)
-            # Second word: actions or subcommands based on first word
-            local domain="\${words[1]}"
-            case "\${domain}" in
+  # Handle completion based on position
+  case \${cword} in
+    1)
+      # First word: domains, builtins, or flags
+      if [[ "\${cur}" == -* ]]; then
+        COMPREPLY=($(compgen -W "\${global_flags}" -- "\${cur}"))
+      else
+        COMPREPLY=($(compgen -W "\${commands} \${builtins}" -- "\${cur}"))
+      fi
+      return 0
+      ;;
+    2)
+      # Second word: actions or subcommands based on first word
+      local domain="\${words[1]}"
+      case "\${domain}" in
 ${customDomainCompletions.join("\n")}
-                help|quit|exit|clear|history|context|ctx)
-                    return 0
-                    ;;
-                *)
-                    # API domain - suggest actions
-                    COMPREPLY=( $(compgen -W "\${actions}" -- "\${cur}") )
-                    return 0
-                    ;;
-            esac
-            ;;
+        help | quit | exit | clear | history | context | ctx)
+          return 0
+          ;;
         *)
-            # Third+ word: flags
-            if [[ "\${cur}" == -* ]]; then
-                local action_flags="--name -n --namespace -ns --output -o --json --yaml --limit --label"
-                COMPREPLY=( $(compgen -W "\${action_flags}" -- "\${cur}") )
-            fi
-            return 0
-            ;;
-    esac
+          # API domain - suggest actions
+          COMPREPLY=($(compgen -W "\${actions}" -- "\${cur}"))
+          return 0
+          ;;
+      esac
+      ;;
+    *)
+      # Third+ word: flags
+      if [[ "\${cur}" == -* ]]; then
+        local action_flags="--name -n --namespace -ns --output -o --json --yaml --limit --label"
+        COMPREPLY=($(compgen -W "\${action_flags}" -- "\${cur}"))
+      fi
+      return 0
+      ;;
+  esac
 }
 
 complete -F _xcsh_completions xcsh

--- a/src/repl/help.ts
+++ b/src/repl/help.ts
@@ -1,0 +1,425 @@
+/**
+ * Multi-context help system for xcsh.
+ * Provides context-aware help at root, domain, and action levels.
+ */
+
+import {
+	CLI_NAME,
+	CLI_VERSION,
+	CLI_FULL_NAME,
+	colorBoldWhite,
+	colorDim,
+} from "../branding/index.js";
+import {
+	formatEnvVarsSection,
+	formatConfigSection,
+} from "../config/envvars.js";
+import {
+	type DomainInfo,
+	domainRegistry,
+	validActions,
+	getDomainInfo,
+} from "../types/domains.js";
+
+/**
+ * Format root-level help with full details.
+ * Includes: description, usage, examples, global flags, environment variables.
+ * Matches the Go version's professional structure.
+ */
+export function formatRootHelp(): string[] {
+	return [
+		"",
+		colorBoldWhite(`${CLI_NAME} - ${CLI_FULL_NAME} v${CLI_VERSION}`),
+		"",
+		"DESCRIPTION",
+		`  Interactive CLI for F5 Distributed Cloud services.`,
+		"",
+		"USAGE",
+		`  ${CLI_NAME}                              Enter interactive REPL mode`,
+		`  ${CLI_NAME} <domain> <action>            Execute command non-interactively`,
+		`  ${CLI_NAME} help [topic]                 Show help for a topic`,
+		"",
+		"EXAMPLES",
+		`  ${CLI_NAME} tenant_and_identity list namespace   List all namespaces`,
+		`  ${CLI_NAME} virtual get http_loadbalancer        Get a specific load balancer`,
+		`  ${CLI_NAME} dns list                             List DNS zones`,
+		`  ${CLI_NAME} waf list -ns prod                    List WAF policies in prod`,
+		`  ${CLI_NAME} --interactive                        Force interactive REPL mode`,
+		"",
+		...formatDomainsSection(),
+		"",
+		...formatGlobalFlags(),
+		"",
+		...formatEnvVarsSection(),
+		"",
+		...formatConfigSection(),
+		"",
+		"NAVIGATION (Interactive Mode)",
+		"  <domain>              Navigate into a domain (e.g., 'dns', 'lb')",
+		"  /domain               Navigate directly to domain from anywhere",
+		"  ..                    Go up one level",
+		"  /                     Return to root",
+		"  context               Show current navigation context",
+		"",
+		"BUILTINS",
+		"  help                  Show this help",
+		"  domains               List all available domains",
+		"  clear                 Clear the screen",
+		"  history               Show command history",
+		"  quit, exit            Exit the shell",
+		"",
+	];
+}
+
+/**
+ * Format global flags section.
+ */
+export function formatGlobalFlags(): string[] {
+	return [
+		"GLOBAL FLAGS",
+		"  -v, --version         Show version number",
+		"  -h, --help            Show this help",
+		"  -i, --interactive     Force interactive mode",
+		"  --no-color            Disable color output",
+		"  -o, --output <fmt>    Output format (json, yaml, table)",
+		"  -ns, --namespace <ns> Target namespace",
+	];
+}
+
+/**
+ * Format environment variables section.
+ * Re-exports the centralized function from config/envvars for backwards compatibility.
+ */
+export function formatEnvironmentVariables(): string[] {
+	return formatEnvVarsSection();
+}
+
+/**
+ * Format domain-level help.
+ * Shows domain-specific information WITHOUT global flags or environment variables.
+ */
+export function formatDomainHelp(domain: DomainInfo): string[] {
+	const output: string[] = ["", colorBoldWhite(`${domain.displayName}`), ""];
+
+	// Description
+	output.push(`  ${domain.description}`);
+	output.push("");
+
+	// Category and complexity if available
+	if (domain.category || domain.complexity) {
+		const meta: string[] = [];
+		if (domain.category) meta.push(`Category: ${domain.category}`);
+		if (domain.complexity) meta.push(`Complexity: ${domain.complexity}`);
+		output.push(colorDim(`  ${meta.join("  |  ")}`));
+		output.push("");
+	}
+
+	// Usage
+	output.push("USAGE");
+	output.push(`  ${CLI_NAME} ${domain.name} <action> [options]`);
+	output.push("");
+
+	// Actions
+	output.push("ACTIONS");
+	const actionDescriptions: Record<string, string> = {
+		list: "List resources",
+		get: "Get a specific resource by name",
+		create: "Create a new resource",
+		delete: "Delete a resource",
+		replace: "Replace a resource configuration",
+		apply: "Apply configuration from file",
+		status: "Get resource status",
+		patch: "Patch a resource",
+		"add-labels": "Add labels to a resource",
+		"remove-labels": "Remove labels from a resource",
+	};
+
+	for (const action of validActions) {
+		const desc = actionDescriptions[action] ?? action;
+		output.push(`  ${action.padEnd(16)} ${desc}`);
+	}
+	output.push("");
+
+	// Examples
+	output.push("EXAMPLES");
+	output.push(`  ${CLI_NAME} ${domain.name} list`);
+	output.push(`  ${CLI_NAME} ${domain.name} get my-resource`);
+	output.push(
+		`  ${CLI_NAME} ${domain.name} create my-resource -f config.yaml`,
+	);
+	output.push(`  ${CLI_NAME} ${domain.name} delete my-resource`);
+	output.push("");
+
+	// Use cases if available
+	if (domain.useCases && domain.useCases.length > 0) {
+		output.push("USE CASES");
+		for (const useCase of domain.useCases.slice(0, 5)) {
+			output.push(`  - ${useCase}`);
+		}
+		output.push("");
+	}
+
+	// Related domains if available
+	if (domain.relatedDomains && domain.relatedDomains.length > 0) {
+		output.push("RELATED DOMAINS");
+		output.push(`  ${domain.relatedDomains.join(", ")}`);
+		output.push("");
+	}
+
+	// Aliases if available
+	if (domain.aliases && domain.aliases.length > 0) {
+		output.push("ALIASES");
+		output.push(`  ${domain.aliases.join(", ")}`);
+		output.push("");
+	}
+
+	// Footer with reference to global help
+	output.push(colorDim(`For global options, run: ${CLI_NAME} --help`));
+	output.push("");
+
+	return output;
+}
+
+/**
+ * Format action-level help.
+ * Shows action-specific usage within a domain context.
+ */
+export function formatActionHelp(domainName: string, action: string): string[] {
+	const domain = getDomainInfo(domainName);
+	const displayDomain = domain?.displayName ?? domainName;
+
+	const actionDescriptions: Record<string, { desc: string; usage: string }> =
+		{
+			list: {
+				desc: "List all resources in the namespace",
+				usage: `${CLI_NAME} ${domainName} list [--limit N] [--label key=value]`,
+			},
+			get: {
+				desc: "Get a specific resource by name",
+				usage: `${CLI_NAME} ${domainName} get <name> [-o json|yaml|table]`,
+			},
+			create: {
+				desc: "Create a new resource",
+				usage: `${CLI_NAME} ${domainName} create <name> -f <file.yaml>`,
+			},
+			delete: {
+				desc: "Delete a resource by name",
+				usage: `${CLI_NAME} ${domainName} delete <name>`,
+			},
+			replace: {
+				desc: "Replace an existing resource configuration",
+				usage: `${CLI_NAME} ${domainName} replace <name> -f <file.yaml>`,
+			},
+			apply: {
+				desc: "Apply configuration from a file (create or update)",
+				usage: `${CLI_NAME} ${domainName} apply -f <file.yaml>`,
+			},
+			status: {
+				desc: "Get the current status of a resource",
+				usage: `${CLI_NAME} ${domainName} status <name>`,
+			},
+			patch: {
+				desc: "Patch specific fields of a resource",
+				usage: `${CLI_NAME} ${domainName} patch <name> -f <patch.yaml>`,
+			},
+			"add-labels": {
+				desc: "Add labels to a resource",
+				usage: `${CLI_NAME} ${domainName} add-labels <name> key=value`,
+			},
+			"remove-labels": {
+				desc: "Remove labels from a resource",
+				usage: `${CLI_NAME} ${domainName} remove-labels <name> key`,
+			},
+		};
+
+	const actionInfo = actionDescriptions[action] ?? {
+		desc: `Execute ${action} operation`,
+		usage: `${CLI_NAME} ${domainName} ${action} [options]`,
+	};
+
+	return [
+		"",
+		colorBoldWhite(`${displayDomain} - ${action}`),
+		"",
+		`  ${actionInfo.desc}`,
+		"",
+		"USAGE",
+		`  ${actionInfo.usage}`,
+		"",
+		"OPTIONS",
+		"  -n, --name <name>     Resource name",
+		"  -ns, --namespace <ns> Target namespace",
+		"  -o, --output <fmt>    Output format (json, yaml, table)",
+		"  -f, --file <path>     Configuration file",
+		"",
+		colorDim(`For domain help, run: ${CLI_NAME} ${domainName} --help`),
+		"",
+	];
+}
+
+/**
+ * Format help for a specific topic.
+ */
+export function formatTopicHelp(topic: string): string[] {
+	const lowerTopic = topic.toLowerCase();
+
+	// Check if it's a domain
+	const domainInfo = getDomainInfo(lowerTopic);
+	if (domainInfo) {
+		return formatDomainHelp(domainInfo);
+	}
+
+	// Check for special topics
+	switch (lowerTopic) {
+		case "domains":
+			return formatDomainsHelp();
+		case "actions":
+			return formatActionsHelp();
+		case "navigation":
+		case "nav":
+			return formatNavigationHelp();
+		case "env":
+		case "environment":
+			return ["", ...formatEnvironmentVariables(), ""];
+		case "flags":
+			return ["", ...formatGlobalFlags(), ""];
+		default:
+			return [
+				"",
+				`Unknown help topic: ${topic}`,
+				"",
+				"Available topics:",
+				"  domains      List all available domains",
+				"  actions      List available actions",
+				"  navigation   Navigation commands",
+				"  env          Environment variables",
+				"  flags        Global flags",
+				"  <domain>     Help for a specific domain (e.g., 'help dns')",
+				"",
+			];
+	}
+}
+
+/**
+ * Format domains list help.
+ */
+export function formatDomainsHelp(): string[] {
+	const output: string[] = ["", colorBoldWhite("Available Domains"), ""];
+
+	// Group domains by category
+	const categories = new Map<string, DomainInfo[]>();
+
+	for (const domain of domainRegistry.values()) {
+		const category = domain.category ?? "Other";
+		if (!categories.has(category)) {
+			categories.set(category, []);
+		}
+		categories.get(category)?.push(domain);
+	}
+
+	// Sort categories and display
+	const sortedCategories = Array.from(categories.keys()).sort();
+
+	for (const category of sortedCategories) {
+		const domains = categories.get(category) ?? [];
+		output.push(colorBoldWhite(`  ${category}`));
+
+		for (const domain of domains.sort((a, b) =>
+			a.name.localeCompare(b.name),
+		)) {
+			const aliases =
+				domain.aliases.length > 0
+					? ` (${domain.aliases.join(", ")})`
+					: "";
+			output.push(
+				`    ${domain.name.padEnd(24)} ${domain.displayName}${aliases}`,
+			);
+		}
+		output.push("");
+	}
+
+	return output;
+}
+
+/**
+ * Format actions help.
+ */
+export function formatActionsHelp(): string[] {
+	return [
+		"",
+		colorBoldWhite("Available Actions"),
+		"",
+		"  list              List all resources in the namespace",
+		"  get               Get a specific resource by name",
+		"  create            Create a new resource from a file",
+		"  delete            Delete a resource by name",
+		"  replace           Replace a resource configuration",
+		"  apply             Apply configuration (create or update)",
+		"  status            Get resource status",
+		"  patch             Patch specific fields of a resource",
+		"  add-labels        Add labels to a resource",
+		"  remove-labels     Remove labels from a resource",
+		"",
+		"USAGE",
+		`  ${CLI_NAME} <domain> <action> [options]`,
+		"",
+		"EXAMPLES",
+		`  ${CLI_NAME} dns list`,
+		`  ${CLI_NAME} lb get my-loadbalancer`,
+		`  ${CLI_NAME} waf create my-policy -f policy.yaml`,
+		"",
+	];
+}
+
+/**
+ * Format navigation help.
+ */
+export function formatNavigationHelp(): string[] {
+	return [
+		"",
+		colorBoldWhite("Navigation Commands"),
+		"",
+		"  <domain>          Navigate into a domain context",
+		"  /<domain>         Navigate directly to domain from anywhere",
+		"  ..                Go up one level in context",
+		"  /                 Return to root context",
+		"  back              Go up one level (same as ..)",
+		"  root              Return to root (same as /)",
+		"",
+		"CONTEXT DISPLAY",
+		"  context           Show current navigation context",
+		"  ctx               Alias for context",
+		"",
+		"EXAMPLES",
+		"  xcsh> dns                    # Enter dns domain",
+		"  dns> list                    # Execute list in dns context",
+		"  dns> ..                      # Return to root",
+		"  xcsh> /waf                   # Jump directly to waf",
+		"  waf> /dns                    # Jump from waf to dns",
+		"",
+	];
+}
+
+/**
+ * Format DOMAINS section for root help.
+ * Displays all registered domains with their descriptions,
+ * dynamically generated from the domain registry (no hardcoding).
+ */
+export function formatDomainsSection(): string[] {
+	const output: string[] = ["DOMAINS"];
+
+	// Get all domains sorted alphabetically
+	const domains = Array.from(domainRegistry.values()).sort((a, b) =>
+		a.name.localeCompare(b.name),
+	);
+
+	// Calculate max name length for column alignment
+	const maxNameLen = Math.max(...domains.map((d) => d.name.length));
+
+	for (const domain of domains) {
+		const padding = " ".repeat(maxNameLen - domain.name.length + 2);
+		output.push(`  ${domain.name}${padding}${domain.description}`);
+	}
+
+	return output;
+}

--- a/src/stubs/ansi-escapes.ts
+++ b/src/stubs/ansi-escapes.ts
@@ -1,0 +1,70 @@
+/**
+ * Patched ansi-escapes that preserves scrollback buffer.
+ *
+ * The original clearTerminal uses \x1b[3J which erases the scrollback buffer.
+ * This patch removes that escape sequence so terminal history is preserved
+ * when Ink clears the screen.
+ *
+ * Original: \x1b[2J\x1b[3J\x1b[H (erase screen + erase scrollback + cursor home)
+ * Patched:  \x1b[2J\x1b[H       (erase screen + cursor home, scrollback preserved)
+ *
+ * Note: We import directly from node_modules to avoid circular alias reference.
+ */
+
+// Import directly from the node_modules path (not the aliased name)
+import originalDefault from "../../node_modules/ansi-escapes/index.js";
+import * as originalNamed from "../../node_modules/ansi-escapes/index.js";
+
+// ESC sequence building blocks
+const ESC = "\u001B[";
+const eraseScreen = `${ESC}2J`;
+const cursorHome = `${ESC}H`;
+
+// Patched clearTerminal without scrollback erase (\x1b[3J)
+const patchedClearTerminal = `${eraseScreen}${cursorHome}`;
+
+// Re-export all named exports from original
+export const {
+	beep,
+	clearScreen,
+	clearViewport,
+	cursorBackward,
+	cursorDown,
+	cursorForward,
+	cursorGetPosition,
+	cursorHide,
+	cursorLeft,
+	cursorMove,
+	cursorNextLine,
+	cursorPrevLine,
+	cursorRestorePosition,
+	cursorSavePosition,
+	cursorShow,
+	cursorTo,
+	cursorUp,
+	enterAlternativeScreen,
+	eraseDown,
+	eraseEndLine,
+	eraseLine,
+	eraseLines,
+	eraseScreen: eraseScreenOriginal,
+	eraseStartLine,
+	eraseUp,
+	exitAlternativeScreen,
+	image,
+	link,
+	scrollDown,
+	scrollUp,
+	setCwd,
+	iTerm,
+	ConEmu,
+} = originalNamed;
+
+// Override clearTerminal as a named export
+export const clearTerminal = patchedClearTerminal;
+
+// Default export with all original functions plus patched clearTerminal
+export default {
+	...originalDefault,
+	clearTerminal: patchedClearTerminal,
+};

--- a/src/stubs/index.ts
+++ b/src/stubs/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Stub modules for optional dependencies.
+ * These provide minimal implementations for packages that are optional
+ * or need patching for terminal compatibility.
+ */
+
+// Export patched ansi-escapes (preserves scrollback buffer)
+export * as ansiEscapes from "./ansi-escapes.js";
+
+// Export devtools stub (optional peer dependency)
+export * as devtools from "./devtools.js";


### PR DESCRIPTION
## Summary

Add core infrastructure components for the ink-based REPL improvements (Issue #316).

### New Components

**Multi-Context Help System** (`src/repl/help.ts`)
- Root-level help with full details (domains, flags, env vars, navigation)
- Domain-level help showing domain-specific actions and usage
- Action-level help with specific usage patterns
- Dynamically generates from domain registry (no hardcoding)
- Topic-based help (domains, actions, navigation, env, flags)

**Environment Variable Registry** (`src/config/`)
- Centralized registry of all CLI environment variables
- Dynamic column alignment for help display
- Flag notation support (e.g., `[--output]` next to `F5XC_OUTPUT_FORMAT`)
- Configuration priority documentation

**Patched ansi-escapes** (`src/stubs/ansi-escapes.ts`)
- Removes `\x1b[3J` (erase scrollback) from `clearTerminal`
- Preserves terminal scrollback history during Ink clears
- Key fix for issue #316 scrollback preservation

**Completion Generator Fix** (`src/domains/completion/generators.ts`)
- Fixed indentation inconsistency (4-space → 2-space)
- Fixed COMPREPLY formatting for bash completion
- Ensures regenerated completions match committed versions

## Files Changed

| File | Purpose |
|------|---------|
| `src/config/envvars.ts` | Environment variable registry |
| `src/config/index.ts` | Config module exports |
| `src/repl/help.ts` | Multi-context help system |
| `src/stubs/ansi-escapes.ts` | Patched ansi-escapes for scrollback |
| `src/stubs/index.ts` | Stubs module exports |
| `src/domains/completion/generators.ts` | Fixed formatting consistency |

## Test Plan

- [x] Build passes: `npm run build`
- [x] Pre-commit hooks pass
- [x] TypeScript type checking passes
- [x] Completion generator produces consistent output

## Related

- Part of #316 (Refactor REPL: Migrate from Go/Bubbletea to Node.js/TypeScript/Ink)

🤖 Generated with [Claude Code](https://claude.com/claude-code)