### PR TITLE
feat: enable auto-merge for upstream spec sync PRs

### DIFF
--- a/.github/workflows/sync-upstream-specs.yml
+++ b/.github/workflows/sync-upstream-specs.yml
@@ -109,6 +109,7 @@ jobs:
           echo "- **New:** ${{ needs.check-upstream.outputs.new_version }}" >> validation-report.md
 
       - name: Create Pull Request
+        id: create-pr
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -161,6 +162,18 @@ jobs:
             chore
           reviewers: |
             robinmordasiewicz
+
+      - name: Enable Auto-Merge
+        if: steps.create-pr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "🔄 Enabling auto-merge for PR #${{ steps.create-pr.outputs.pull-request-number }}"
+          gh pr merge ${{ steps.create-pr.outputs.pull-request-number }} \
+            --auto \
+            --squash \
+            --delete-branch
+          echo "✅ Auto-merge enabled - PR will merge automatically when CI passes"
 
   # Step 3: Report if no updates
   no-updates:


### PR DESCRIPTION
## Summary

Enable fully automated upstream spec sync → release pipeline with zero manual intervention.

### Changes
- Add step ID to "Create Pull Request" action for output reference
- Add "Enable Auto-Merge" step using `gh pr merge --auto --squash --delete-branch`

### Repository Configuration (Already Applied)
| Setting | Value |
|---------|-------|
| `allow_auto_merge` | `true` |
| Branch protection | Required checks: Lint, Test (3 platforms), Build |
| Required reviews | None (disabled for automation) |
| `enforce_admins` | `false` |

### Automated Pipeline Flow
```
6 AM UTC (Daily)
    ↓
Check upstream specs → New version? → Generate code → Validate
    ↓
Create PR with auto-merge enabled
    ↓
CI runs (lint, test×3, build)
    ↓
✅ Auto-merge when all checks pass
    ↓
Release workflow triggers → npm publish → macOS signing → docs deploy
```

### Safety
- All CI checks must pass before auto-merge
- Pre-PR validation (build + tests) in sync workflow
- Git tags for each release enable rollback

🤖 Generated with [Claude Code](https://claude.com/claude-code)