### PR TITLE
fix: remove non-existent team-reviewers from sync workflow

### DIFF
--- a/.github/workflows/sync-upstream-specs.yml
+++ b/.github/workflows/sync-upstream-specs.yml
@@ -161,8 +161,6 @@ jobs:
             chore
           reviewers: |
             robinmordasiewicz
-          team-reviewers: |
-            maintainers
 
   # Step 3: Report if no updates
   no-updates:


### PR DESCRIPTION
## Summary

The Sync Upstream Specs workflow was failing after PR creation because it tried to request reviews from a "maintainers" team that doesn't exist in this personal repository.

## Changes

- Removed `team-reviewers: maintainers` from sync-upstream-specs.yml

## Error Fixed

```
##[error]Reviews may only be requested from collaborators. One or more of the teams you specified is not a collaborator of the robinmordasiewicz/f5xc-xcsh repository.
```

## Test Plan

- [x] Workflow syntax valid (GitHub Workflows pre-commit check passed)
- [ ] Re-run Sync Upstream Specs workflow after merge to verify fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)