### PR TITLE
fix: add formatting step to sync workflow

### DIFF
--- a/.github/workflows/sync-upstream-specs.yml
+++ b/.github/workflows/sync-upstream-specs.yml
@@ -85,6 +85,9 @@ jobs:
       - name: Generate domains
         run: npx tsx scripts/generate-domains.ts
 
+      - name: Format generated code
+        run: npx prettier --write "src/**/*.{ts,tsx}"
+
       - name: Validate generated code
         run: npm run build
 


### PR DESCRIPTION
## Summary

Add `npx prettier --write` step to sync-upstream-specs workflow to automatically format generated files before validation and PR creation.

### Problem
The sync workflow generates code files that may not be properly formatted, causing CI lint failures in the PR.

### Solution
Run prettier on generated TypeScript files after domain generation and before build validation.

### Changes
- Added "Format generated code" step between "Generate domains" and "Validate generated code"

🤖 Generated with [Claude Code](https://claude.com/claude-code)