### PR TITLE
feat: rename repository and package to f5xc-xcsh

### DIFF
--- a/.github/ISSUE_TEMPLATE/upstream-spec-quality.md
+++ b/.github/ISSUE_TEMPLATE/upstream-spec-quality.md
@@ -69,4 +69,4 @@ We have documented this in `.specs/domain_config.yaml` with the following overri
 
 ---
 
-**Note**: Issues of this type are automatically detected during daily upstream syncs. This issue may have been created automatically by the [xcsh sync-upstream-specs](https://github.com/robinmordasiewicz/xcsh/blob/main/.github/workflows/sync-upstream-specs.yml) workflow.
+**Note**: Issues of this type are automatically detected during daily upstream syncs. This issue may have been created automatically by the [xcsh sync-upstream-specs](https://github.com/robinmordasiewicz/f5xc-xcsh/blob/main/.github/workflows/sync-upstream-specs.yml) workflow.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -342,28 +342,28 @@ jobs:
 
           **macOS (Apple Silicon)**
           ```bash
-          curl -LO https://github.com/robinmordasiewicz/xcsh/releases/download/v${VERSION}/xcsh_${VERSION}_darwin_arm64.tar.gz
+          curl -LO https://github.com/robinmordasiewicz/f5xc-xcsh/releases/download/v${VERSION}/xcsh_${VERSION}_darwin_arm64.tar.gz
           tar -xzf xcsh_${VERSION}_darwin_arm64.tar.gz
           sudo mv xcsh /usr/local/bin/
           ```
 
           **macOS (Intel)**
           ```bash
-          curl -LO https://github.com/robinmordasiewicz/xcsh/releases/download/v${VERSION}/xcsh_${VERSION}_darwin_amd64.tar.gz
+          curl -LO https://github.com/robinmordasiewicz/f5xc-xcsh/releases/download/v${VERSION}/xcsh_${VERSION}_darwin_amd64.tar.gz
           tar -xzf xcsh_${VERSION}_darwin_amd64.tar.gz
           sudo mv xcsh /usr/local/bin/
           ```
 
           **Linux (amd64)**
           ```bash
-          curl -LO https://github.com/robinmordasiewicz/xcsh/releases/download/v${VERSION}/xcsh_${VERSION}_linux_amd64.tar.gz
+          curl -LO https://github.com/robinmordasiewicz/f5xc-xcsh/releases/download/v${VERSION}/xcsh_${VERSION}_linux_amd64.tar.gz
           tar -xzf xcsh_${VERSION}_linux_amd64.tar.gz
           sudo mv xcsh /usr/local/bin/
           ```
 
           **Linux (arm64)**
           ```bash
-          curl -LO https://github.com/robinmordasiewicz/xcsh/releases/download/v${VERSION}/xcsh_${VERSION}_linux_arm64.tar.gz
+          curl -LO https://github.com/robinmordasiewicz/f5xc-xcsh/releases/download/v${VERSION}/xcsh_${VERSION}_linux_arm64.tar.gz
           tar -xzf xcsh_${VERSION}_linux_arm64.tar.gz
           sudo mv xcsh /usr/local/bin/
           ```
@@ -373,12 +373,12 @@ jobs:
 
           **npm (requires Node.js)**
           ```bash
-          npm install -g @robinmordasiewicz/xcsh
+          npm install -g @robinmordasiewicz/f5xc-xcsh
           ```
 
           **npx (no installation)**
           ```bash
-          npx @robinmordasiewicz/xcsh
+          npx @robinmordasiewicz/f5xc-xcsh
           ```
           RELEASE_EOF
 
@@ -689,7 +689,7 @@ jobs:
           cask "xcsh" do
             name "xcsh"
             desc "Command-line interface for F5 Distributed Cloud"
-            homepage "https://robinmordasiewicz.github.io/xcsh"
+            homepage "https://robinmordasiewicz.github.io/f5xc-xcsh"
             version "${VERSION}"
 
             livecheck do
@@ -725,22 +725,22 @@ jobs:
 
             on_macos do
               on_intel do
-                url "https://github.com/robinmordasiewicz/xcsh/releases/download/v#{version}/xcsh_#{version}_darwin_amd64.tar.gz"
+                url "https://github.com/robinmordasiewicz/f5xc-xcsh/releases/download/v#{version}/xcsh_#{version}_darwin_amd64.tar.gz"
                 sha256 "${HASH_darwin_amd64}"
               end
               on_arm do
-                url "https://github.com/robinmordasiewicz/xcsh/releases/download/v#{version}/xcsh_#{version}_darwin_arm64.tar.gz"
+                url "https://github.com/robinmordasiewicz/f5xc-xcsh/releases/download/v#{version}/xcsh_#{version}_darwin_arm64.tar.gz"
                 sha256 "${HASH_darwin_arm64}"
               end
             end
 
             on_linux do
               on_intel do
-                url "https://github.com/robinmordasiewicz/xcsh/releases/download/v#{version}/xcsh_#{version}_linux_amd64.tar.gz"
+                url "https://github.com/robinmordasiewicz/f5xc-xcsh/releases/download/v#{version}/xcsh_#{version}_linux_amd64.tar.gz"
                 sha256 "${HASH_linux_amd64}"
               end
               on_arm do
-                url "https://github.com/robinmordasiewicz/xcsh/releases/download/v#{version}/xcsh_#{version}_linux_arm64.tar.gz"
+                url "https://github.com/robinmordasiewicz/f5xc-xcsh/releases/download/v#{version}/xcsh_#{version}_linux_arm64.tar.gz"
                 sha256 "${HASH_linux_arm64}"
               end
             end
@@ -752,7 +752,7 @@ jobs:
               You may need to restart your shell or source your shell config.
 
               For setup instructions, see:
-                https://robinmordasiewicz.github.io/xcsh/install/homebrew/
+                https://robinmordasiewicz.github.io/f5xc-xcsh/install/homebrew/
 
               Quick start:
                 xcsh --help

--- a/.serena/memories/codebase_structure.md
+++ b/.serena/memories/codebase_structure.md
@@ -5,7 +5,7 @@
 ```text
 xcsh/
 ├── main.go              # Entry point - calls cmd.Execute()
-├── go.mod               # Go module definition (github.com/robinmordasiewicz/xcsh)
+├── go.mod               # Go module definition (github.com/robinmordasiewicz/f5xc-xcsh)
 ├── go.sum               # Dependency checksums
 ├── Makefile             # Build, test, lint commands
 ├── .goreleaser.yaml     # GoReleaser configuration

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ F5 Distributed Cloud Shell - A command-line interface for managing F5 Distribute
 
 ## Documentation
 
-Full documentation is available at **[robinmordasiewicz.github.io/xcsh](https://robinmordasiewicz.github.io/xcsh)**
+Full documentation is available at **[robinmordasiewicz.github.io/f5xc-xcsh](https://robinmordasiewicz.github.io/f5xc-xcsh)**
 
 ## Installation
 
@@ -18,7 +18,7 @@ brew install --cask xcsh
 ### Install Script
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/robinmordasiewicz/xcsh/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/robinmordasiewicz/f5xc-xcsh/main/install.sh | sh
 ```
 
 ## Usage

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -58,7 +58,7 @@ brew install --cask xcsh
 Or use the universal install script on any platform:
 
 ```bash
-curl -fsSL https://robinmordasiewicz.github.io/xcsh/install.sh | sh
+curl -fsSL https://robinmordasiewicz.github.io/f5xc-xcsh/install.sh | sh
 ```
 
 ## Post-Installation Setup

--- a/docs/install/script.md
+++ b/docs/install/script.md
@@ -5,7 +5,7 @@ Install xcsh on Linux or macOS using the universal install script.
 ## Quick Install
 
 ```bash
-curl -fsSL https://robinmordasiewicz.github.io/xcsh/install.sh | sh
+curl -fsSL https://robinmordasiewicz.github.io/f5xc-xcsh/install.sh | sh
 ```
 
 ## What the Script Does
@@ -42,13 +42,13 @@ Customize the installation with these environment variables:
 ### Example: User-Local Installation
 
 ```bash
-F5XC_NO_SUDO=1 curl -fsSL https://robinmordasiewicz.github.io/xcsh/install.sh | sh
+F5XC_NO_SUDO=1 curl -fsSL https://robinmordasiewicz.github.io/f5xc-xcsh/install.sh | sh
 ```
 
 ### Example: Specific Version
 
 ```bash
-F5XC_VERSION=4.39.0 curl -fsSL https://robinmordasiewicz.github.io/xcsh/install.sh | sh
+F5XC_VERSION=4.39.0 curl -fsSL https://robinmordasiewicz.github.io/f5xc-xcsh/install.sh | sh
 ```
 
 ## Post-Installation

--- a/docs/install/source.md
+++ b/docs/install/source.md
@@ -14,7 +14,7 @@ Building from source requires:
 ## Clone Repository
 
 ```bash
-git clone https://github.com/robinmordasiewicz/xcsh.git
+git clone https://github.com/robinmordasiewicz/f5xc-xcsh.git
 cd xcsh
 ```
 
@@ -54,8 +54,8 @@ Move the binary to your PATH:
 For release-quality builds with embedded version information:
 
 ```bash
-go build -ldflags="-X github.com/robinmordasiewicz/xcsh/cmd.Version=dev \
-  -X github.com/robinmordasiewicz/xcsh/cmd.GitCommit=$(git rev-parse --short HEAD) \
-  -X github.com/robinmordasiewicz/xcsh/cmd.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+go build -ldflags="-X github.com/robinmordasiewicz/f5xc-xcsh/cmd.Version=dev \
+  -X github.com/robinmordasiewicz/f5xc-xcsh/cmd.GitCommit=$(git rev-parse --short HEAD) \
+  -X github.com/robinmordasiewicz/f5xc-xcsh/cmd.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
   -o xcsh .
 ```

--- a/docs/install/windows.md
+++ b/docs/install/windows.md
@@ -4,7 +4,7 @@ Install xcsh on Windows by downloading the binary directly.
 
 ## Download
 
-1. Go to the [GitHub Releases](https://github.com/robinmordasiewicz/xcsh/releases) page
+1. Go to the [GitHub Releases](https://github.com/robinmordasiewicz/f5xc-xcsh/releases) page
 2. Download `xcsh_windows_amd64.zip` (or `xcsh_windows_arm64.zip` for ARM)
 3. Extract the archive
 
@@ -60,7 +60,7 @@ xcsh completion powershell | Out-String | Invoke-Expression
 If you prefer a Unix-like environment, you can use Windows Subsystem for Linux (WSL) and follow the [Script](script.md) installation method:
 
 ```bash
-curl -fsSL https://robinmordasiewicz.github.io/xcsh/install.sh | sh
+curl -fsSL https://robinmordasiewicz.github.io/f5xc-xcsh/install.sh | sh
 ```
 
 ## Troubleshooting

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -35,13 +35,13 @@ brew install robinmordasiewicz/tap/xcsh
 #### Using Install Script
 
 ```bash
-sh -c "$(curl -sSL https://raw.githubusercontent.com/robinmordasiewicz/xcsh/main/install.sh)"
+sh -c "$(curl -sSL https://raw.githubusercontent.com/robinmordasiewicz/f5xc-xcsh/main/install.sh)"
 ```
 
 #### Using npm (for development)
 
 ```bash
-git clone https://github.com/robinmordasiewicz/xcsh.git
+git clone https://github.com/robinmordasiewicz/f5xc-xcsh.git
 cd xcsh
 npm install
 npm run build
@@ -777,9 +777,9 @@ Manage multiple environments with profiles:
 
 ### Support
 
-- **Report Issues**: https://github.com/robinmordasiewicz/xcsh/issues
-- **Discussions**: https://github.com/robinmordasiewicz/xcsh/discussions
-- **Documentation**: https://github.com/robinmordasiewicz/xcsh/tree/main/docs
+- **Report Issues**: https://github.com/robinmordasiewicz/f5xc-xcsh/issues
+- **Discussions**: https://github.com/robinmordasiewicz/f5xc-xcsh/discussions
+- **Documentation**: https://github.com/robinmordasiewicz/f5xc-xcsh/tree/main/docs
 
 ### Contributing
 

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # xcsh install script
-# Usage: curl -fsSL https://robinmordasiewicz.github.io/xcsh/install.sh | sh
+# Usage: curl -fsSL https://robinmordasiewicz.github.io/f5xc-xcsh/install.sh | sh
 #
 # Environment variables:
 #   F5XC_VERSION      - Specific version to install (default: latest)
@@ -12,7 +12,7 @@
 set -eu
 
 # Configuration
-GITHUB_REPO="robinmordasiewicz/xcsh"
+GITHUB_REPO="robinmordasiewicz/f5xc-xcsh"
 GITHUB_API="https://api.github.com/repos/${GITHUB_REPO}/releases/latest"
 GITHUB_RELEASES="https://github.com/${GITHUB_REPO}/releases/download"
 DEFAULT_INSTALL_DIR="/usr/local/bin"
@@ -879,8 +879,8 @@ Automatically detects your platform and installs the appropriate binary
 from GitHub releases.
 
 USAGE
-    curl -fsSL https://robinmordasiewicz.github.io/xcsh/install.sh | sh
-    wget -qO- https://robinmordasiewicz.github.io/xcsh/install.sh | sh
+    curl -fsSL https://robinmordasiewicz.github.io/f5xc-xcsh/install.sh | sh
+    wget -qO- https://robinmordasiewicz.github.io/f5xc-xcsh/install.sh | sh
 
 OPTIONS
     --uninstall     Remove xcsh and shell completions
@@ -899,23 +899,23 @@ SUPPORTED PLATFORMS
 
 EXAMPLES
     # Install latest version
-    curl -fsSL https://robinmordasiewicz.github.io/xcsh/install.sh | sh
+    curl -fsSL https://robinmordasiewicz.github.io/f5xc-xcsh/install.sh | sh
 
     # Install specific version
-    curl -fsSL https://robinmordasiewicz.github.io/xcsh/install.sh | F5XC_VERSION=1.1.0 sh
+    curl -fsSL https://robinmordasiewicz.github.io/f5xc-xcsh/install.sh | F5XC_VERSION=1.1.0 sh
 
     # Install to custom directory (no sudo required)
-    curl -fsSL https://robinmordasiewicz.github.io/xcsh/install.sh | F5XC_INSTALL_DIR=$HOME/.local/bin sh
+    curl -fsSL https://robinmordasiewicz.github.io/f5xc-xcsh/install.sh | F5XC_INSTALL_DIR=$HOME/.local/bin sh
 
     # Install using wget instead of curl
-    wget -qO- https://robinmordasiewicz.github.io/xcsh/install.sh | sh
+    wget -qO- https://robinmordasiewicz.github.io/f5xc-xcsh/install.sh | sh
 
     # Uninstall
-    curl -fsSL https://robinmordasiewicz.github.io/xcsh/install.sh | sh -s -- --uninstall
+    curl -fsSL https://robinmordasiewicz.github.io/f5xc-xcsh/install.sh | sh -s -- --uninstall
 
 WINDOWS INSTALLATION
     Download the appropriate zip file from GitHub releases:
-    https://github.com/robinmordasiewicz/xcsh/releases/latest
+    https://github.com/robinmordasiewicz/f5xc-xcsh/releases/latest
 
     - Windows (Intel/AMD): xcsh_VERSION_windows_amd64.zip
     - Windows (ARM):       xcsh_VERSION_windows_arm64.zip

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
 site_name: xcsh Documentation
 site_description: Open-source CLI for F5 Distributed Cloud
-site_url: https://robinmordasiewicz.github.io/xcsh/
-repo_name: robinmordasiewicz/xcsh
-repo_url: https://github.com/robinmordasiewicz/xcsh
+site_url: https://robinmordasiewicz.github.io/f5xc-xcsh/
+repo_name: robinmordasiewicz/f5xc-xcsh
+repo_url: https://github.com/robinmordasiewicz/f5xc-xcsh
 
 theme:
   name: material
@@ -75,7 +75,7 @@ markdown_extensions:
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/robinmordasiewicz/xcsh
+      link: https://github.com/robinmordasiewicz/f5xc-xcsh
   generator: false
 
 extra_css:

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@robinmordasiewicz/xcsh",
+  "name": "@robinmordasiewicz/f5xc-xcsh",
   "version": "6.4.1",
   "description": "F5 Distributed Cloud Shell - Interactive CLI for F5 XC",
   "type": "module",
@@ -9,9 +9,9 @@
   "main": "./dist/index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/robinmordasiewicz/xcsh.git"
+    "url": "https://github.com/robinmordasiewicz/f5xc-xcsh.git"
   },
-  "homepage": "https://robinmordasiewicz.github.io/xcsh",
+  "homepage": "https://robinmordasiewicz.github.io/f5xc-xcsh",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"

--- a/scripts/templates/script.md.j2
+++ b/scripts/templates/script.md.j2
@@ -7,13 +7,13 @@ Install xcsh with automatic platform detection and shell configuration.
 === "curl"
 
     ```bash
-    curl -fsSL https://robinmordasiewicz.github.io/xcsh/install.sh | sh
+    curl -fsSL https://robinmordasiewicz.github.io/f5xc-xcsh/install.sh | sh
     ```
 
 === "wget"
 
     ```bash
-    wget -qO- https://robinmordasiewicz.github.io/xcsh/install.sh | sh
+    wget -qO- https://robinmordasiewicz.github.io/f5xc-xcsh/install.sh | sh
     ```
 
 {% if install_output %}
@@ -31,19 +31,19 @@ Install xcsh with automatic platform detection and shell configuration.
 ## Specific Version
 
 ```bash
-curl -fsSL https://robinmordasiewicz.github.io/xcsh/install.sh | VES_VERSION={{ version or 'X.Y.Z' }} sh
+curl -fsSL https://robinmordasiewicz.github.io/f5xc-xcsh/install.sh | VES_VERSION={{ version or 'X.Y.Z' }} sh
 ```
 
 ## Custom Install Directory
 
 ```bash
-curl -fsSL https://robinmordasiewicz.github.io/xcsh/install.sh | VES_INSTALL_DIR=$HOME/.local/bin sh
+curl -fsSL https://robinmordasiewicz.github.io/f5xc-xcsh/install.sh | VES_INSTALL_DIR=$HOME/.local/bin sh
 ```
 
 ## Uninstall
 
 ```bash
-curl -fsSL https://robinmordasiewicz.github.io/xcsh/install.sh | sh -s -- --uninstall
+curl -fsSL https://robinmordasiewicz.github.io/f5xc-xcsh/install.sh | sh -s -- --uninstall
 ```
 
 ## Environment Variables
@@ -71,4 +71,4 @@ curl -fsSL https://robinmordasiewicz.github.io/xcsh/install.sh | sh -s -- --unin
 | macOS | amd64 (Intel), arm64 (Apple Silicon) |
 
 !!! note "Windows"
-    Download manually from [GitHub Releases](https://github.com/robinmordasiewicz/xcsh/releases/latest).
+    Download manually from [GitHub Releases](https://github.com/robinmordasiewicz/f5xc-xcsh/releases/latest).

--- a/scripts/templates/source.md.j2
+++ b/scripts/templates/source.md.j2
@@ -23,7 +23,7 @@ Building from source requires:
 ## Clone Repository
 
 ```bash
-git clone https://github.com/robinmordasiewicz/xcsh.git
+git clone https://github.com/robinmordasiewicz/f5xc-xcsh.git
 cd xcsh
 ```
 

--- a/scripts/templates/windows.md.j2
+++ b/scripts/templates/windows.md.j2
@@ -11,7 +11,7 @@ Download and extract the latest release:
     ```powershell
     # Download latest release
     $version = "{{ version or 'X.Y.Z' }}"
-    $url = "https://github.com/robinmordasiewicz/xcsh/releases/download/v$version/xcsh-win-x64.exe"
+    $url = "https://github.com/robinmordasiewicz/f5xc-xcsh/releases/download/v$version/xcsh-win-x64.exe"
 
     # Create installation directory
     $installDir = "$env:LOCALAPPDATA\Programs\xcsh"
@@ -32,7 +32,7 @@ Download and extract the latest release:
     ```powershell
     # Download latest release
     $version = "{{ version or 'X.Y.Z' }}"
-    $url = "https://github.com/robinmordasiewicz/xcsh/releases/download/v$version/xcsh-win-arm64.exe"
+    $url = "https://github.com/robinmordasiewicz/f5xc-xcsh/releases/download/v$version/xcsh-win-arm64.exe"
 
     # Create installation directory
     $installDir = "$env:LOCALAPPDATA\Programs\xcsh"
@@ -78,7 +78,7 @@ if ($currentPath -notlike "*$installDir*") {
 
 Alternatively, download directly from GitHub:
 
-1. Visit [GitHub Releases](https://github.com/robinmordasiewicz/xcsh/releases/latest)
+1. Visit [GitHub Releases](https://github.com/robinmordasiewicz/f5xc-xcsh/releases/latest)
 2. Download `xcsh-win-x64.exe` (or `xcsh-win-arm64.exe` for ARM processors)
 3. Rename to `xcsh.exe` and place in a directory of your choice
 4. Add the directory to your PATH
@@ -124,7 +124,7 @@ To upgrade to a newer version:
 ```powershell
 # Download new version (same as install)
 $version = "NEW_VERSION"
-$url = "https://github.com/robinmordasiewicz/xcsh/releases/download/v$version/xcsh-win-x64.exe"
+$url = "https://github.com/robinmordasiewicz/f5xc-xcsh/releases/download/v$version/xcsh-win-x64.exe"
 Invoke-WebRequest -Uri $url -OutFile "$env:LOCALAPPDATA\Programs\xcsh\xcsh.exe"
 ```
 

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -9,7 +9,7 @@ const packageJson = JSON.parse(readFileSync("./package.json", "utf-8"));
 function fetchLatestRelease(): string | null {
 	try {
 		const result = execSync(
-			'curl -s --connect-timeout 3 "https://api.github.com/repos/robinmordasiewicz/xcsh/releases/latest" | grep \'"tag_name":\' | sed -E \'s/.*"v?([^"]+)".*/\\1/\'',
+			'curl -s --connect-timeout 3 "https://api.github.com/repos/robinmordasiewicz/f5xc-xcsh/releases/latest" | grep \'"tag_name":\' | sed -E \'s/.*"v?([^"]+)".*/\\1/\'',
 			{ encoding: "utf-8", timeout: 5000 },
 		).trim();
 		// Validate we got a version-like string (e.g., "6.9.0")


### PR DESCRIPTION
## Summary

Rename GitHub repository and npm package to follow F5 naming convention:
- **GitHub repo**: `robinmordasiewicz/xcsh` → `robinmordasiewicz/f5xc-xcsh`
- **npm package**: `@robinmordasiewicz/xcsh` → `@robinmordasiewicz/f5xc-xcsh`

### What Stays the Same
- CLI binary name: `xcsh` (user convenience)
- Config file: `.xcshconfig` (backward compatibility)
- ENV_PREFIX: `F5XC` (already F5-branded)
- Homebrew cask name: `xcsh`

### Files Changed
- `package.json` - name, repository.url, homepage
- `tsup.config.ts` - GitHub API URL
- `install.sh` - GITHUB_REPO and all URLs (~10 places)
- `.github/workflows/release.yml` - release URLs, npm package, Homebrew (~15 places)
- `mkdocs.yml` - site_url, repo_name, repo_url
- `docs/*.md` - documentation and install URLs
- `scripts/templates/*.j2` - template URLs
- `.github/ISSUE_TEMPLATE/upstream-spec-quality.md`

## Test Plan
- [x] Build succeeds (`npm run build`)
- [x] CLI runs (`./dist/index.js version`)
- [x] No old URLs remain in codebase (verified with grep)
- [x] All pre-commit hooks pass

## Next Steps (After Merge)
Repository rename via `gh repo rename f5xc-xcsh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)