### PR TITLE
feat: tables respect terminal width on resize

### DIFF
--- a/src/output/table.ts
+++ b/src/output/table.ts
@@ -13,6 +13,7 @@ import type {
 } from "./types.js";
 import { DEFAULT_TABLE_STYLE, PLAIN_TABLE_STYLE } from "./types.js";
 import { shouldUseColors } from "./resolver.js";
+import { getTerminalWidth } from "./terminal.js";
 
 /**
  * Unicode box drawing characters (rounded corners)
@@ -205,8 +206,13 @@ export function formatBeautifulTable(
 	const box = getBoxCharacters(style);
 	const borderColor = style.borderColor ?? colors.red;
 
-	// Calculate column widths
-	const widths = calculateColumnWidths(config.columns, data, config.maxWidth);
+	// Calculate column widths using terminal width if maxWidth not explicitly set
+	const effectiveMaxWidth = config.maxWidth ?? getTerminalWidth();
+	const widths = calculateColumnWidths(
+		config.columns,
+		data,
+		effectiveMaxWidth,
+	);
 
 	// Build table lines
 	const lines: string[] = [];

--- a/src/output/terminal.ts
+++ b/src/output/terminal.ts
@@ -1,0 +1,49 @@
+/**
+ * Terminal dimensions context
+ * Provides current terminal width to output formatters
+ *
+ * This module maintains a global terminal width state that can be accessed
+ * by any output formatter without threading width through the entire
+ * execution pipeline.
+ */
+
+const DEFAULT_WIDTH = 80;
+const MIN_WIDTH = 40;
+
+let terminalWidth = process.stdout.columns ?? DEFAULT_WIDTH;
+
+/**
+ * Get current terminal width
+ * Returns the cached terminal width, falling back to default if unavailable
+ */
+export function getTerminalWidth(): number {
+	return Math.max(terminalWidth, MIN_WIDTH);
+}
+
+/**
+ * Set terminal width manually
+ * Used by REPL to sync Ink's width state with this context
+ */
+export function setTerminalWidth(width: number): void {
+	terminalWidth = Math.max(width, MIN_WIDTH);
+}
+
+/**
+ * Initialize terminal resize listener
+ * Call once at startup for non-REPL mode (REPL uses setTerminalWidth)
+ */
+export function initTerminalResize(): void {
+	if (process.stdout.isTTY) {
+		process.stdout.on("resize", () => {
+			terminalWidth = process.stdout.columns ?? DEFAULT_WIDTH;
+		});
+	}
+}
+
+/**
+ * Get raw terminal columns without minimum enforcement
+ * Useful for checking actual terminal size
+ */
+export function getRawTerminalWidth(): number {
+	return process.stdout.columns ?? DEFAULT_WIDTH;
+}

--- a/src/repl/App.tsx
+++ b/src/repl/App.tsx
@@ -18,6 +18,7 @@ import { executeCommand } from "./executor.js";
 import { isCustomDomain } from "../domains/index.js";
 import { domainRegistry } from "../types/domains.js";
 import { extensionRegistry } from "../extensions/index.js";
+import { setTerminalWidth } from "../output/terminal.js";
 
 /**
  * Props for the App component
@@ -177,13 +178,20 @@ export function App({ initialSession }: AppProps = {}): React.ReactElement {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [session]);
 
-	// Handle terminal resize
+	// Handle terminal resize - sync to both local state and global context
 	useEffect(() => {
 		const handleResize = () => {
 			if (stdout) {
-				setWidth(stdout.columns ?? 80);
+				const newWidth = stdout.columns ?? 80;
+				setWidth(newWidth);
+				setTerminalWidth(newWidth);
 			}
 		};
+
+		// Initialize terminal width context on mount
+		if (stdout) {
+			setTerminalWidth(stdout.columns ?? 80);
+		}
 
 		stdout?.on("resize", handleResize);
 		return () => {


### PR DESCRIPTION
## Summary

Add a global terminal width context that table formatters use to constrain output to the current terminal dimensions.

## Changes

- **New:** `src/output/terminal.ts` - Terminal width context module
  - Maintains global terminal width state
  - Provides `getTerminalWidth()` for formatters
  - Provides `setTerminalWidth()` for REPL sync
  - Enforces minimum width of 40 columns

- **Modified:** `src/output/table.ts` - Uses terminal width for table sizing
  - Uses `getTerminalWidth()` when `maxWidth` not explicitly set

- **Modified:** `src/repl/App.tsx` - Syncs REPL width to context
  - Calls `setTerminalWidth()` on mount and resize events

## Test Plan

- [x] Build passes
- [x] All pre-commit hooks pass
- [x] 215 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #409