### PR TITLE
fix: prevent duplicate command display in scrollback

### DIFF
--- a/src/repl/App.tsx
+++ b/src/repl/App.tsx
@@ -371,10 +371,13 @@ export function App({ initialSession }: AppProps = {}): React.ReactElement {
 				return;
 			}
 
-			// Execute command
-			await runCommand(value);
+			// Clear input immediately to prevent duplicate display in scrollback
+			// (InputBox would show command while addOutput also adds it to Static)
 			setInput("");
 			history.reset();
+
+			// Execute command
+			await runCommand(value);
 		},
 		[completion, applyCompletion, runCommand, history],
 	);


### PR DESCRIPTION
## Summary

Fixes duplicate command display in scrollback when executing commands, especially visible with `login banner`.

### Problem
When a command was submitted:
1. `addOutput(prompt + trimmed)` added the command to Static (scrollback)
2. InputBox still showed the command (not yet cleared)
3. Both appeared in the same render cycle, causing duplicate display

### Solution
Clear input immediately when user presses Enter, **before** executing the command:
```typescript
// Clear input immediately to prevent duplicate display
setInput("");
history.reset();

// Execute command
await runCommand(value);
```

## Test Plan
- [x] Build succeeds
- [x] Pre-commit hooks pass
- [ ] Manual test: `./xcsh` → type `login banner` → command should appear only once

🤖 Generated with [Claude Code](https://claude.com/claude-code)