### PR TITLE
feat: migrate to XDG Base Directory compliance

### DIFF
--- a/src/branding/index.ts
+++ b/src/branding/index.ts
@@ -52,7 +52,6 @@ export const CLI_DESCRIPTION_MEDIUM = cliDescs?.medium ?? CLI_DESCRIPTION_SHORT;
 export const CLI_DESCRIPTION_LONG = cliDescs?.long ?? CLI_DESCRIPTION_MEDIUM;
 
 // Configuration
-export const CONFIG_FILE_NAME = ".xcshconfig";
 export const ENV_PREFIX = "F5XC";
 
 // F5 Logo - compact circular logo with F5 text

--- a/src/config/envvars.ts
+++ b/src/config/envvars.ts
@@ -4,7 +4,8 @@
  * Used for dynamic help generation with column alignment and flag notation.
  */
 
-import { ENV_PREFIX, CONFIG_FILE_NAME, DOCS_URL } from "../branding/index.js";
+import { ENV_PREFIX, DOCS_URL } from "../branding/index.js";
+import { paths } from "./paths.js";
 
 export interface EnvVar {
 	name: string;
@@ -76,7 +77,7 @@ export function formatEnvVarsSection(): string[] {
 export function formatConfigSection(): string[] {
 	return [
 		"CONFIGURATION",
-		`  Config file:  ~/${CONFIG_FILE_NAME}`,
+		`  Config file:  ${paths.settings}`,
 		"  Priority:     CLI flags > environment variables > config file > defaults",
 		"",
 		"DOCUMENTATION",

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -1,0 +1,66 @@
+/**
+ * XDG Base Directory compliant paths for xcsh
+ * See: https://specifications.freedesktop.org/basedir/latest/
+ *
+ * This is the single source of truth for all application paths.
+ * All modules should import from here instead of constructing paths directly.
+ */
+
+import { homedir } from "os";
+import { join } from "path";
+
+const APP_NAME = "xcsh";
+
+/**
+ * Get XDG-compliant config directory
+ * Config files: settings, profiles, preferences
+ * Default: ~/.config/xcsh
+ */
+export function getConfigDir(): string {
+	const xdgConfig = process.env.XDG_CONFIG_HOME;
+	if (xdgConfig) {
+		return join(xdgConfig, APP_NAME);
+	}
+	return join(homedir(), ".config", APP_NAME);
+}
+
+/**
+ * Get XDG-compliant state directory
+ * State files: history, logs, undo history, session state
+ * Default: ~/.local/state/xcsh
+ */
+export function getStateDir(): string {
+	const xdgState = process.env.XDG_STATE_HOME;
+	if (xdgState) {
+		return join(xdgState, APP_NAME);
+	}
+	return join(homedir(), ".local", "state", APP_NAME);
+}
+
+/**
+ * Centralized path definitions
+ * Use these getters for all file path access throughout the application
+ */
+export const paths = {
+	// Config files (XDG_CONFIG_HOME)
+	get configDir() {
+		return getConfigDir();
+	},
+	get profilesDir() {
+		return join(getConfigDir(), "profiles");
+	},
+	get activeProfile() {
+		return join(getConfigDir(), "active_profile");
+	},
+	get settings() {
+		return join(getConfigDir(), "config.yaml");
+	},
+
+	// State files (XDG_STATE_HOME)
+	get stateDir() {
+		return getStateDir();
+	},
+	get history() {
+		return join(getStateDir(), "history");
+	},
+};

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -1,13 +1,13 @@
 /**
- * Application settings from .xcshconfig file.
+ * Application settings from config.yaml file.
  * Handles loading, parsing, and validation of user configuration.
+ *
+ * Location: ~/.config/xcsh/config.yaml (XDG Base Directory compliant)
  */
 
 import { promises as fs } from "fs";
-import { homedir } from "os";
-import { join } from "path";
 import YAML from "yaml";
-import { CONFIG_FILE_NAME } from "../branding/index.js";
+import { paths } from "./paths.js";
 
 /**
  * Logo display mode definition with descriptions.
@@ -86,10 +86,10 @@ function validateSettings(
 }
 
 /**
- * Load settings from .xcshconfig file.
+ * Load settings from config.yaml file.
  *
  * File format: YAML
- * Location: ~/.xcshconfig
+ * Location: ~/.config/xcsh/config.yaml (XDG Base Directory compliant)
  *
  * Example:
  * ```yaml
@@ -100,7 +100,7 @@ function validateSettings(
  * @returns Merged settings with defaults for missing values
  */
 export async function loadSettings(): Promise<AppSettings> {
-	const configPath = join(homedir(), CONFIG_FILE_NAME);
+	const configPath = paths.settings;
 
 	try {
 		const content = await fs.readFile(configPath, "utf-8");
@@ -121,7 +121,7 @@ export async function loadSettings(): Promise<AppSettings> {
  * Uses defaults if file doesn't exist or can't be read.
  */
 export function loadSettingsSync(): AppSettings {
-	const configPath = join(homedir(), CONFIG_FILE_NAME);
+	const configPath = paths.settings;
 
 	try {
 		// eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -144,5 +144,5 @@ export function loadSettingsSync(): AppSettings {
  * Get the path to the config file.
  */
 export function getConfigPath(): string {
-	return join(homedir(), CONFIG_FILE_NAME);
+	return paths.settings;
 }

--- a/src/profile/manager.ts
+++ b/src/profile/manager.ts
@@ -1,11 +1,13 @@
 /**
  * ProfileManager - XDG-compliant profile storage and management
+ *
+ * Profiles are stored in ~/.config/xcsh/profiles/ (XDG Base Directory compliant)
  */
 
 import { promises as fs } from "fs";
-import { homedir } from "os";
 import { join } from "path";
 import YAML from "yaml";
+import { paths } from "../config/paths.js";
 import type { Profile, ProfileConfig, ProfileResult } from "./types.js";
 
 /**
@@ -29,28 +31,16 @@ function convertKeysToCamelCase(
 }
 
 /**
- * Get XDG-compliant config directory
- */
-function getConfigDir(): string {
-	const xdgConfig = process.env.XDG_CONFIG_HOME;
-	if (xdgConfig) {
-		return join(xdgConfig, "xcsh");
-	}
-	return join(homedir(), ".config", "xcsh");
-}
-
-/**
  * ProfileManager handles profile CRUD operations with secure file storage
  */
 export class ProfileManager {
 	private config: ProfileConfig;
 
 	constructor() {
-		const configDir = getConfigDir();
 		this.config = {
-			configDir,
-			profilesDir: join(configDir, "profiles"),
-			activeProfileFile: join(configDir, "active_profile"),
+			configDir: paths.configDir,
+			profilesDir: paths.profilesDir,
+			activeProfileFile: paths.activeProfile,
 		};
 	}
 

--- a/src/repl/history.ts
+++ b/src/repl/history.ts
@@ -1,11 +1,13 @@
 /**
  * HistoryManager handles command history persistence.
  * Stores commands to disk and provides navigation through history.
+ *
+ * Location: ~/.local/state/xcsh/history (XDG Base Directory compliant)
  */
 
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
-import { homedir } from "node:os";
-import { join, dirname } from "node:path";
+import { dirname } from "node:path";
+import { paths } from "../config/paths.js";
 
 /**
  * Patterns for sensitive data that should be redacted from history
@@ -57,13 +59,10 @@ export function redactSensitive(cmd: string): string {
 
 /**
  * Get the default history file path
+ * Location: ~/.local/state/xcsh/history (XDG Base Directory compliant)
  */
 export function getHistoryFilePath(): string {
-	try {
-		return join(homedir(), ".xcsh_history");
-	} catch {
-		return ".xcsh_history";
-	}
+	return paths.history;
 }
 
 /**


### PR DESCRIPTION
## Summary

Migrate xcsh configuration and state files to follow the XDG Base Directory Specification.

### Changes
- **Settings**: `~/.xcshconfig` → `~/.config/xcsh/config.yaml`
- **History**: `~/.xcsh_history` → `~/.local/state/xcsh/history`
- Creates centralized `src/config/paths.ts` as single source of truth
- Respects `XDG_CONFIG_HOME` and `XDG_STATE_HOME` environment variables

### Files Changed
- New: `src/config/paths.ts`
- Modified: `src/branding/index.ts`, `src/config/envvars.ts`, `src/config/settings.ts`, `src/profile/manager.ts`, `src/repl/history.ts`

### Breaking Change
Users must manually migrate existing files:
```bash
mkdir -p ~/.config/xcsh ~/.local/state/xcsh
mv ~/.xcshconfig ~/.config/xcsh/config.yaml
mv ~/.xcsh_history ~/.local/state/xcsh/history
```

## Test Plan
- [x] Build passes with `npm run build`
- [x] TypeCheck passes
- [x] Pre-commit hooks pass
- [x] XDG environment variables respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #407