### PR TITLE
feat: increase completion suggestions display limit to 20

### DIFF
--- a/src/repl/App.tsx
+++ b/src/repl/App.tsx
@@ -441,7 +441,7 @@ export function App(): React.ReactElement {
 							onSelect={handleSuggestionSelect}
 							onNavigate={handleSuggestionNavigate}
 							onCancel={completion.hide}
-							maxVisible={10}
+							maxVisible={20}
 							isActive={false} // Let App handle keyboard
 						/>
 					) : (

--- a/src/repl/components/Suggestions.tsx
+++ b/src/repl/components/Suggestions.tsx
@@ -89,7 +89,7 @@ export function Suggestions({
 	onSelect,
 	onNavigate,
 	onCancel,
-	maxVisible = 10,
+	maxVisible = 20,
 	isActive = true,
 }: SuggestionsProps): React.ReactElement | null {
 	// Handle keyboard navigation


### PR DESCRIPTION
## Summary
Increase the maximum visible completion suggestions from 10 to 20 items for CLI power users.

## Changes
- `src/repl/App.tsx`: Update `maxVisible={10}` to `maxVisible={20}`
- `src/repl/components/Suggestions.tsx`: Update default `maxVisible = 10` to `maxVisible = 20`

## Background
UX research shows 8-10 is standard for web UIs, but CLI power users (like zsh users) benefit from seeing more options. Scroll indicators already implemented for larger lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #352