### PR TITLE
fix: remove duplicate v prefix from CLI display strings

### DIFF
--- a/src/domains/login/banner/display.ts
+++ b/src/domains/login/banner/display.ts
@@ -143,7 +143,7 @@ function printImageBanner(
 	const helpStartRow = Math.floor((imageHeight - HELP_LINES.length) / 2);
 
 	// Build title line
-	const title = ` ${CLI_FULL_NAME} v${CLI_VERSION} `;
+	const title = ` ${CLI_FULL_NAME} ${CLI_VERSION} `;
 	const leftDashes = 3;
 	const rightDashes = TOTAL_WIDTH - 1 - leftDashes - title.length - 1;
 
@@ -245,7 +245,7 @@ function printAsciiBanner(): void {
 	const HELP_START_ROW = 8;
 
 	// Build title line
-	const title = ` ${CLI_FULL_NAME} v${CLI_VERSION} `;
+	const title = ` ${CLI_FULL_NAME} ${CLI_VERSION} `;
 	const leftDashes = 3;
 	const rightDashes = TOTAL_WIDTH - 1 - leftDashes - title.length - 1;
 
@@ -335,7 +335,7 @@ function getBannerLines(
 	const helpColumnWidth = INNER_WIDTH - logoWidth - 1;
 
 	// Build title line
-	const title = ` ${CLI_FULL_NAME} v${CLI_VERSION} `;
+	const title = ` ${CLI_FULL_NAME} ${CLI_VERSION} `;
 	const leftDashes = 3;
 	const rightDashes = TOTAL_WIDTH - 1 - leftDashes - title.length - 1;
 

--- a/src/repl/help.ts
+++ b/src/repl/help.ts
@@ -58,7 +58,7 @@ function wrapText(text: string, width: number, indent: number): string[] {
 export function formatRootHelp(): string[] {
 	return [
 		"",
-		colorBoldWhite(`${CLI_NAME} - ${CLI_FULL_NAME} v${CLI_VERSION}`),
+		colorBoldWhite(`${CLI_NAME} - ${CLI_FULL_NAME} ${CLI_VERSION}`),
 		"",
 		"DESCRIPTION",
 		...wrapText(CLI_DESCRIPTION_LONG, 80, 2),


### PR DESCRIPTION
## Summary

CLI_VERSION now includes the `v` prefix (e.g., `v1.0.82-2512312131`) after the versioning revamp. Remove the extra `v` prefix from display strings in help and banner output to prevent showing `vv1.0.82-...`

### Files Changed
- `src/repl/help.ts` - Root help header
- `src/domains/login/banner/display.ts` - Banner title (3 locations)

## Test Plan
- [x] Pre-commit hooks pass
- [ ] CI builds pass
- [ ] `xcsh --help` shows `v1.0.82-...` (not `vv1.0.82-...`)
- [ ] Banner shows correct version format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #401