### PR TITLE
test: add comprehensive output format testing

### DIFF
--- a/tests/unit/__snapshots__/output-table.test.ts.snap
+++ b/tests/unit/__snapshots__/output-table.test.ts.snap
@@ -1,0 +1,68 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Unicode handling > matches snapshot for unicode table > unicode-table 1`] = `
+"+----------------------+-----------------+
+|         NAME         |     STATUS      |
++----------------------+-----------------+
+| Resource 🚀          | ✅ Active        |
+| 日本語リソース              | ⏳ Pending       |
+| 中文资源                 | ❌ Error         |
++----------------------+-----------------+"
+`;
+
+exports[`formatBeautifulTable > snapshot tests > matches snapshot for custom columns > custom-columns-table 1`] = `
+"+------------+-------------------------------+---------+-------+
+|     ID     |             NAME              | STATUS  | COUNT |
++------------+-------------------------------+---------+-------+
+| 001        | First Resource                | Active  |    42 |
+| 002        | Second Resource               | Pending |    17 |
+| 003        | Third Resource with Long Name |  Error  |     0 |
++------------+-------------------------------+---------+-------+"
+`;
+
+exports[`formatBeautifulTable > snapshot tests > matches snapshot for single row > single-row-table 1`] = `
+"+-----------+-------------+---------------------+
+| NAMESPACE |    NAME     |       LABELS        |
++-----------+-------------+---------------------+
+| system    | single-item | map[component:core] |
++-----------+-------------+---------------------+"
+`;
+
+exports[`formatBeautifulTable > snapshot tests > matches snapshot for standard table > standard-table 1`] = `
+"+-----------+------------+-----------------------------+
+| NAMESPACE |    NAME    |           LABELS            |
++-----------+------------+-----------------------------+
+| default   | resource-1 | map[env:prod team:platform] |
+| staging   | resource-2 | map[env:staging]            |
+| default   | resource-3 | <None>                      |
++-----------+------------+-----------------------------+"
+`;
+
+exports[`formatBeautifulTable > snapshot tests > matches snapshot for table with title > table-with-title 1`] = `
+"+- Test Resources -------------------------------------+
+| NAMESPACE |    NAME    |           LABELS            |
++-----------+------------+-----------------------------+
+| default   | resource-1 | map[env:prod team:platform] |
+| staging   | resource-2 | map[env:staging]            |
+| default   | resource-3 | <None>                      |
++-----------+------------+-----------------------------+"
+`;
+
+exports[`formatKeyValueBox > matches snapshot > key-value-box 1`] = `
+"+- Session Info ----------------------+
+| User     :  admin@example.com       |
+| Tenant   :  acme-corp               |
+| Namespace:  default                 |
+| API URL  :  https://api.example.com |
++-------------------------------------+"
+`;
+
+exports[`formatResourceTable > matches snapshot > resource-table 1`] = `
+"+-----------+------------+-----------------------------+
+| NAMESPACE |    NAME    |           LABELS            |
++-----------+------------+-----------------------------+
+| default   | resource-1 | map[env:prod team:platform] |
+| staging   | resource-2 | map[env:staging]            |
+| default   | resource-3 | <None>                      |
++-----------+------------+-----------------------------+"
+`;

--- a/tests/unit/output-formatter.test.ts
+++ b/tests/unit/output-formatter.test.ts
@@ -1,0 +1,325 @@
+/**
+ * Output Formatter Tests
+ * Tests for main formatter routing and format-specific functions
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+	formatOutput,
+	formatJSON,
+	formatYAML,
+	formatTSV,
+	formatAPIError,
+	parseOutputFormat,
+} from "../../src/output/formatter.js";
+import {
+	standardResource,
+	resourceList,
+	wrappedItems,
+	nestedData,
+	emptyData,
+	specialCharsData,
+	apiErrorResponses,
+	unicodeData,
+} from "./output-test-fixtures.js";
+
+describe("formatOutput", () => {
+	beforeEach(() => {
+		// Mock TTY detection for consistent color behavior
+		vi.stubEnv("NO_COLOR", "1");
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	describe("format routing", () => {
+		it("routes to JSON format", () => {
+			const result = formatOutput(standardResource, "json");
+			expect(result).toBe(JSON.stringify(standardResource, null, 2));
+		});
+
+		it("routes to YAML format", () => {
+			const result = formatOutput(standardResource, "yaml");
+			expect(result).toContain("name: test-resource");
+			expect(result).toContain("namespace: default");
+		});
+
+		it("routes to table format", () => {
+			const result = formatOutput(resourceList, "table", true);
+			expect(result).toContain("NAME");
+			expect(result).toContain("resource-1");
+		});
+
+		it("routes text to table format", () => {
+			const result = formatOutput(resourceList, "text", true);
+			expect(result).toContain("NAME");
+		});
+
+		it("routes to TSV format", () => {
+			const result = formatOutput(resourceList, "tsv");
+			expect(result).toContain("\t");
+			expect(result).toContain("resource-1");
+		});
+
+		it("returns empty string for none format", () => {
+			const result = formatOutput(standardResource, "none");
+			expect(result).toBe("");
+		});
+
+		it("routes spec format to JSON", () => {
+			const result = formatOutput(standardResource, "spec");
+			expect(result).toBe(JSON.stringify(standardResource, null, 2));
+		});
+
+		it("defaults to table format", () => {
+			const result = formatOutput(resourceList, undefined, true);
+			expect(result).toContain("NAME");
+		});
+	});
+
+	describe("noColor parameter", () => {
+		it("respects noColor=true", () => {
+			const result = formatOutput(resourceList, "table", true);
+			// Should use ASCII box characters when colors disabled
+			expect(result).toContain("+");
+			expect(result).not.toContain("\x1b[");
+		});
+	});
+});
+
+describe("formatJSON", () => {
+	it("formats standard object with 2-space indent", () => {
+		const result = formatJSON(standardResource);
+		expect(result).toBe(JSON.stringify(standardResource, null, 2));
+	});
+
+	it("formats nested objects", () => {
+		const result = formatJSON(nestedData);
+		expect(result).toContain("level1");
+		expect(result).toContain("deeply nested");
+	});
+
+	it("formats arrays", () => {
+		const result = formatJSON(resourceList);
+		expect(result.startsWith("[")).toBe(true);
+		expect(result.endsWith("]")).toBe(true);
+	});
+
+	it("handles null value", () => {
+		const result = formatJSON(null);
+		expect(result).toBe("null");
+	});
+
+	it("handles empty array", () => {
+		const result = formatJSON([]);
+		expect(result).toBe("[]");
+	});
+
+	it("handles empty object", () => {
+		const result = formatJSON({});
+		expect(result).toBe("{}");
+	});
+
+	it("preserves special characters in strings", () => {
+		const result = formatJSON(specialCharsData);
+		expect(result).toContain("path/with/slashes");
+		expect(result).toContain('"quotes"');
+	});
+
+	it("handles unicode characters", () => {
+		const result = formatJSON(unicodeData);
+		expect(result).toContain("🚀");
+		expect(result).toContain("日本語テスト");
+	});
+});
+
+describe("formatYAML", () => {
+	it("formats standard object", () => {
+		const result = formatYAML(standardResource);
+		expect(result).toContain("name: test-resource");
+		expect(result).toContain("namespace: default");
+		expect(result).toContain("status: ACTIVE");
+	});
+
+	it("formats nested structures", () => {
+		const result = formatYAML(nestedData);
+		expect(result).toContain("level1:");
+		expect(result).toContain("level2:");
+		expect(result).toContain("deeply nested");
+	});
+
+	it("formats arrays", () => {
+		const result = formatYAML(resourceList);
+		expect(result).toContain("- name:");
+	});
+
+	it("handles null value", () => {
+		const result = formatYAML(null);
+		expect(result.trim()).toBe("null");
+	});
+
+	it("handles empty array", () => {
+		const result = formatYAML([]);
+		expect(result.trim()).toBe("[]");
+	});
+
+	it("handles empty object", () => {
+		const result = formatYAML({});
+		expect(result.trim()).toBe("{}");
+	});
+
+	it("handles unicode characters", () => {
+		const result = formatYAML(unicodeData);
+		expect(result).toContain("🚀");
+		expect(result).toContain("日本語テスト");
+	});
+
+	it("escapes special YAML characters", () => {
+		const data = { key: "value: with colon" };
+		const result = formatYAML(data);
+		// YAML should properly handle the colon in the value
+		expect(result).toContain("value: with colon");
+	});
+});
+
+describe("formatTSV", () => {
+	it("formats array of objects as TSV", () => {
+		const result = formatTSV(resourceList);
+		const lines = result.split("\n");
+		expect(lines.length).toBe(3);
+		expect(lines[0]).toContain("\t");
+	});
+
+	it("prioritizes common columns (name, namespace, status)", () => {
+		const result = formatTSV(resourceList);
+		const firstLine = result.split("\n")[0];
+		const columns = firstLine?.split("\t") ?? [];
+		// Name should appear early
+		expect(columns.some((col) => col?.includes("resource-1"))).toBe(true);
+	});
+
+	it("handles items wrapper", () => {
+		const result = formatTSV(wrappedItems);
+		expect(result).toContain("resource-1");
+		expect(result.split("\n").length).toBe(3);
+	});
+
+	it("returns empty string for empty data", () => {
+		expect(formatTSV(emptyData.emptyArray)).toBe("");
+		expect(formatTSV(emptyData.emptyItems)).toBe("");
+	});
+
+	it("handles null values in objects", () => {
+		const data = [{ name: "test", value: null }];
+		const result = formatTSV(data);
+		expect(result).toContain("test");
+	});
+
+	it("stringifies nested objects", () => {
+		const data = [{ name: "test", nested: { key: "value" } }];
+		const result = formatTSV(data);
+		expect(result).toContain('{"key":"value"}');
+	});
+
+	it("handles single item", () => {
+		const result = formatTSV(standardResource);
+		expect(result).toContain("test-resource");
+	});
+});
+
+describe("formatAPIError", () => {
+	it("formats 401 unauthorized error", () => {
+		const { statusCode, body, operation } = apiErrorResponses.unauthorized;
+		const result = formatAPIError(statusCode, body, operation);
+
+		expect(result).toContain("ERROR: list resources failed (HTTP 401)");
+		expect(result).toContain("Invalid API token");
+		expect(result).toContain("UNAUTHORIZED");
+		expect(result).toContain("Authentication failed");
+	});
+
+	it("formats 403 forbidden error", () => {
+		const { statusCode, body, operation } = apiErrorResponses.forbidden;
+		const result = formatAPIError(statusCode, body, operation);
+
+		expect(result).toContain("ERROR: get resource failed (HTTP 403)");
+		expect(result).toContain("Permission denied");
+	});
+
+	it("formats 404 not found error", () => {
+		const { statusCode, body, operation } = apiErrorResponses.notFound;
+		const result = formatAPIError(statusCode, body, operation);
+
+		expect(result).toContain("ERROR: get resource failed (HTTP 404)");
+		expect(result).toContain("Resource not found");
+		expect(result).toContain("Verify the name and namespace");
+	});
+
+	it("formats 409 conflict error", () => {
+		const { statusCode, body, operation } = apiErrorResponses.conflict;
+		const result = formatAPIError(statusCode, body, operation);
+
+		expect(result).toContain("ERROR: create resource failed (HTTP 409)");
+		expect(result).toContain("Conflict");
+	});
+
+	it("formats 429 rate limit error", () => {
+		const { statusCode, body, operation } = apiErrorResponses.rateLimit;
+		const result = formatAPIError(statusCode, body, operation);
+
+		expect(result).toContain("ERROR: list resources failed (HTTP 429)");
+		expect(result).toContain("Rate limited");
+	});
+
+	it("formats 500 server error", () => {
+		const { statusCode, body, operation } = apiErrorResponses.serverError;
+		const result = formatAPIError(statusCode, body, operation);
+
+		expect(result).toContain("ERROR: update resource failed (HTTP 500)");
+		expect(result).toContain("Server error");
+		expect(result).toContain("Database timeout");
+	});
+
+	it("handles error without body", () => {
+		const result = formatAPIError(500, null, "test operation");
+		expect(result).toContain("ERROR: test operation failed (HTTP 500)");
+	});
+
+	it("handles error with only message", () => {
+		const result = formatAPIError(400, { message: "Bad request" }, "test");
+		expect(result).toContain("Bad request");
+	});
+});
+
+describe("parseOutputFormat", () => {
+	it("parses json format", () => {
+		expect(parseOutputFormat("json")).toBe("json");
+		expect(parseOutputFormat("JSON")).toBe("json");
+	});
+
+	it("parses yaml format", () => {
+		expect(parseOutputFormat("yaml")).toBe("yaml");
+		expect(parseOutputFormat("YAML")).toBe("yaml");
+	});
+
+	it("parses table format", () => {
+		expect(parseOutputFormat("table")).toBe("table");
+		expect(parseOutputFormat("text")).toBe("table");
+		expect(parseOutputFormat("")).toBe("table");
+	});
+
+	it("parses tsv format", () => {
+		expect(parseOutputFormat("tsv")).toBe("tsv");
+		expect(parseOutputFormat("TSV")).toBe("tsv");
+	});
+
+	it("parses none format", () => {
+		expect(parseOutputFormat("none")).toBe("none");
+	});
+
+	it("returns table for invalid format", () => {
+		expect(parseOutputFormat("invalid")).toBe("table");
+		expect(parseOutputFormat("xml")).toBe("table");
+	});
+});

--- a/tests/unit/output-resolver.test.ts
+++ b/tests/unit/output-resolver.test.ts
@@ -1,0 +1,402 @@
+/**
+ * Output Resolver Tests
+ * Tests for format resolution and flag parsing
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+	resolveOutputFormat,
+	getOutputFormatFromEnv,
+	parseOutputFlag,
+	parseSpecFlag,
+	parseOutputFlags,
+	shouldUseColors,
+	buildOutputContext,
+	OUTPUT_FORMAT_ENV_VAR,
+} from "../../src/output/resolver.js";
+import type { OutputContext } from "../../src/output/types.js";
+
+describe("resolveOutputFormat", () => {
+	describe("precedence order", () => {
+		it("CLI flag takes highest precedence", () => {
+			const context: OutputContext = {
+				cliFormat: "json",
+				envFormat: "yaml",
+				configFormat: "tsv",
+				isInteractive: false,
+				isTTY: true,
+			};
+			expect(resolveOutputFormat(context)).toBe("json");
+		});
+
+		it("env format is second priority", () => {
+			const context: OutputContext = {
+				envFormat: "yaml",
+				configFormat: "tsv",
+				isInteractive: false,
+				isTTY: true,
+			};
+			expect(resolveOutputFormat(context)).toBe("yaml");
+		});
+
+		it("config format is third priority", () => {
+			const context: OutputContext = {
+				configFormat: "tsv",
+				isInteractive: false,
+				isTTY: true,
+			};
+			expect(resolveOutputFormat(context)).toBe("tsv");
+		});
+
+		it("defaults to table when no format specified", () => {
+			const context: OutputContext = {
+				isInteractive: false,
+				isTTY: true,
+			};
+			expect(resolveOutputFormat(context)).toBe("table");
+		});
+	});
+
+	describe("format types", () => {
+		it("resolves json format", () => {
+			const context: OutputContext = {
+				cliFormat: "json",
+				isInteractive: false,
+				isTTY: true,
+			};
+			expect(resolveOutputFormat(context)).toBe("json");
+		});
+
+		it("resolves yaml format", () => {
+			const context: OutputContext = {
+				cliFormat: "yaml",
+				isInteractive: false,
+				isTTY: true,
+			};
+			expect(resolveOutputFormat(context)).toBe("yaml");
+		});
+
+		it("resolves table format", () => {
+			const context: OutputContext = {
+				cliFormat: "table",
+				isInteractive: false,
+				isTTY: true,
+			};
+			expect(resolveOutputFormat(context)).toBe("table");
+		});
+
+		it("resolves tsv format", () => {
+			const context: OutputContext = {
+				cliFormat: "tsv",
+				isInteractive: false,
+				isTTY: true,
+			};
+			expect(resolveOutputFormat(context)).toBe("tsv");
+		});
+
+		it("resolves none format", () => {
+			const context: OutputContext = {
+				cliFormat: "none",
+				isInteractive: false,
+				isTTY: true,
+			};
+			expect(resolveOutputFormat(context)).toBe("none");
+		});
+	});
+});
+
+describe("getOutputFormatFromEnv", () => {
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it("returns undefined when env var not set", () => {
+		vi.stubEnv(OUTPUT_FORMAT_ENV_VAR, "");
+		expect(getOutputFormatFromEnv()).toBeUndefined();
+	});
+
+	it("parses json format", () => {
+		vi.stubEnv(OUTPUT_FORMAT_ENV_VAR, "json");
+		expect(getOutputFormatFromEnv()).toBe("json");
+	});
+
+	it("parses yaml format", () => {
+		vi.stubEnv(OUTPUT_FORMAT_ENV_VAR, "yaml");
+		expect(getOutputFormatFromEnv()).toBe("yaml");
+	});
+
+	it("handles uppercase format", () => {
+		vi.stubEnv(OUTPUT_FORMAT_ENV_VAR, "JSON");
+		expect(getOutputFormatFromEnv()).toBe("json");
+	});
+
+	it("handles format with whitespace", () => {
+		vi.stubEnv(OUTPUT_FORMAT_ENV_VAR, "  json  ");
+		expect(getOutputFormatFromEnv()).toBe("json");
+	});
+
+	it("returns undefined for invalid format", () => {
+		vi.stubEnv(OUTPUT_FORMAT_ENV_VAR, "invalid");
+		expect(getOutputFormatFromEnv()).toBeUndefined();
+	});
+});
+
+describe("parseOutputFlag", () => {
+	describe("long form --output", () => {
+		it("parses --output json", () => {
+			const result = parseOutputFlag(["--output", "json"]);
+			expect(result.format).toBe("json");
+			expect(result.remainingArgs).toEqual([]);
+		});
+
+		it("parses --output yaml", () => {
+			const result = parseOutputFlag(["--output", "yaml"]);
+			expect(result.format).toBe("yaml");
+		});
+
+		it("parses --output=json (equals form)", () => {
+			const result = parseOutputFlag(["--output=json"]);
+			expect(result.format).toBe("json");
+			expect(result.remainingArgs).toEqual([]);
+		});
+
+		it("preserves other arguments", () => {
+			const result = parseOutputFlag([
+				"--name",
+				"test",
+				"--output",
+				"json",
+				"--namespace",
+				"default",
+			]);
+			expect(result.format).toBe("json");
+			expect(result.remainingArgs).toEqual([
+				"--name",
+				"test",
+				"--namespace",
+				"default",
+			]);
+		});
+	});
+
+	describe("short form -o", () => {
+		it("parses -o json", () => {
+			const result = parseOutputFlag(["-o", "json"]);
+			expect(result.format).toBe("json");
+			expect(result.remainingArgs).toEqual([]);
+		});
+
+		it("parses -o=yaml (equals form)", () => {
+			const result = parseOutputFlag(["-o=yaml"]);
+			expect(result.format).toBe("yaml");
+		});
+	});
+
+	describe("edge cases", () => {
+		it("returns undefined when no output flag", () => {
+			const result = parseOutputFlag(["--name", "test"]);
+			expect(result.format).toBeUndefined();
+			expect(result.remainingArgs).toEqual(["--name", "test"]);
+		});
+
+		it("handles --output without value", () => {
+			const result = parseOutputFlag(["--output"]);
+			expect(result.format).toBeUndefined();
+		});
+
+		it("handles --output followed by another flag", () => {
+			const result = parseOutputFlag(["--output", "--name", "test"]);
+			expect(result.format).toBeUndefined();
+			expect(result.remainingArgs).toContain("--name");
+		});
+
+		it("ignores invalid format values", () => {
+			const result = parseOutputFlag(["--output", "invalid"]);
+			expect(result.format).toBeUndefined();
+		});
+
+		it("handles empty array", () => {
+			const result = parseOutputFlag([]);
+			expect(result.format).toBeUndefined();
+			expect(result.remainingArgs).toEqual([]);
+		});
+
+		it("handles case insensitivity", () => {
+			const result = parseOutputFlag(["--output", "JSON"]);
+			expect(result.format).toBe("json");
+		});
+	});
+});
+
+describe("parseSpecFlag", () => {
+	it("detects --spec flag", () => {
+		const result = parseSpecFlag(["--spec"]);
+		expect(result.spec).toBe(true);
+		expect(result.remainingArgs).toEqual([]);
+	});
+
+	it("removes --spec from remaining args", () => {
+		const result = parseSpecFlag(["--name", "test", "--spec", "--namespace", "default"]);
+		expect(result.spec).toBe(true);
+		expect(result.remainingArgs).toEqual(["--name", "test", "--namespace", "default"]);
+	});
+
+	it("returns false when no --spec", () => {
+		const result = parseSpecFlag(["--name", "test"]);
+		expect(result.spec).toBe(false);
+		expect(result.remainingArgs).toEqual(["--name", "test"]);
+	});
+
+	it("handles empty array", () => {
+		const result = parseSpecFlag([]);
+		expect(result.spec).toBe(false);
+		expect(result.remainingArgs).toEqual([]);
+	});
+});
+
+describe("parseOutputFlags", () => {
+	it("parses both --output and --spec", () => {
+		const result = parseOutputFlags(["--output", "json", "--spec"]);
+		expect(result.format).toBe("json");
+		expect(result.spec).toBe(true);
+		expect(result.remainingArgs).toEqual([]);
+	});
+
+	it("handles --output only", () => {
+		const result = parseOutputFlags(["--output", "yaml"]);
+		expect(result.format).toBe("yaml");
+		expect(result.spec).toBe(false);
+	});
+
+	it("handles --spec only", () => {
+		const result = parseOutputFlags(["--spec"]);
+		expect(result.format).toBeUndefined();
+		expect(result.spec).toBe(true);
+	});
+
+	it("preserves other arguments", () => {
+		const result = parseOutputFlags([
+			"--name",
+			"test",
+			"--output",
+			"json",
+			"--spec",
+			"--ns",
+			"default",
+		]);
+		expect(result.format).toBe("json");
+		expect(result.spec).toBe(true);
+		expect(result.remainingArgs).toEqual(["--name", "test", "--ns", "default"]);
+	});
+});
+
+describe("shouldUseColors", () => {
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	describe("noColor flag", () => {
+		it("returns false when noColorFlag is true", () => {
+			expect(shouldUseColors(true, true)).toBe(false);
+		});
+
+		it("ignores TTY when noColorFlag is true", () => {
+			expect(shouldUseColors(true, true)).toBe(false);
+		});
+	});
+
+	describe("NO_COLOR environment variable", () => {
+		it("returns false when NO_COLOR is set", () => {
+			vi.stubEnv("NO_COLOR", "1");
+			expect(shouldUseColors(true, false)).toBe(false);
+		});
+
+		it("returns false when NO_COLOR is empty string", () => {
+			vi.stubEnv("NO_COLOR", "");
+			expect(shouldUseColors(true, false)).toBe(false);
+		});
+	});
+
+	describe("FORCE_COLOR environment variable", () => {
+		it("returns true when FORCE_COLOR is set", () => {
+			vi.stubEnv("FORCE_COLOR", "1");
+			expect(shouldUseColors(false, false)).toBe(true);
+		});
+
+		it("FORCE_COLOR overrides non-TTY", () => {
+			vi.stubEnv("FORCE_COLOR", "1");
+			expect(shouldUseColors(false, false)).toBe(true);
+		});
+	});
+
+	describe("TTY detection", () => {
+		it("returns true for TTY without flags", () => {
+			expect(shouldUseColors(true, false)).toBe(true);
+		});
+
+		it("returns false for non-TTY without FORCE_COLOR", () => {
+			expect(shouldUseColors(false, false)).toBe(false);
+		});
+	});
+
+	describe("precedence", () => {
+		it("noColorFlag takes precedence over FORCE_COLOR", () => {
+			vi.stubEnv("FORCE_COLOR", "1");
+			expect(shouldUseColors(true, true)).toBe(false);
+		});
+
+		it("NO_COLOR takes precedence over FORCE_COLOR", () => {
+			vi.stubEnv("NO_COLOR", "1");
+			vi.stubEnv("FORCE_COLOR", "1");
+			expect(shouldUseColors(true, false)).toBe(false);
+		});
+	});
+});
+
+describe("buildOutputContext", () => {
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it("builds context with CLI format", () => {
+		const context = buildOutputContext({ cliFormat: "json" });
+		expect(context.cliFormat).toBe("json");
+	});
+
+	it("builds context with config format", () => {
+		const context = buildOutputContext({ configFormat: "yaml" });
+		expect(context.configFormat).toBe("yaml");
+	});
+
+	it("includes env format when set", () => {
+		vi.stubEnv(OUTPUT_FORMAT_ENV_VAR, "tsv");
+		const context = buildOutputContext();
+		expect(context.envFormat).toBe("tsv");
+	});
+
+	it("sets isInteractive", () => {
+		const context = buildOutputContext({ isInteractive: true });
+		expect(context.isInteractive).toBe(true);
+	});
+
+	it("sets noColor", () => {
+		const context = buildOutputContext({ noColor: true });
+		expect(context.noColor).toBe(true);
+	});
+
+	it("defaults isInteractive to false", () => {
+		const context = buildOutputContext();
+		expect(context.isInteractive).toBe(false);
+	});
+
+	it("does not include undefined optional properties", () => {
+		const context = buildOutputContext();
+		expect("cliFormat" in context).toBe(false);
+		expect("configFormat" in context).toBe(false);
+	});
+
+	it("includes isTTY from process.stdout", () => {
+		const context = buildOutputContext();
+		expect(typeof context.isTTY).toBe("boolean");
+	});
+});

--- a/tests/unit/output-table.test.ts
+++ b/tests/unit/output-table.test.ts
@@ -1,0 +1,559 @@
+/**
+ * Table Rendering Tests
+ * Tests for beautiful table formatting with snapshots
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+	formatBeautifulTable,
+	formatResourceTable,
+	formatKeyValueBox,
+	wrapText,
+	DEFAULT_RESOURCE_COLUMNS,
+} from "../../src/output/table.js";
+import type { TableConfig, ColumnDefinition } from "../../src/output/types.js";
+import {
+	resourceList,
+	singleResource,
+	wrappedItems,
+	unicodeResourceList,
+	longTextData,
+	keyValueData,
+	customColumns,
+	customColumnData,
+	generateLargeDataset,
+	generateWideDataset,
+	emptyData,
+} from "./output-test-fixtures.js";
+
+describe("wrapText", () => {
+	it("returns single line for short text", () => {
+		const result = wrapText("short text", 20);
+		expect(result).toEqual(["short text"]);
+	});
+
+	it("wraps at word boundaries", () => {
+		const result = wrapText("hello world test", 10);
+		expect(result.length).toBeGreaterThan(1);
+		expect(result[0]).toBe("hello");
+	});
+
+	it("handles text exactly at max width", () => {
+		const result = wrapText("exactly10c", 10);
+		expect(result).toEqual(["exactly10c"]);
+	});
+
+	it("handles long words without spaces", () => {
+		const result = wrapText("superlongwordwithoutspaces", 10);
+		expect(result.length).toBeGreaterThan(1);
+		// Should break at max width when no spaces
+		expect(result[0]?.length).toBeLessThanOrEqual(10);
+	});
+
+	it("handles empty string", () => {
+		const result = wrapText("", 10);
+		expect(result).toEqual([""]);
+	});
+
+	it("preserves multiple spaces at line start after wrap", () => {
+		const result = wrapText("word1 word2 word3", 6);
+		expect(result.length).toBeGreaterThan(1);
+	});
+});
+
+describe("formatBeautifulTable", () => {
+	beforeEach(() => {
+		vi.stubEnv("NO_COLOR", "1");
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	describe("basic table rendering", () => {
+		it("renders empty string for empty data", () => {
+			const result = formatBeautifulTable([], { columns: [] }, true);
+			expect(result).toBe("");
+		});
+
+		it("renders single row table", () => {
+			const config: TableConfig = {
+				columns: DEFAULT_RESOURCE_COLUMNS,
+			};
+			const result = formatBeautifulTable([singleResource], config, true);
+
+			expect(result).toContain("NAMESPACE");
+			expect(result).toContain("NAME");
+			expect(result).toContain("single-item");
+			expect(result).toContain("system");
+		});
+
+		it("renders multiple row table", () => {
+			const config: TableConfig = {
+				columns: DEFAULT_RESOURCE_COLUMNS,
+			};
+			const result = formatBeautifulTable(resourceList, config, true);
+
+			expect(result).toContain("resource-1");
+			expect(result).toContain("resource-2");
+			expect(result).toContain("resource-3");
+		});
+
+		it("renders table with title", () => {
+			const config: TableConfig = {
+				columns: DEFAULT_RESOURCE_COLUMNS,
+				title: "Resources",
+			};
+			const result = formatBeautifulTable(resourceList, config, true);
+
+			expect(result).toContain("Resources");
+		});
+	});
+
+	describe("column alignment", () => {
+		const alignColumns: ColumnDefinition[] = [
+			{ header: "LEFT", accessor: "left", align: "left" },
+			{ header: "CENTER", accessor: "center", align: "center" },
+			{ header: "RIGHT", accessor: "right", align: "right" },
+		];
+
+		it("handles different column alignments", () => {
+			const data = [{ left: "L", center: "C", right: "R" }];
+			const config: TableConfig = { columns: alignColumns };
+			const result = formatBeautifulTable(data, config, true);
+
+			expect(result).toContain("LEFT");
+			expect(result).toContain("CENTER");
+			expect(result).toContain("RIGHT");
+		});
+	});
+
+	describe("column widths", () => {
+		it("respects minWidth", () => {
+			const columns: ColumnDefinition[] = [
+				{ header: "A", accessor: "a", minWidth: 20 },
+			];
+			const data = [{ a: "x" }];
+			const result = formatBeautifulTable(data, { columns }, true);
+
+			// Column should be at least 20 chars
+			const lines = result.split("\n");
+			const headerLine = lines.find((l) => l.includes("A"));
+			expect(headerLine?.length).toBeGreaterThanOrEqual(20);
+		});
+
+		it("respects maxWidth", () => {
+			const columns: ColumnDefinition[] = [
+				{ header: "A", accessor: "a", maxWidth: 10 },
+			];
+			const data = [{ a: "this is a very long value that should be truncated" }];
+			const result = formatBeautifulTable(
+				data,
+				{ columns, wrapText: true },
+				true,
+			);
+
+			// Value should be wrapped
+			expect(result).toContain("this is a");
+		});
+
+		it("respects fixed width", () => {
+			const columns: ColumnDefinition[] = [
+				{ header: "A", accessor: "a", width: 15 },
+			];
+			const data = [{ a: "value" }];
+			const result = formatBeautifulTable(data, { columns }, true);
+
+			expect(result).toContain("value");
+		});
+	});
+
+	describe("text wrapping", () => {
+		it("wraps long text when enabled", () => {
+			const columns: ColumnDefinition[] = [
+				{ header: "DESC", accessor: "description", maxWidth: 20 },
+			];
+			const data = [{ description: longTextData.description }];
+			const result = formatBeautifulTable(
+				data,
+				{ columns, wrapText: true },
+				true,
+			);
+
+			// Should have multiple lines for the content
+			const lines = result.split("\n");
+			expect(lines.length).toBeGreaterThan(3);
+		});
+
+		it("disables wrapping when wrapText=false", () => {
+			const columns: ColumnDefinition[] = [
+				{ header: "DESC", accessor: "description", maxWidth: 20 },
+			];
+			const data = [{ description: "long text that should not wrap here" }];
+			const result = formatBeautifulTable(
+				data,
+				{ columns, wrapText: false },
+				true,
+			);
+
+			// Content should be truncated, not wrapped
+			const contentLines = result
+				.split("\n")
+				.filter((l) => !l.includes("DESC") && l.includes("|"));
+			expect(contentLines.length).toBeLessThanOrEqual(3);
+		});
+	});
+
+	describe("row separators", () => {
+		it("renders without row separators by default", () => {
+			const config: TableConfig = {
+				columns: DEFAULT_RESOURCE_COLUMNS,
+			};
+			const result = formatBeautifulTable(resourceList, config, true);
+
+			// Table should render without extra separators between data rows
+			expect(result).toContain("resource-1");
+			expect(result).toContain("resource-2");
+			// Get lines and check structure
+			const lines = result.split("\n");
+			expect(lines.length).toBeGreaterThan(3);
+		});
+
+		it("renders with row separators when enabled", () => {
+			const config: TableConfig = {
+				columns: DEFAULT_RESOURCE_COLUMNS,
+				rowSeparators: true,
+			};
+			const result = formatBeautifulTable(resourceList, config, true);
+
+			// Should have more separator lines than without
+			const lines = result.split("\n");
+			const separatorLines = lines.filter(
+				(l) => l.startsWith("+") && l.includes("-"),
+			);
+			// With 3 data rows and row separators, should have 5+ separator lines
+			expect(separatorLines.length).toBeGreaterThanOrEqual(5);
+		});
+	});
+
+	describe("labels formatting", () => {
+		it("formats labels as map[key:value]", () => {
+			const config: TableConfig = {
+				columns: DEFAULT_RESOURCE_COLUMNS,
+			};
+			const result = formatBeautifulTable(resourceList, config, true);
+
+			expect(result).toContain("map[env:prod");
+			expect(result).toContain("team:platform");
+		});
+
+		it("handles empty labels", () => {
+			const config: TableConfig = {
+				columns: DEFAULT_RESOURCE_COLUMNS,
+			};
+			const data = [{ name: "test", namespace: "default", labels: {} }];
+			const result = formatBeautifulTable(data, config, true);
+
+			expect(result).toContain("<None>");
+		});
+	});
+
+	describe("ASCII mode (no colors)", () => {
+		it("uses ASCII box characters", () => {
+			const config: TableConfig = { columns: DEFAULT_RESOURCE_COLUMNS };
+			const result = formatBeautifulTable(resourceList, config, true);
+
+			expect(result).toContain("+");
+			expect(result).toContain("-");
+			expect(result).toContain("|");
+		});
+
+		it("does not include ANSI escape codes", () => {
+			const config: TableConfig = { columns: DEFAULT_RESOURCE_COLUMNS };
+			const result = formatBeautifulTable(resourceList, config, true);
+
+			expect(result).not.toContain("\x1b[");
+		});
+	});
+
+	describe("snapshot tests", () => {
+		it("matches snapshot for standard table", () => {
+			const config: TableConfig = {
+				columns: DEFAULT_RESOURCE_COLUMNS,
+			};
+			const result = formatBeautifulTable(resourceList, config, true);
+			expect(result).toMatchSnapshot("standard-table");
+		});
+
+		it("matches snapshot for single row", () => {
+			const config: TableConfig = {
+				columns: DEFAULT_RESOURCE_COLUMNS,
+			};
+			const result = formatBeautifulTable([singleResource], config, true);
+			expect(result).toMatchSnapshot("single-row-table");
+		});
+
+		it("matches snapshot for table with title", () => {
+			const config: TableConfig = {
+				columns: DEFAULT_RESOURCE_COLUMNS,
+				title: "Test Resources",
+			};
+			const result = formatBeautifulTable(resourceList, config, true);
+			expect(result).toMatchSnapshot("table-with-title");
+		});
+
+		it("matches snapshot for custom columns", () => {
+			const config: TableConfig = {
+				columns: customColumns,
+			};
+			const result = formatBeautifulTable(customColumnData, config, true);
+			expect(result).toMatchSnapshot("custom-columns-table");
+		});
+	});
+});
+
+describe("formatResourceTable", () => {
+	beforeEach(() => {
+		vi.stubEnv("NO_COLOR", "1");
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it("formats array of resources", () => {
+		const result = formatResourceTable(resourceList, true);
+
+		expect(result).toContain("NAMESPACE");
+		expect(result).toContain("NAME");
+		expect(result).toContain("LABELS");
+		expect(result).toContain("resource-1");
+	});
+
+	it("handles items wrapper", () => {
+		const result = formatResourceTable(wrappedItems, true);
+
+		expect(result).toContain("resource-1");
+		expect(result).toContain("resource-2");
+	});
+
+	it("handles single object", () => {
+		const result = formatResourceTable(singleResource, true);
+
+		expect(result).toContain("single-item");
+		expect(result).toContain("system");
+	});
+
+	it("returns empty string for empty array", () => {
+		const result = formatResourceTable([], true);
+		expect(result).toBe("");
+	});
+
+	it("returns empty string for empty items", () => {
+		const result = formatResourceTable(emptyData.emptyItems, true);
+		expect(result).toBe("");
+	});
+
+	it("matches snapshot", () => {
+		const result = formatResourceTable(resourceList, true);
+		expect(result).toMatchSnapshot("resource-table");
+	});
+});
+
+describe("formatKeyValueBox", () => {
+	beforeEach(() => {
+		vi.stubEnv("NO_COLOR", "1");
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it("renders key-value pairs", () => {
+		const result = formatKeyValueBox(keyValueData, "Session Info", true);
+
+		expect(result).toContain("User");
+		expect(result).toContain("admin@example.com");
+		expect(result).toContain("Tenant");
+		expect(result).toContain("acme-corp");
+	});
+
+	it("includes title", () => {
+		const result = formatKeyValueBox(keyValueData, "My Title", true);
+		expect(result).toContain("My Title");
+	});
+
+	it("returns empty string for empty data", () => {
+		const result = formatKeyValueBox([], "Title", true);
+		expect(result).toBe("");
+	});
+
+	it("aligns labels correctly", () => {
+		const data = [
+			{ label: "Short", value: "val1" },
+			{ label: "Longer Label", value: "val2" },
+		];
+		const result = formatKeyValueBox(data, "Test", true);
+
+		// Both colons should align
+		const lines = result.split("\n");
+		const dataLines = lines.filter((l) => l.includes(":"));
+		expect(dataLines.length).toBeGreaterThan(0);
+	});
+
+	it("uses ASCII characters when noColor=true", () => {
+		const result = formatKeyValueBox(keyValueData, "Test", true);
+
+		expect(result).toContain("+");
+		expect(result).not.toContain("\x1b[");
+	});
+
+	it("matches snapshot", () => {
+		const result = formatKeyValueBox(keyValueData, "Session Info", true);
+		expect(result).toMatchSnapshot("key-value-box");
+	});
+});
+
+describe("Unicode handling", () => {
+	beforeEach(() => {
+		vi.stubEnv("NO_COLOR", "1");
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it("handles emoji in table cells", () => {
+		// Use columns that include status to test emoji in that field
+		const columns: ColumnDefinition[] = [
+			{ header: "NAME", accessor: "name", minWidth: 20 },
+			{ header: "STATUS", accessor: "status", minWidth: 15 },
+		];
+		const config: TableConfig = { columns };
+		const result = formatBeautifulTable(unicodeResourceList, config, true);
+
+		expect(result).toContain("🚀");
+		expect(result).toContain("✅");
+		expect(result).toContain("⏳");
+		expect(result).toContain("❌");
+	});
+
+	it("handles CJK characters", () => {
+		const config: TableConfig = {
+			columns: DEFAULT_RESOURCE_COLUMNS,
+		};
+		const result = formatBeautifulTable(unicodeResourceList, config, true);
+
+		expect(result).toContain("日本語");
+		expect(result).toContain("中文");
+	});
+
+	it("matches snapshot for unicode table", () => {
+		const columns: ColumnDefinition[] = [
+			{ header: "NAME", accessor: "name", minWidth: 20 },
+			{ header: "STATUS", accessor: "status", minWidth: 15 },
+		];
+		const config: TableConfig = { columns };
+		const result = formatBeautifulTable(unicodeResourceList, config, true);
+		expect(result).toMatchSnapshot("unicode-table");
+	});
+});
+
+describe("Large datasets", () => {
+	beforeEach(() => {
+		vi.stubEnv("NO_COLOR", "1");
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it("handles 100+ row dataset", () => {
+		const data = generateLargeDataset(100);
+		const config: TableConfig = {
+			columns: DEFAULT_RESOURCE_COLUMNS,
+		};
+		const result = formatBeautifulTable(data, config, true);
+
+		expect(result).toContain("resource-1");
+		expect(result).toContain("resource-100");
+		expect(result.split("\n").length).toBeGreaterThan(100);
+	});
+
+	it("handles wide dataset with many columns", () => {
+		const data = generateWideDataset(10);
+		const columns: ColumnDefinition[] = Array.from({ length: 10 }, (_, i) => ({
+			header: `COL${i + 1}`,
+			accessor: `column_${i + 1}`,
+			maxWidth: 15,
+		}));
+		const config: TableConfig = { columns };
+		const result = formatBeautifulTable(data, config, true);
+
+		expect(result).toContain("COL1");
+		expect(result).toContain("COL10");
+	});
+});
+
+describe("Edge cases", () => {
+	beforeEach(() => {
+		vi.stubEnv("NO_COLOR", "1");
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it("handles null values in cells", () => {
+		const columns: ColumnDefinition[] = [
+			{ header: "NAME", accessor: "name", minWidth: 10 },
+			{ header: "VALUE", accessor: "value", minWidth: 10 },
+		];
+		const data = [{ name: "test", value: null }];
+		const result = formatBeautifulTable(data, { columns }, true);
+
+		// The table shows empty/null values as <None>
+		expect(result).toContain("NAME");
+		expect(result).toContain("VALUE");
+		expect(result).toContain("test");
+	});
+
+	it("handles undefined values in cells", () => {
+		const columns: ColumnDefinition[] = [
+			{ header: "NAME", accessor: "name", minWidth: 10 },
+			{ header: "VALUE", accessor: "value", minWidth: 10 },
+		];
+		const data = [{ name: "test" }]; // value is undefined
+		const result = formatBeautifulTable(data, { columns }, true);
+
+		// The table should render even with missing values
+		expect(result).toContain("NAME");
+		expect(result).toContain("VALUE");
+		expect(result).toContain("test");
+	});
+
+	it("handles accessor function", () => {
+		const columns: ColumnDefinition[] = [
+			{ header: "NAME", accessor: "name" },
+			{
+				header: "CUSTOM",
+				accessor: (row) => `Custom: ${row.name}`,
+			},
+		];
+		const data = [{ name: "test" }];
+		const result = formatBeautifulTable(data, { columns }, true);
+
+		expect(result).toContain("Custom: test");
+	});
+
+	it("handles nested object in cell", () => {
+		const columns: ColumnDefinition[] = [
+			{ header: "NAME", accessor: "name" },
+			{ header: "NESTED", accessor: "nested" },
+		];
+		const data = [{ name: "test", nested: { key: "value" } }];
+		const result = formatBeautifulTable(data, { columns }, true);
+
+		expect(result).toContain('{"key":"value"}');
+	});
+});

--- a/tests/unit/output-test-fixtures.ts
+++ b/tests/unit/output-test-fixtures.ts
@@ -1,0 +1,234 @@
+/**
+ * Output Test Fixtures
+ * Shared test data for output format testing
+ */
+
+/**
+ * Standard F5 XC resource for testing
+ */
+export const standardResource = {
+	name: "test-resource",
+	namespace: "default",
+	status: "ACTIVE",
+	created: "2024-01-15T10:30:00Z",
+};
+
+/**
+ * Resource list for table testing
+ */
+export const resourceList = [
+	{
+		name: "resource-1",
+		namespace: "default",
+		status: "ACTIVE",
+		labels: { env: "prod", team: "platform" },
+	},
+	{
+		name: "resource-2",
+		namespace: "staging",
+		status: "PENDING",
+		labels: { env: "staging" },
+	},
+	{
+		name: "resource-3",
+		namespace: "default",
+		status: "ERROR",
+		labels: {},
+	},
+];
+
+/**
+ * Single resource for single-item tests
+ */
+export const singleResource = {
+	name: "single-item",
+	namespace: "system",
+	status: "ACTIVE",
+	labels: { component: "core" },
+};
+
+/**
+ * Data with items wrapper (API response format)
+ */
+export const wrappedItems = {
+	items: resourceList,
+	metadata: {
+		total: 3,
+		page: 1,
+	},
+};
+
+/**
+ * Unicode test data with emoji and CJK characters
+ */
+export const unicodeData = {
+	name: "Test 🚀",
+	status: "✅ Active",
+	japanese: "日本語テスト",
+	chinese: "中文测试",
+	labels: { emoji: "🎉", type: "unicode" },
+};
+
+/**
+ * Unicode resource list for table testing
+ */
+export const unicodeResourceList = [
+	{ name: "Resource 🚀", namespace: "default", status: "✅ Active", labels: {} },
+	{
+		name: "日本語リソース",
+		namespace: "system",
+		status: "⏳ Pending",
+		labels: {},
+	},
+	{ name: "中文资源", namespace: "staging", status: "❌ Error", labels: {} },
+];
+
+/**
+ * Special characters in values
+ */
+export const specialCharsData = {
+	name: "path/with/slashes",
+	path: '/path/with spaces/and"quotes',
+	regex: "pattern.*[a-z]+",
+	json: '{"nested": "value"}',
+};
+
+/**
+ * Empty and null data variations
+ */
+export const emptyData = {
+	emptyArray: [],
+	emptyObject: {},
+	emptyItems: { items: [] },
+	nullValue: null,
+	undefinedField: { field: undefined },
+};
+
+/**
+ * Nested data for JSON/YAML testing
+ */
+export const nestedData = {
+	level1: {
+		level2: {
+			level3: {
+				level4: {
+					value: "deeply nested",
+				},
+			},
+		},
+	},
+	array: [{ nested: true }, { also: "nested" }],
+	mixed: {
+		string: "value",
+		number: 42,
+		boolean: true,
+		null: null,
+		array: [1, 2, 3],
+	},
+};
+
+/**
+ * Large dataset generator for performance testing
+ */
+export function generateLargeDataset(
+	count: number,
+): Array<Record<string, unknown>> {
+	return Array.from({ length: count }, (_, i) => ({
+		name: `resource-${i + 1}`,
+		namespace: i % 3 === 0 ? "default" : i % 3 === 1 ? "staging" : "prod",
+		status: i % 4 === 0 ? "ACTIVE" : i % 4 === 1 ? "PENDING" : "ERROR",
+		created: new Date(Date.now() - i * 86400000).toISOString(),
+		labels: { index: String(i), batch: String(Math.floor(i / 10)) },
+	}));
+}
+
+/**
+ * Wide dataset with many columns
+ */
+export function generateWideDataset(
+	columns: number,
+): Array<Record<string, unknown>> {
+	const row: Record<string, unknown> = {};
+	for (let i = 0; i < columns; i++) {
+		row[`column_${i + 1}`] = `value_${i + 1}`;
+	}
+	return [row, { ...row }, { ...row }];
+}
+
+/**
+ * Long text for wrapping tests
+ */
+export const longTextData = {
+	name: "resource-with-very-long-name-that-should-wrap",
+	description:
+		"This is a very long description that should definitely wrap across multiple lines when displayed in a table with reasonable column widths.",
+	labels: {
+		"very-long-label-key-name": "very-long-label-value-content",
+		another: "label",
+	},
+};
+
+/**
+ * API error response for error formatting tests
+ */
+export const apiErrorResponses = {
+	unauthorized: {
+		statusCode: 401,
+		body: { message: "Invalid API token", code: "UNAUTHORIZED" },
+		operation: "list resources",
+	},
+	forbidden: {
+		statusCode: 403,
+		body: { message: "Access denied to namespace", code: "FORBIDDEN" },
+		operation: "get resource",
+	},
+	notFound: {
+		statusCode: 404,
+		body: { message: "Resource not found", code: "NOT_FOUND" },
+		operation: "get resource",
+	},
+	conflict: {
+		statusCode: 409,
+		body: { message: "Resource already exists", code: "CONFLICT" },
+		operation: "create resource",
+	},
+	rateLimit: {
+		statusCode: 429,
+		body: { message: "Rate limit exceeded", code: "RATE_LIMITED" },
+		operation: "list resources",
+	},
+	serverError: {
+		statusCode: 500,
+		body: { message: "Internal server error", details: "Database timeout" },
+		operation: "update resource",
+	},
+};
+
+/**
+ * Key-value data for formatKeyValueBox tests
+ */
+export const keyValueData = [
+	{ label: "User", value: "admin@example.com" },
+	{ label: "Tenant", value: "acme-corp" },
+	{ label: "Namespace", value: "default" },
+	{ label: "API URL", value: "https://api.example.com" },
+];
+
+/**
+ * Column definitions for custom table tests
+ */
+export const customColumns = [
+	{ header: "ID", accessor: "id", width: 10 },
+	{ header: "NAME", accessor: "name", minWidth: 15, maxWidth: 30 },
+	{ header: "STATUS", accessor: "status", align: "center" as const },
+	{ header: "COUNT", accessor: "count", align: "right" as const },
+];
+
+/**
+ * Data for custom column tests
+ */
+export const customColumnData = [
+	{ id: "001", name: "First Resource", status: "Active", count: 42 },
+	{ id: "002", name: "Second Resource", status: "Pending", count: 17 },
+	{ id: "003", name: "Third Resource with Long Name", status: "Error", count: 0 },
+];


### PR DESCRIPTION
## Summary

Implement comprehensive test coverage for the output formatting system (`src/output/`), establishing a foundation for iterative output format improvements.

### New Test Files
- `output-formatter.test.ts` - 46 tests for format routing, JSON, YAML, TSV, API errors
- `output-table.test.ts` - 47 tests for table rendering with snapshot testing
- `output-resolver.test.ts` - 53 tests for format resolution precedence
- `output-test-fixtures.ts` - Shared test data including edge cases

### Coverage Achieved
| File | Coverage |
|------|----------|
| formatter.ts | 98% |
| resolver.ts | 100% |
| table.ts | 98.5% |
| types.ts | 100% |

### Test Scenarios
- All 6 output formats (json, yaml, table, text, tsv, spec, none)
- Format resolution precedence (CLI → env → config → default)
- Unicode and emoji handling (🚀, ✅, 日本語)
- Empty/null data edge cases
- Large datasets (100+ rows) and wide tables (10+ columns)
- Color/no-color terminal modes
- API error formatting with HTTP status codes

## Test Plan
- [x] All 146 output tests pass
- [x] All 333 unit tests pass
- [x] Pre-commit hooks pass
- [x] Snapshots generated for visual regression testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #413