### PR TITLE
feat: add repository_dispatch trigger for upstream notifications

### DIFF
--- a/.github/workflows/sync-upstream-specs.yml
+++ b/.github/workflows/sync-upstream-specs.yml
@@ -8,6 +8,10 @@ on:
   # Allow manual trigger for immediate sync
   workflow_dispatch:
 
+  # Triggered by upstream f5xc-api-enriched when new specs are released
+  repository_dispatch:
+    types: [enriched-specs-updated]
+
   # Trigger on domain config changes
   push:
     paths:
@@ -25,6 +29,15 @@ jobs:
       current_version: ${{ steps.check.outputs.current_version }}
 
     steps:
+      - name: Log upstream dispatch info
+        if: github.event_name == 'repository_dispatch'
+        run: |
+          echo "🔔 Triggered by upstream repository_dispatch"
+          echo "Event type: ${{ github.event.action }}"
+          echo "Version: ${{ github.event.client_payload.version }}"
+          echo "Release: ${{ github.event.client_payload.release_url }}"
+          echo "Source: ${{ github.event.client_payload.trigger_source }}"
+
       - uses: actions/checkout@v4
 
       - name: Get current version from specs


### PR DESCRIPTION
## Summary

Add `repository_dispatch` trigger to enable automatic sync when upstream f5xc-api-enriched releases new API specifications.

## Changes

- Added `repository_dispatch` with `enriched-specs-updated` event type
- Added logging step to show upstream payload when dispatch triggered
- Preserves existing schedule, manual dispatch, and push triggers

## How It Works

When f5xc-api-enriched creates a new release, it now dispatches an `enriched-specs-updated` event to this repository. This triggers the sync workflow immediately instead of waiting for the next scheduled run.

## Benefits

- **Instant sync**: No more 6-hour polling delay
- **Better visibility**: Payload logging shows what triggered the workflow
- **Reliability**: Part of cross-repository notification system

## Related

- Upstream PR: robinmordasiewicz/f5xc-api-enriched#264

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)