### PR TITLE
feat: styled scrollback prompt with blue indicator and bright white command

### DIFF
--- a/src/repl/App.tsx
+++ b/src/repl/App.tsx
@@ -11,6 +11,7 @@ import type { Suggestion } from "./components/Suggestions.js";
 import { getGitInfo, type GitInfo } from "./components/StatusBar.js";
 import { REPLSession } from "./session.js";
 import { buildPlainPrompt } from "./prompt.js";
+import { colorBlue, colorBoldWhite } from "../branding/index.js";
 import { useDoubleCtrlC } from "./hooks/useDoubleCtrlC.js";
 import { useHistory } from "./hooks/useHistory.js";
 import { useCompletion } from "./hooks/useCompletion.js";
@@ -279,8 +280,10 @@ export function App({ initialSession }: AppProps = {}): React.ReactElement {
 			const trimmed = cmd.trim();
 			if (!trimmed) return;
 
-			// Show command in output
-			addOutput(prompt + trimmed);
+			// Show command in scrollback with blue indicator and bright white command
+			// Format: ⏺ xcsh> command (blue ⏺, bright white command text)
+			const scrollbackCommand = `${colorBlue("⏺")} ${colorBoldWhite(prompt + trimmed)}`;
+			addOutput(scrollbackCommand);
 
 			// Execute via executor module
 			const result = await executeCommand(trimmed, session);

--- a/src/repl/prompt.ts
+++ b/src/repl/prompt.ts
@@ -4,13 +4,14 @@
  */
 
 import type { REPLSession } from "./session.js";
+import { CLI_NAME } from "../branding/index.js";
 
 /**
  * Build a plain text prompt string.
- * Simple ">" prompt.
+ * Shows CLI name with ">" suffix (e.g., "xcsh> ")
  */
 export function buildPlainPrompt(_session: REPLSession): string {
-	return "> ";
+	return `${CLI_NAME}> `;
 }
 
 /**


### PR DESCRIPTION
## Summary

Enhance the REPL scrollback display with visual distinction between command prompts and output.

### Changes
- Add blue `⏺` indicator for scrollback commands
- Display command text in bright white for visibility
- Change prompt from `> ` to `xcsh> ` for clarity

### Visual Format
```
⏺ xcsh> login profile list    ← bright white
  ⎿  Running in the background    ← normal white
```

### Files Modified
- `src/repl/App.tsx` - Add color formatting for scrollback commands
- `src/repl/prompt.ts` - Update prompt to show CLI name

## Test Plan
- [x] Build passes
- [x] Pre-commit hooks pass
- [ ] Manual verification of scrollback prompt styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #411