### PR TITLE
feat: show Initializing message before banner on startup

### DIFF
--- a/src/repl/index.ts
+++ b/src/repl/index.ts
@@ -15,7 +15,7 @@ export {
 } from "./prompt.js";
 
 // Main application
-export { App } from "./App.js";
+export { App, type AppProps } from "./App.js";
 
 // Hooks
 export { useDoubleCtrlC, useHistory, useCompletion } from "./hooks/index.js";


### PR DESCRIPTION
## Summary

Reorders the startup sequence so users see "Initializing..." first, then the banner appears after session initialization completes.

### Changes
- Initialize session before Ink starts (in `index.tsx`)
- Pass pre-initialized session to App component via `initialSession` prop
- Clear "Initializing..." message before showing banner
- App component now accepts optional `initialSession` prop to skip redundant initialization

### Behavior
**Before:** Banner → "Initializing..." → REPL ready
**After:** "Initializing..." → Banner → REPL ready

This provides better UX by showing feedback immediately while the session loads, then displaying the banner when ready.

## Test Plan
- [x] Build succeeds with `npm run build`
- [x] All pre-commit hooks pass
- [ ] Manual verification: run `./xcsh` and verify "Initializing..." appears first, then banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)