### PR TITLE
feat: make login command default to showing connection info

### DIFF
--- a/completions/_xcsh
+++ b/completions/_xcsh
@@ -167,7 +167,7 @@ _xcsh() {
         (action)
             case ${line[1]} in
         (login)
-            _values 'command' 'show:Command' 'banner:Command' 'profile:Subcommand group' 'context:Subcommand group'
+            _values 'command' 'banner:Command' 'profile:Subcommand group' 'context:Subcommand group'
             ;;
         (cloudstatus)
             _values 'command' 'status:Command' 'summary:Command' 'components:Command' 'incidents:Command' 'maintenance:Command'

--- a/completions/xcsh.bash
+++ b/completions/xcsh.bash
@@ -27,7 +27,7 @@ _xcsh_completions() {
       local domain="${words[1]}"
       case "${domain}" in
         login)
-          COMPREPLY=($(compgen -W "show banner profile context" -- "${cur}"))
+          COMPREPLY=($(compgen -W "banner profile context" -- "${cur}"))
           return 0
           ;;
         login/profile)

--- a/completions/xcsh.fish
+++ b/completions/xcsh.fish
@@ -151,7 +151,6 @@ complete -c xcsh -n "__fish_use_subcommand" -a "firewall" -d 'Alias for waf'
 complete -c xcsh -n "__fish_use_subcommand" -a "appfw" -d 'Alias for waf'
 
 # Custom domain subcommands
-complete -c xcsh -n "__fish_seen_subcommand_from login" -a "show" -d 'Command'
 complete -c xcsh -n "__fish_seen_subcommand_from login" -a "banner" -d 'Command'
 complete -c xcsh -n "__fish_seen_subcommand_from login" -a "profile" -d 'Subcommand group'
 complete -c xcsh -n "__fish_seen_subcommand_from login; and __fish_seen_subcommand_from profile" -a "list" -d 'Command'

--- a/src/domains/login/index.ts
+++ b/src/domains/login/index.ts
@@ -33,14 +33,12 @@ const profileSubcommands: SubcommandGroup = {
 export const loginDomain: DomainDefinition = {
 	name: "login",
 	description:
-		"Authentication, identity, and session management for F5 XC. Manage connection profiles to save and switch between tenants, handle context for namespace targeting, and verify current authentication status with whoami.",
+		"Authentication, identity, and session management for F5 XC. Manage connection profiles to save and switch between tenants, handle context for namespace targeting, and verify current authentication status.",
 	descriptionShort: "Authentication and session management",
 	descriptionMedium:
 		"Manage connection profiles, authentication contexts, and session identity for F5 Distributed Cloud.",
-	commands: new Map([
-		["show", whoamiCommand],
-		["banner", bannerCommand],
-	]),
+	defaultCommand: whoamiCommand,
+	commands: new Map([["banner", bannerCommand]]),
 	subcommands: new Map([
 		["profile", profileSubcommands],
 		["context", contextSubcommands],

--- a/src/domains/registry.ts
+++ b/src/domains/registry.ts
@@ -91,6 +91,8 @@ export interface DomainDefinition {
 	commands: Map<string, CommandDefinition>;
 	/** Subcommand groups (e.g., "login profile") */
 	subcommands: Map<string, SubcommandGroup>;
+	/** Default command to run when domain is invoked with no args */
+	defaultCommand?: CommandDefinition;
 }
 
 /**
@@ -159,8 +161,11 @@ class DomainRegistry {
 			};
 		}
 
-		// No args - show domain help
+		// No args - run default command if set, otherwise show help
 		if (args.length === 0) {
+			if (domain.defaultCommand) {
+				return domain.defaultCommand.execute([], session);
+			}
 			return this.showDomainHelp(domain);
 		}
 


### PR DESCRIPTION
## Summary

Refactor the `login` command so that invoking `login` with no arguments directly shows connection/identity info, eliminating the redundant `login show` subcommand.

### Changes
- Add `defaultCommand` field to `DomainDefinition` interface in registry
- When a domain is invoked with no args, run `defaultCommand` if set, otherwise show help
- Remove `["show", whoamiCommand]` from login domain commands map
- Set `defaultCommand: whoamiCommand` on login domain
- Shell completions auto-regenerated (show removed from login)

### Behavior Changes

| Command | Before | After |
|---------|--------|-------|
| `login` | Shows domain help | Shows connection info |
| `login show` | Shows connection info | Error: unknown command |
| `login banner` | Shows banner | No change |
| `login profile list` | Lists profiles | No change |

### Files Changed
- `src/domains/registry.ts` - Added `defaultCommand` to interface and execute() logic
- `src/domains/login/index.ts` - Removed show command, added defaultCommand
- `completions/*.{bash,fish}` and `completions/_xcsh` - Auto-regenerated

## Test Plan
- [x] Build succeeds with `npm run build`
- [x] Typecheck passes
- [x] Lint passes
- [x] Completions regenerated correctly (show removed from login)

🤖 Generated with [Claude Code](https://claude.com/claude-code)