### PR TITLE
fix: enable keyboard input in Bun-compiled binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -255,8 +255,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Generate fresh completions
-        run: npm run generate:completions
+      - name: Generate fresh domains and completions
+        run: npm run generate
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -43,6 +43,10 @@ program
 				}
 
 				// Enter interactive REPL mode
+				// WORKAROUND: Bun doesn't call process.stdin.resume() automatically,
+				// which breaks Ink's useInput hook. This is a known Bun bug:
+				// https://github.com/oven-sh/bun/issues/6862
+				process.stdin.resume();
 				render(<App />);
 				return;
 			}


### PR DESCRIPTION
## Summary

Fixes scrollback and tab selection not working in Homebrew-installed xcsh.

### Root Cause

Bun doesn't call `process.stdin.resume()` automatically, which breaks Ink's `useInput` hook in compiled binaries. This is a known Bun bug:
- https://github.com/oven-sh/bun/issues/6862

### Changes

- Add `process.stdin.resume()` workaround before entering REPL mode
- Align release workflow to use full `npm run generate` instead of just `generate:completions` for consistency

### Test Plan

- [x] TypeScript compiles without errors
- [x] Pre-commit hooks pass
- [x] Fix included in bundle: `grep -c "process.stdin.resume" dist/index.js` → 1
- [x] Fix included in binary: `strings binaries/xcsh-macos-arm64 | grep -c "stdin.resume"` → 2
- [ ] Manual testing of scrollback (Up/Down arrows) in Bun binary
- [ ] Manual testing of Tab completion in Bun binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)