### PR TITLE
fix: revert generate step in create-release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -255,8 +255,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Generate fresh domains and completions
-        run: npm run generate
+      - name: Generate fresh completions
+        run: npm run generate:completions
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary

The previous PR #347 inadvertently changed `generate:completions` to `generate` in the create-release job. This broke the release workflow because:

- The `create-release` job doesn't download API specs
- `npm run generate` runs both `generate:domains` and `generate:completions`
- `generate:domains` requires `.specs/index.json` which doesn't exist in this job

The fix reverts to just `generate:completions` which is all that's needed for packaging completion scripts into release archives.

## Test Plan
- [x] CI passes
- [ ] Release workflow completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)