### PR TITLE
fix: hide InputBox during raw stdout to prevent scrollback capture

### DIFF
--- a/src/repl/App.tsx
+++ b/src/repl/App.tsx
@@ -511,7 +511,8 @@ export function App({ initialSession }: AppProps = {}): React.ReactElement {
 			</Static>
 
 			{/* Conditionally render active UI or loading state */}
-			{isInitialized ? (
+			{/* Hide entire active UI when writing raw stdout to prevent it appearing in scrollback */}
+			{isInitialized && !hideStatusBar ? (
 				<>
 					{/* Input box */}
 					<InputBox
@@ -525,32 +526,30 @@ export function App({ initialSession }: AppProps = {}): React.ReactElement {
 					/>
 
 					{/* Suggestions popup OR Status bar - mutually exclusive to conserve space */}
-					{/* Hide status bar when writing raw stdout to prevent it appearing in scrollback */}
-					{!hideStatusBar &&
-						(completion.isShowing &&
-						completion.suggestions.length > 0 ? (
-							<Suggestions
-								suggestions={toUISuggestions(
-									completion.suggestions,
-								)}
-								selectedIndex={completion.selectedIndex}
-								onSelect={handleSuggestionSelect}
-								onNavigate={handleSuggestionNavigate}
-								onCancel={completion.hide}
-								maxVisible={20}
-								isActive={false} // Let App handle keyboard
-							/>
-						) : (
-							<StatusBar
-								gitInfo={gitInfo}
-								width={width}
-								hint={statusHint}
-							/>
-						))}
+					{completion.isShowing &&
+					completion.suggestions.length > 0 ? (
+						<Suggestions
+							suggestions={toUISuggestions(
+								completion.suggestions,
+							)}
+							selectedIndex={completion.selectedIndex}
+							onSelect={handleSuggestionSelect}
+							onNavigate={handleSuggestionNavigate}
+							onCancel={completion.hide}
+							maxVisible={20}
+							isActive={false} // Let App handle keyboard
+						/>
+					) : (
+						<StatusBar
+							gitInfo={gitInfo}
+							width={width}
+							hint={statusHint}
+						/>
+					)}
 				</>
-			) : (
+			) : !isInitialized ? (
 				<Text>Initializing...</Text>
-			)}
+			) : null}
 		</Box>
 	);
 }


### PR DESCRIPTION
## Summary

Fix the issue where an empty prompt line `> ` with red horizontal rules was appearing in the scrollback after executing commands that use raw stdout (like `login banner`).

### Problem
When executing commands that write raw stdout content (such as the banner command with inline images), the InputBox component was still being rendered during the raw stdout write operation. This caused the prompt line and its styling to be captured in the terminal scrollback.

### Solution
Changed the render condition from `isInitialized` to `isInitialized && !hideStatusBar` to hide the **entire active UI** (InputBox, Suggestions, and StatusBar) during raw stdout operations, not just the StatusBar.

### Files Changed
- `src/repl/App.tsx` - Modified render condition to hide all active UI during raw stdout writes

## Test Plan
- [x] Build succeeds with `npm run build`
- [ ] Execute `login banner` command - no extra prompt in scrollback
- [ ] Execute other commands - normal behavior preserved
- [ ] Startup banner displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)