### PR TITLE
feat: unified output format system for API-generated domains

### DIFF
--- a/src/output/index.ts
+++ b/src/output/index.ts
@@ -15,6 +15,13 @@ export {
 } from "./formatter.js";
 export type { FormatterConfig } from "./formatter.js";
 
+// Domain-specific formatting (for unified output handling)
+export {
+	formatDomainOutput,
+	parseDomainOutputFlags,
+	type DomainFormatOptions,
+} from "./domain-formatter.js";
+
 // Types
 export type {
 	OutputFormat,

--- a/src/repl/executor.ts
+++ b/src/repl/executor.ts
@@ -22,7 +22,7 @@ import { extensionRegistry } from "../extensions/index.js";
 import { getWhoamiInfo, formatWhoami } from "../domains/login/whoami/index.js";
 import { APIError } from "../api/index.js";
 import {
-	formatOutput,
+	formatDomainOutput,
 	formatAPIError,
 	parseOutputFormat,
 	getCommandSpec,
@@ -1139,10 +1139,13 @@ async function executeAPICommand(
 		// Format output
 		// Priority: CLI flag (--output) > session format (from env var or default)
 		const effectiveFormat = outputFormat ?? session.getOutputFormat();
-		const formatted = formatOutput(result, effectiveFormat, noColor);
+		const formatted = formatDomainOutput(result, {
+			format: effectiveFormat,
+			noColor: noColor ?? false,
+		});
 
 		return {
-			output: formatted ? [formatted] : ["(no output)"],
+			output: formatted.length > 0 ? formatted : ["(no output)"],
 			shouldExit: false,
 			shouldClear: false,
 			contextChanged: false,

--- a/tests/unit/cloudstatus-fixtures.ts
+++ b/tests/unit/cloudstatus-fixtures.ts
@@ -1,0 +1,339 @@
+/**
+ * Cloudstatus Test Fixtures
+ *
+ * Mock API response data matching the Atlassian Statuspage v2 API format
+ * used by F5 Cloud Status (https://www.f5cloudstatus.com/api/v2)
+ */
+
+import type {
+	StatusResponse,
+	SummaryResponse,
+	ComponentsResponse,
+	IncidentsResponse,
+	MaintenancesResponse,
+	Component,
+	Incident,
+	ScheduledMaintenance,
+	PageInfo,
+	Status,
+} from "../../src/cloudstatus/types.js";
+
+// Common page info for all responses
+export const mockPageInfo: PageInfo = {
+	id: "test-page-id",
+	name: "F5 Distributed Cloud Status",
+	url: "https://www.f5cloudstatus.com",
+	time_zone: "UTC",
+	updated_at: "2024-01-15T12:00:00Z",
+};
+
+// Status indicators for different scenarios
+export const mockStatusHealthy: Status = {
+	indicator: "none",
+	description: "All Systems Operational",
+};
+
+export const mockStatusMinor: Status = {
+	indicator: "minor",
+	description: "Minor System Issue",
+};
+
+export const mockStatusMajor: Status = {
+	indicator: "major",
+	description: "Major System Issue",
+};
+
+export const mockStatusCritical: Status = {
+	indicator: "critical",
+	description: "Critical System Outage",
+};
+
+export const mockStatusMaintenance: Status = {
+	indicator: "maintenance",
+	description: "System Under Maintenance",
+};
+
+// StatusResponse fixtures
+export const mockStatusResponse: StatusResponse = {
+	page: mockPageInfo,
+	status: mockStatusHealthy,
+};
+
+export const mockStatusResponseMinor: StatusResponse = {
+	page: mockPageInfo,
+	status: mockStatusMinor,
+};
+
+export const mockStatusResponseMajor: StatusResponse = {
+	page: mockPageInfo,
+	status: mockStatusMajor,
+};
+
+export const mockStatusResponseCritical: StatusResponse = {
+	page: mockPageInfo,
+	status: mockStatusCritical,
+};
+
+export const mockStatusResponseMaintenance: StatusResponse = {
+	page: mockPageInfo,
+	status: mockStatusMaintenance,
+};
+
+// Component fixtures
+export const mockOperationalComponent: Component = {
+	id: "comp-1",
+	name: "F5 XC Console",
+	status: "operational",
+	description: "Main console application",
+	group_id: null,
+	group: false,
+	position: 1,
+	showcase: true,
+	only_show_if_degraded: false,
+	page_id: "test-page-id",
+	start_date: null,
+	created_at: "2023-01-01T00:00:00Z",
+	updated_at: "2024-01-15T12:00:00Z",
+};
+
+export const mockDegradedComponent: Component = {
+	id: "comp-2",
+	name: "API Gateway",
+	status: "degraded_performance",
+	description: "API gateway service",
+	group_id: null,
+	group: false,
+	position: 2,
+	showcase: true,
+	only_show_if_degraded: false,
+	page_id: "test-page-id",
+	start_date: null,
+	created_at: "2023-01-01T00:00:00Z",
+	updated_at: "2024-01-15T12:00:00Z",
+};
+
+export const mockPartialOutageComponent: Component = {
+	id: "comp-3",
+	name: "Load Balancer",
+	status: "partial_outage",
+	description: "Load balancing service",
+	group_id: null,
+	group: false,
+	position: 3,
+	showcase: true,
+	only_show_if_degraded: false,
+	page_id: "test-page-id",
+	start_date: null,
+	created_at: "2023-01-01T00:00:00Z",
+	updated_at: "2024-01-15T12:00:00Z",
+};
+
+export const mockGroupComponent: Component = {
+	id: "group-1",
+	name: "Core Services",
+	status: "operational",
+	description: "Group of core services",
+	group_id: null,
+	group: true,
+	components: ["comp-1", "comp-2"],
+	position: 0,
+	showcase: true,
+	only_show_if_degraded: false,
+	page_id: "test-page-id",
+	start_date: null,
+	created_at: "2023-01-01T00:00:00Z",
+	updated_at: "2024-01-15T12:00:00Z",
+};
+
+// ComponentsResponse fixture
+export const mockComponentsResponse: ComponentsResponse = {
+	page: mockPageInfo,
+	components: [
+		mockGroupComponent,
+		mockOperationalComponent,
+		mockDegradedComponent,
+		mockPartialOutageComponent,
+	],
+};
+
+// All operational components for testing
+export const mockComponentsAllOperational: ComponentsResponse = {
+	page: mockPageInfo,
+	components: [
+		mockGroupComponent,
+		mockOperationalComponent,
+		{ ...mockOperationalComponent, id: "comp-4", name: "DNS Service" },
+	],
+};
+
+// Incident fixtures
+export const mockActiveIncident: Incident = {
+	id: "inc-1",
+	name: "API Latency Issues",
+	status: "investigating",
+	impact: "minor",
+	shortlink: "https://stspg.io/abc123",
+	page_id: "test-page-id",
+	created_at: "2024-01-15T10:00:00Z",
+	updated_at: "2024-01-15T11:00:00Z",
+	started_at: "2024-01-15T10:00:00Z",
+	monitoring_at: null,
+	resolved_at: null,
+	incident_updates: [
+		{
+			id: "update-1",
+			status: "investigating",
+			body: "We are currently investigating increased API response times in the US-East region. Our team is actively working to identify the root cause.",
+			incident_id: "inc-1",
+			created_at: "2024-01-15T11:00:00Z",
+			updated_at: "2024-01-15T11:00:00Z",
+			display_at: "2024-01-15T11:00:00Z",
+			affected_components: [],
+			deliver_notifications: true,
+		},
+	],
+	components: [mockDegradedComponent],
+};
+
+export const mockResolvedIncident: Incident = {
+	id: "inc-2",
+	name: "Console Login Issues",
+	status: "resolved",
+	impact: "major",
+	shortlink: "https://stspg.io/def456",
+	page_id: "test-page-id",
+	created_at: "2024-01-14T08:00:00Z",
+	updated_at: "2024-01-14T12:00:00Z",
+	started_at: "2024-01-14T08:00:00Z",
+	monitoring_at: "2024-01-14T11:00:00Z",
+	resolved_at: "2024-01-14T12:00:00Z",
+	incident_updates: [
+		{
+			id: "update-2",
+			status: "resolved",
+			body: "This incident has been resolved. Login functionality has been restored.",
+			incident_id: "inc-2",
+			created_at: "2024-01-14T12:00:00Z",
+			updated_at: "2024-01-14T12:00:00Z",
+			display_at: "2024-01-14T12:00:00Z",
+			affected_components: [],
+			deliver_notifications: true,
+		},
+	],
+	components: [mockOperationalComponent],
+};
+
+// IncidentsResponse fixtures
+export const mockIncidentsResponse: IncidentsResponse = {
+	page: mockPageInfo,
+	incidents: [mockActiveIncident, mockResolvedIncident],
+};
+
+export const mockIncidentsActiveOnly: IncidentsResponse = {
+	page: mockPageInfo,
+	incidents: [mockActiveIncident],
+};
+
+export const mockIncidentsEmpty: IncidentsResponse = {
+	page: mockPageInfo,
+	incidents: [],
+};
+
+// Maintenance fixtures
+export const mockScheduledMaintenance: ScheduledMaintenance = {
+	id: "maint-1",
+	name: "Planned Infrastructure Upgrade",
+	status: "scheduled",
+	impact: "minor",
+	shortlink: "https://stspg.io/maint123",
+	page_id: "test-page-id",
+	scheduled_for: "2024-01-20T02:00:00Z",
+	scheduled_until: "2024-01-20T06:00:00Z",
+	created_at: "2024-01-10T00:00:00Z",
+	updated_at: "2024-01-10T00:00:00Z",
+	started_at: null,
+	monitoring_at: null,
+	resolved_at: null,
+	incident_updates: [],
+	components: [mockOperationalComponent],
+};
+
+export const mockInProgressMaintenance: ScheduledMaintenance = {
+	id: "maint-2",
+	name: "Database Migration",
+	status: "in_progress",
+	impact: "major",
+	shortlink: "https://stspg.io/maint456",
+	page_id: "test-page-id",
+	scheduled_for: "2024-01-15T02:00:00Z",
+	scheduled_until: "2024-01-15T06:00:00Z",
+	created_at: "2024-01-08T00:00:00Z",
+	updated_at: "2024-01-15T02:30:00Z",
+	started_at: "2024-01-15T02:00:00Z",
+	monitoring_at: null,
+	resolved_at: null,
+	incident_updates: [],
+	components: [mockDegradedComponent],
+};
+
+export const mockCompletedMaintenance: ScheduledMaintenance = {
+	id: "maint-3",
+	name: "Security Patch Deployment",
+	status: "completed",
+	impact: "none",
+	shortlink: "https://stspg.io/maint789",
+	page_id: "test-page-id",
+	scheduled_for: "2024-01-12T02:00:00Z",
+	scheduled_until: "2024-01-12T04:00:00Z",
+	created_at: "2024-01-05T00:00:00Z",
+	updated_at: "2024-01-12T04:00:00Z",
+	started_at: "2024-01-12T02:00:00Z",
+	monitoring_at: "2024-01-12T03:30:00Z",
+	resolved_at: "2024-01-12T04:00:00Z",
+	incident_updates: [],
+	components: [mockOperationalComponent],
+};
+
+// MaintenancesResponse fixtures
+export const mockMaintenancesResponse: MaintenancesResponse = {
+	page: mockPageInfo,
+	scheduled_maintenances: [
+		mockScheduledMaintenance,
+		mockInProgressMaintenance,
+		mockCompletedMaintenance,
+	],
+};
+
+export const mockMaintenancesUpcomingOnly: MaintenancesResponse = {
+	page: mockPageInfo,
+	scheduled_maintenances: [mockScheduledMaintenance],
+};
+
+export const mockMaintenancesEmpty: MaintenancesResponse = {
+	page: mockPageInfo,
+	scheduled_maintenances: [],
+};
+
+// SummaryResponse fixture (combines all)
+export const mockSummaryResponse: SummaryResponse = {
+	page: mockPageInfo,
+	status: mockStatusHealthy,
+	components: [
+		mockGroupComponent,
+		mockOperationalComponent,
+		mockDegradedComponent,
+	],
+	incidents: [mockActiveIncident, mockResolvedIncident],
+	scheduled_maintenances: [
+		mockScheduledMaintenance,
+		mockInProgressMaintenance,
+	],
+};
+
+export const mockSummaryResponseAllClear: SummaryResponse = {
+	page: mockPageInfo,
+	status: mockStatusHealthy,
+	components: [mockGroupComponent, mockOperationalComponent],
+	incidents: [],
+	scheduled_maintenances: [],
+};

--- a/tests/unit/cloudstatus.test.ts
+++ b/tests/unit/cloudstatus.test.ts
@@ -1,0 +1,560 @@
+/**
+ * Cloudstatus Domain Tests
+ *
+ * Comprehensive verification tests for the cloudstatus custom command group.
+ * Tests output format handling, flag behavior, exit codes, and error handling.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { REPLSession } from "../../src/repl/session.js";
+import {
+	mockStatusResponse,
+	mockStatusResponseMinor,
+	mockStatusResponseMajor,
+	mockStatusResponseCritical,
+	mockStatusResponseMaintenance,
+	mockSummaryResponse,
+	mockComponentsResponse,
+	mockIncidentsResponse,
+	mockIncidentsActiveOnly,
+	mockMaintenancesResponse,
+	mockMaintenancesUpcomingOnly,
+} from "./cloudstatus-fixtures.js";
+
+// Mock the cloudstatus client module before importing the domain
+const mockGetStatus = vi.fn();
+const mockGetSummary = vi.fn();
+const mockGetComponents = vi.fn();
+const mockGetIncidents = vi.fn();
+const mockGetUnresolvedIncidents = vi.fn();
+const mockGetMaintenances = vi.fn();
+const mockGetUpcomingMaintenances = vi.fn();
+
+vi.mock("../../src/cloudstatus/index.js", () => ({
+	CloudstatusClient: vi.fn(() => ({
+		getStatus: mockGetStatus,
+		getSummary: mockGetSummary,
+		getComponents: mockGetComponents,
+		getIncidents: mockGetIncidents,
+		getUnresolvedIncidents: mockGetUnresolvedIncidents,
+		getMaintenances: mockGetMaintenances,
+		getUpcomingMaintenances: mockGetUpcomingMaintenances,
+	})),
+	isIncidentActive: (incident: { status: string }) =>
+		incident.status !== "resolved" && incident.status !== "postmortem",
+	isMaintenanceActive: (maint: { status: string }) =>
+		maint.status === "in_progress" || maint.status === "verifying",
+	isMaintenanceUpcoming: (maint: { status: string }) =>
+		maint.status === "scheduled",
+	isMaintenanceCompleted: (maint: { status: string }) =>
+		maint.status === "completed",
+	isComponentDegraded: (comp: { status: string }) =>
+		comp.status !== "operational",
+	isComponentOperational: (comp: { status: string }) =>
+		comp.status === "operational",
+	statusIndicatorToExitCode: (indicator: string) => {
+		switch (indicator) {
+			case "none":
+				return 0;
+			case "minor":
+				return 1;
+			case "major":
+				return 2;
+			case "critical":
+				return 3;
+			case "maintenance":
+				return 4;
+			default:
+				return 0;
+		}
+	},
+}));
+
+// Import after mocking
+import { cloudstatusDomain } from "../../src/domains/cloudstatus/index.js";
+
+// Create mock session with configurable output format
+function createMockSession(outputFormat: string = "table"): REPLSession {
+	return {
+		getOutputFormat: () => outputFormat,
+	} as unknown as REPLSession;
+}
+
+// Get command from domain
+function getCommand(name: string) {
+	return cloudstatusDomain.commands.get(name);
+}
+
+describe("cloudstatus domain", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe("status command", () => {
+		const command = getCommand("status");
+
+		it("returns JSON output with --output json", async () => {
+			mockGetStatus.mockResolvedValueOnce(mockStatusResponse);
+			const session = createMockSession();
+			const result = await command!.execute(["--output", "json"], session);
+
+			expect(result.error).toBeUndefined();
+			expect(result.output.length).toBeGreaterThan(0);
+			const jsonOutput = result.output.join("\n");
+			expect(() => JSON.parse(jsonOutput)).not.toThrow();
+			const parsed = JSON.parse(jsonOutput);
+			expect(parsed.status.indicator).toBe("none");
+		});
+
+		it("returns YAML output with --output yaml", async () => {
+			mockGetStatus.mockResolvedValueOnce(mockStatusResponse);
+			const session = createMockSession();
+			const result = await command!.execute(["--output", "yaml"], session);
+
+			expect(result.error).toBeUndefined();
+			expect(result.output.length).toBeGreaterThan(0);
+			const yamlOutput = result.output.join("\n");
+			expect(yamlOutput).toContain("indicator:");
+			expect(yamlOutput).toContain("none");
+		});
+
+		it("returns TSV output with --output tsv", async () => {
+			mockGetStatus.mockResolvedValueOnce(mockStatusResponse);
+			const session = createMockSession();
+			const result = await command!.execute(["--output", "tsv"], session);
+
+			expect(result.error).toBeUndefined();
+			expect(result.output.length).toBeGreaterThan(0);
+		});
+
+		it("returns table output by default", async () => {
+			mockGetStatus.mockResolvedValueOnce(mockStatusResponse);
+			const session = createMockSession();
+			const result = await command!.execute([], session);
+
+			expect(result.error).toBeUndefined();
+			expect(result.output.length).toBeGreaterThan(0);
+			// Table format has box drawing characters
+			const tableOutput = result.output.join("\n");
+			expect(tableOutput).toContain("STATUS");
+			expect(tableOutput).toContain("DESCRIPTION");
+		});
+
+		it("returns empty array with --output none", async () => {
+			mockGetStatus.mockResolvedValueOnce(mockStatusResponse);
+			const session = createMockSession();
+			const result = await command!.execute(["--output", "none"], session);
+
+			expect(result.error).toBeUndefined();
+			expect(result.output).toEqual([]);
+		});
+
+		it("returns exit code info with --quiet flag", async () => {
+			mockGetStatus.mockResolvedValueOnce(mockStatusResponse);
+			const session = createMockSession();
+			const result = await command!.execute(["--quiet"], session);
+
+			expect(result.error).toBeUndefined();
+			expect(result.output.length).toBe(1);
+			expect(result.output[0]).toContain("Exit code:");
+			expect(result.output[0]).toContain("0");
+		});
+
+		it("returns exit code 0 for healthy status", async () => {
+			mockGetStatus.mockResolvedValueOnce(mockStatusResponse);
+			const session = createMockSession();
+			const result = await command!.execute(["--quiet"], session);
+
+			expect(result.error).toBeUndefined();
+			expect(result.output[0]).toContain("Exit code: 0");
+		});
+
+		it("returns exit code 1 for minor status", async () => {
+			mockGetStatus.mockResolvedValueOnce(mockStatusResponseMinor);
+			const session = createMockSession();
+			const result = await command!.execute(["--quiet"], session);
+
+			expect(result.error).toBeUndefined();
+			expect(result.output[0]).toContain("Exit code: 1");
+		});
+
+		it("returns exit code 2 for major status", async () => {
+			mockGetStatus.mockResolvedValueOnce(mockStatusResponseMajor);
+			const session = createMockSession();
+			const result = await command!.execute(["--quiet"], session);
+
+			expect(result.error).toBeUndefined();
+			expect(result.output[0]).toContain("Exit code: 2");
+		});
+
+		it("returns exit code 3 for critical status", async () => {
+			mockGetStatus.mockResolvedValueOnce(mockStatusResponseCritical);
+			const session = createMockSession();
+			const result = await command!.execute(["--quiet"], session);
+
+			expect(result.error).toBeUndefined();
+			expect(result.output[0]).toContain("Exit code: 3");
+		});
+
+		it("returns exit code 4 for maintenance status", async () => {
+			mockGetStatus.mockResolvedValueOnce(mockStatusResponseMaintenance);
+			const session = createMockSession();
+			const result = await command!.execute(["--quiet"], session);
+
+			expect(result.error).toBeUndefined();
+			expect(result.output[0]).toContain("Exit code: 4");
+		});
+	});
+
+	describe("summary command", () => {
+		const command = getCommand("summary");
+
+		it("returns JSON output with --output json", async () => {
+			mockGetSummary.mockResolvedValueOnce(mockSummaryResponse);
+			const session = createMockSession();
+			const result = await command!.execute(["--output", "json"], session);
+
+			expect(result.error).toBeUndefined();
+			const jsonOutput = result.output.join("\n");
+			expect(() => JSON.parse(jsonOutput)).not.toThrow();
+			const parsed = JSON.parse(jsonOutput);
+			expect(parsed.status).toBeDefined();
+			expect(parsed.components).toBeDefined();
+		});
+
+		it("returns YAML output with --output yaml", async () => {
+			mockGetSummary.mockResolvedValueOnce(mockSummaryResponse);
+			const session = createMockSession();
+			const result = await command!.execute(["--output", "yaml"], session);
+
+			expect(result.error).toBeUndefined();
+			const yamlOutput = result.output.join("\n");
+			expect(yamlOutput).toContain("status:");
+			expect(yamlOutput).toContain("components:");
+		});
+
+		it("returns TSV output with --output tsv", async () => {
+			mockGetSummary.mockResolvedValueOnce(mockSummaryResponse);
+			const session = createMockSession();
+			const result = await command!.execute(["--output", "tsv"], session);
+
+			expect(result.error).toBeUndefined();
+			expect(result.output.length).toBeGreaterThan(0);
+		});
+
+		it("returns full summary by default", async () => {
+			mockGetSummary.mockResolvedValueOnce(mockSummaryResponse);
+			const session = createMockSession();
+			const result = await command!.execute([], session);
+
+			expect(result.error).toBeUndefined();
+			const output = result.output.join("\n");
+			expect(output).toContain("=== OVERALL STATUS ===");
+			expect(output).toContain("=== COMPONENTS ===");
+			expect(output).toContain("=== ACTIVE INCIDENTS ===");
+		});
+
+		it("returns empty array with --output none", async () => {
+			mockGetSummary.mockResolvedValueOnce(mockSummaryResponse);
+			const session = createMockSession();
+			const result = await command!.execute(["--output", "none"], session);
+
+			expect(result.error).toBeUndefined();
+			expect(result.output).toEqual([]);
+		});
+
+		it("returns brief summary with --brief flag", async () => {
+			mockGetSummary.mockResolvedValueOnce(mockSummaryResponse);
+			const session = createMockSession();
+			const result = await command!.execute(["--brief"], session);
+
+			expect(result.error).toBeUndefined();
+			const output = result.output.join("\n");
+			expect(output).toContain("Status:");
+			expect(output).toContain("Components:");
+			expect(output).toContain("Incidents:");
+			expect(output).toContain("Maintenance:");
+			// Brief should not have full section headers
+			expect(output).not.toContain("=== OVERALL STATUS ===");
+		});
+	});
+
+	describe("components command", () => {
+		const command = getCommand("components");
+
+		it("returns JSON output with --output json", async () => {
+			mockGetComponents.mockResolvedValueOnce(mockComponentsResponse);
+			const session = createMockSession();
+			const result = await command!.execute(["--output", "json"], session);
+
+			expect(result.error).toBeUndefined();
+			const jsonOutput = result.output.join("\n");
+			expect(() => JSON.parse(jsonOutput)).not.toThrow();
+			const parsed = JSON.parse(jsonOutput);
+			expect(Array.isArray(parsed)).toBe(true);
+		});
+
+		it("returns YAML output with --output yaml", async () => {
+			mockGetComponents.mockResolvedValueOnce(mockComponentsResponse);
+			const session = createMockSession();
+			const result = await command!.execute(["--output", "yaml"], session);
+
+			expect(result.error).toBeUndefined();
+			const yamlOutput = result.output.join("\n");
+			expect(yamlOutput).toContain("name:");
+			expect(yamlOutput).toContain("status:");
+		});
+
+		it("returns TSV output with --output tsv", async () => {
+			mockGetComponents.mockResolvedValueOnce(mockComponentsResponse);
+			const session = createMockSession();
+			const result = await command!.execute(["--output", "tsv"], session);
+
+			expect(result.error).toBeUndefined();
+			expect(result.output.length).toBeGreaterThan(0);
+		});
+
+		it("returns table output by default", async () => {
+			mockGetComponents.mockResolvedValueOnce(mockComponentsResponse);
+			const session = createMockSession();
+			const result = await command!.execute([], session);
+
+			expect(result.error).toBeUndefined();
+			const output = result.output.join("\n");
+			expect(output).toContain("NAME");
+			expect(output).toContain("STATUS");
+		});
+
+		it("returns empty array with --output none", async () => {
+			mockGetComponents.mockResolvedValueOnce(mockComponentsResponse);
+			const session = createMockSession();
+			const result = await command!.execute(["--output", "none"], session);
+
+			expect(result.error).toBeUndefined();
+			expect(result.output).toEqual([]);
+		});
+
+		it("filters group components from output", async () => {
+			mockGetComponents.mockResolvedValueOnce(mockComponentsResponse);
+			const session = createMockSession();
+			const result = await command!.execute(["--output", "json"], session);
+
+			expect(result.error).toBeUndefined();
+			const jsonOutput = result.output.join("\n");
+			const parsed = JSON.parse(jsonOutput);
+			// Group components should be filtered out
+			const groups = parsed.filter(
+				(c: { group: boolean }) => c.group === true,
+			);
+			expect(groups.length).toBe(0);
+		});
+
+		it("shows only degraded with --degraded-only flag", async () => {
+			mockGetComponents.mockResolvedValueOnce(mockComponentsResponse);
+			const session = createMockSession();
+			const result = await command!.execute(
+				["--degraded-only", "--output", "json"],
+				session,
+			);
+
+			expect(result.error).toBeUndefined();
+			const jsonOutput = result.output.join("\n");
+			const parsed = JSON.parse(jsonOutput);
+			// All components should be non-operational
+			for (const comp of parsed) {
+				expect(comp.status).not.toBe("operational");
+			}
+		});
+	});
+
+	describe("incidents command", () => {
+		const command = getCommand("incidents");
+
+		it("returns JSON output with --output json", async () => {
+			mockGetIncidents.mockResolvedValueOnce(mockIncidentsResponse);
+			const session = createMockSession();
+			const result = await command!.execute(["--output", "json"], session);
+
+			expect(result.error).toBeUndefined();
+			const jsonOutput = result.output.join("\n");
+			expect(() => JSON.parse(jsonOutput)).not.toThrow();
+			const parsed = JSON.parse(jsonOutput);
+			expect(Array.isArray(parsed)).toBe(true);
+		});
+
+		it("returns YAML output with --output yaml", async () => {
+			mockGetIncidents.mockResolvedValueOnce(mockIncidentsResponse);
+			const session = createMockSession();
+			const result = await command!.execute(["--output", "yaml"], session);
+
+			expect(result.error).toBeUndefined();
+			const yamlOutput = result.output.join("\n");
+			expect(yamlOutput).toContain("name:");
+			expect(yamlOutput).toContain("status:");
+		});
+
+		it("returns TSV output with --output tsv", async () => {
+			mockGetIncidents.mockResolvedValueOnce(mockIncidentsResponse);
+			const session = createMockSession();
+			const result = await command!.execute(["--output", "tsv"], session);
+
+			expect(result.error).toBeUndefined();
+			expect(result.output.length).toBeGreaterThan(0);
+		});
+
+		it("returns formatted text by default", async () => {
+			mockGetIncidents.mockResolvedValueOnce(mockIncidentsResponse);
+			const session = createMockSession();
+			const result = await command!.execute([], session);
+
+			expect(result.error).toBeUndefined();
+			const output = result.output.join("\n");
+			expect(output).toMatch(/\[(ACTIVE|RESOLVED)\]/);
+			expect(output).toContain("Impact:");
+		});
+
+		it("returns empty array with --output none", async () => {
+			mockGetIncidents.mockResolvedValueOnce(mockIncidentsResponse);
+			const session = createMockSession();
+			const result = await command!.execute(["--output", "none"], session);
+
+			expect(result.error).toBeUndefined();
+			expect(result.output).toEqual([]);
+		});
+
+		it("shows only active with --active-only flag", async () => {
+			mockGetUnresolvedIncidents.mockResolvedValueOnce(
+				mockIncidentsActiveOnly,
+			);
+			const session = createMockSession();
+			const result = await command!.execute(
+				["--active-only", "--output", "json"],
+				session,
+			);
+
+			expect(result.error).toBeUndefined();
+			const jsonOutput = result.output.join("\n");
+			const parsed = JSON.parse(jsonOutput);
+			// All incidents should be active (not resolved or postmortem)
+			for (const inc of parsed) {
+				expect(inc.status).not.toBe("resolved");
+				expect(inc.status).not.toBe("postmortem");
+			}
+		});
+	});
+
+	describe("maintenance command", () => {
+		const command = getCommand("maintenance");
+
+		it("returns JSON output with --output json", async () => {
+			mockGetMaintenances.mockResolvedValueOnce(mockMaintenancesResponse);
+			const session = createMockSession();
+			const result = await command!.execute(["--output", "json"], session);
+
+			expect(result.error).toBeUndefined();
+			const jsonOutput = result.output.join("\n");
+			expect(() => JSON.parse(jsonOutput)).not.toThrow();
+			const parsed = JSON.parse(jsonOutput);
+			expect(Array.isArray(parsed)).toBe(true);
+		});
+
+		it("returns YAML output with --output yaml", async () => {
+			mockGetMaintenances.mockResolvedValueOnce(mockMaintenancesResponse);
+			const session = createMockSession();
+			const result = await command!.execute(["--output", "yaml"], session);
+
+			expect(result.error).toBeUndefined();
+			const yamlOutput = result.output.join("\n");
+			expect(yamlOutput).toContain("name:");
+			expect(yamlOutput).toContain("status:");
+		});
+
+		it("returns TSV output with --output tsv", async () => {
+			mockGetMaintenances.mockResolvedValueOnce(mockMaintenancesResponse);
+			const session = createMockSession();
+			const result = await command!.execute(["--output", "tsv"], session);
+
+			expect(result.error).toBeUndefined();
+			expect(result.output.length).toBeGreaterThan(0);
+		});
+
+		it("returns formatted text by default", async () => {
+			mockGetMaintenances.mockResolvedValueOnce(mockMaintenancesResponse);
+			const session = createMockSession();
+			const result = await command!.execute([], session);
+
+			expect(result.error).toBeUndefined();
+			const output = result.output.join("\n");
+			expect(output).toMatch(/\[(SCHEDULED|IN PROGRESS)\]/);
+			expect(output).toContain("Scheduled:");
+		});
+
+		it("returns empty array with --output none", async () => {
+			mockGetMaintenances.mockResolvedValueOnce(mockMaintenancesResponse);
+			const session = createMockSession();
+			const result = await command!.execute(["--output", "none"], session);
+
+			expect(result.error).toBeUndefined();
+			expect(result.output).toEqual([]);
+		});
+
+		it("hides completed maintenance by default", async () => {
+			mockGetMaintenances.mockResolvedValueOnce(mockMaintenancesResponse);
+			const session = createMockSession();
+			const result = await command!.execute([], session);
+
+			expect(result.error).toBeUndefined();
+			const output = result.output.join("\n");
+			// Completed maintenance should not appear in default table view
+			expect(output).not.toContain("Security Patch Deployment");
+		});
+
+		it("shows only upcoming with --upcoming flag", async () => {
+			mockGetUpcomingMaintenances.mockResolvedValueOnce(
+				mockMaintenancesUpcomingOnly,
+			);
+			const session = createMockSession();
+			const result = await command!.execute(
+				["--upcoming", "--output", "json"],
+				session,
+			);
+
+			expect(result.error).toBeUndefined();
+			const jsonOutput = result.output.join("\n");
+			const parsed = JSON.parse(jsonOutput);
+			// All maintenance should be scheduled
+			for (const maint of parsed) {
+				expect(maint.status).toBe("scheduled");
+			}
+		});
+	});
+
+	describe("error handling", () => {
+		it("handles API timeout gracefully", async () => {
+			const command = getCommand("status");
+			mockGetStatus.mockRejectedValueOnce(new Error("Request timeout"));
+			const session = createMockSession();
+			const result = await command!.execute([], session);
+
+			expect(result.error).toBeDefined();
+			expect(result.output[0]).toContain("Failed to get status");
+			expect(result.output[0]).toContain("Request timeout");
+		});
+
+		it("handles network errors gracefully", async () => {
+			const command = getCommand("components");
+			mockGetComponents.mockRejectedValueOnce(
+				new Error("Network error: Unable to connect"),
+			);
+			const session = createMockSession();
+			const result = await command!.execute([], session);
+
+			expect(result.error).toBeDefined();
+			expect(result.output[0]).toContain("Failed to get components");
+		});
+	});
+});

--- a/tests/unit/virtual-domain.test.ts
+++ b/tests/unit/virtual-domain.test.ts
@@ -1,0 +1,579 @@
+/**
+ * Virtual Domain Tests
+ *
+ * Comprehensive verification tests for the virtual API-generated domain.
+ * Tests output format handling, flag behavior, and error handling.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { REPLSession } from "../../src/repl/session.js";
+import type { APIClient as APIClientType } from "../../src/api/client.js";
+import type { ContextPath } from "../../src/repl/context.js";
+import {
+	mockVirtualList,
+	mockVirtualGet,
+	mockVirtualEmpty,
+	mockVirtualDelete,
+	mockAPIErrors,
+} from "./virtual-fixtures.js";
+
+// Import executor
+import { executeCommand } from "../../src/repl/executor.js";
+
+// Store the current mock response for API client
+let mockClientResponse: { data: unknown; ok: boolean; statusCode: number } | null = null;
+let mockClientError: Error | null = null;
+
+// Set up mock API response for next client call
+function mockAPIResponse(data: unknown, status = 200) {
+	mockClientResponse = { data, ok: status >= 200 && status < 300, statusCode: status };
+	mockClientError = null;
+}
+
+// Mock error response helper
+function mockAPIErrorResponse(status: number, message: string) {
+	mockClientResponse = null;
+	mockClientError = new Error(message);
+	(mockClientError as Error & { statusCode: number }).statusCode = status;
+}
+
+// Create mock API client that uses the stored response
+function createMockAPIClient(authenticated = true): APIClientType {
+	return {
+		isAuthenticated: () => authenticated,
+		isValidated: () => true,
+		get: vi.fn().mockImplementation(async () => {
+			if (mockClientError) {
+				throw mockClientError;
+			}
+			return mockClientResponse;
+		}),
+		post: vi.fn().mockImplementation(async () => {
+			if (mockClientError) {
+				throw mockClientError;
+			}
+			return mockClientResponse;
+		}),
+		put: vi.fn().mockImplementation(async () => {
+			if (mockClientError) {
+				throw mockClientError;
+			}
+			return mockClientResponse;
+		}),
+		delete: vi.fn().mockImplementation(async () => {
+			if (mockClientError) {
+				throw mockClientError;
+			}
+			return mockClientResponse;
+		}),
+	} as unknown as APIClientType;
+}
+
+// Create mock context - mutable to track domain/action changes
+function createMockContext(initialDomain?: string, initialAction?: string): ContextPath {
+	let domain: string | null = initialDomain ?? null;
+	let action: string | null = initialAction ?? null;
+
+	return {
+		get domain() {
+			return domain;
+		},
+		get action() {
+			return action;
+		},
+		resource: null,
+		isRoot: () => !domain,
+		isAction: () => !!action,
+		isDomain: () => !!domain && !action,
+		setDomain: (d: string) => {
+			domain = d;
+		},
+		setAction: (a: string) => {
+			action = a;
+		},
+		reset: () => {
+			domain = null;
+			action = null;
+		},
+		toString: () =>
+			domain ? (action ? `/${domain}/${action}` : `/${domain}`) : "/",
+	} as unknown as ContextPath;
+}
+
+// Create mock history manager
+function createMockHistory() {
+	return {
+		add: vi.fn(),
+		get: vi.fn().mockReturnValue([]),
+		getAll: vi.fn().mockReturnValue([]),
+		clear: vi.fn(),
+		length: 0,
+	};
+}
+
+// Create mock session - with optional initial domain and action context
+function createMockSession(
+	outputFormat = "table",
+	namespace = "default",
+	authenticated = true,
+	initialDomain?: string,
+	initialAction?: string,
+): REPLSession {
+	const mockClient = createMockAPIClient(authenticated);
+	const mockHistory = createMockHistory();
+	const mockContext = createMockContext(initialDomain, initialAction);
+
+	return {
+		getOutputFormat: () => outputFormat,
+		getNamespace: () => namespace,
+		getAPIClient: () => mockClient,
+		getContextPath: () => mockContext,
+		setOutputFormat: vi.fn(),
+		addToHistory: vi.fn(),
+		getHistory: () => mockHistory,
+	} as unknown as REPLSession;
+}
+
+describe("virtual domain output formatting", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe("list command", () => {
+		it("returns JSON output with --output json", async () => {
+			mockAPIResponse(mockVirtualList);
+			// Start in "virtual > list" action context so command executes immediately
+			const session = createMockSession(
+				"table",
+				"default",
+				true,
+				"virtual",
+				"list",
+			);
+
+			const result = await executeCommand("--output json", session);
+
+			expect(result.error).toBeUndefined();
+			expect(result.output.length).toBeGreaterThan(0);
+			const jsonOutput = result.output.join("\n");
+			expect(() => JSON.parse(jsonOutput)).not.toThrow();
+			const parsed = JSON.parse(jsonOutput);
+			expect(parsed.items).toBeDefined();
+			expect(parsed.items.length).toBe(3);
+		});
+
+		it("returns YAML output with --output yaml", async () => {
+			mockAPIResponse(mockVirtualList);
+			const session = createMockSession(
+				"table",
+				"default",
+				true,
+				"virtual",
+				"list",
+			);
+
+			const result = await executeCommand("--output yaml", session);
+
+			expect(result.error).toBeUndefined();
+			expect(result.output.length).toBeGreaterThan(0);
+			const yamlOutput = result.output.join("\n");
+			expect(yamlOutput).toContain("items:");
+			expect(yamlOutput).toContain("name:");
+		});
+
+		it("returns TSV output with --output tsv", async () => {
+			mockAPIResponse(mockVirtualList);
+			const session = createMockSession(
+				"table",
+				"default",
+				true,
+				"virtual",
+				"list",
+			);
+
+			const result = await executeCommand("--output tsv", session);
+
+			expect(result.error).toBeUndefined();
+			expect(result.output.length).toBeGreaterThan(0);
+		});
+
+		it("returns table output by default", async () => {
+			mockAPIResponse(mockVirtualList);
+			const session = createMockSession(
+				"table",
+				"default",
+				true,
+				"virtual",
+				"list",
+			);
+
+			// Execute with a namespace flag to trigger list without specifying format
+			const result = await executeCommand("--namespace default", session);
+
+			expect(result.error).toBeUndefined();
+			expect(result.output.length).toBeGreaterThan(0);
+			const tableOutput = result.output.join("\n");
+			// Table format has headers
+			expect(tableOutput).toMatch(/NAMESPACE|NAME|LABELS/i);
+		});
+
+		it("returns empty array with --output none", async () => {
+			mockAPIResponse(mockVirtualList);
+			const session = createMockSession(
+				"table",
+				"default",
+				true,
+				"virtual",
+				"list",
+			);
+
+			const result = await executeCommand("--output none", session);
+
+			expect(result.error).toBeUndefined();
+			// With none format, output should be minimal
+			expect(
+				result.output.length === 0 ||
+					result.output[0] === "(no output)",
+			).toBe(true);
+		});
+
+		it("respects session default format", async () => {
+			mockAPIResponse(mockVirtualList);
+			// Session default is json, start in virtual > list context
+			const session = createMockSession(
+				"json",
+				"default",
+				true,
+				"virtual",
+				"list",
+			);
+
+			// Execute with namespace flag to trigger without specifying output format
+			const result = await executeCommand("--namespace default", session);
+
+			expect(result.error).toBeUndefined();
+			const jsonOutput = result.output.join("\n");
+			// Should be valid JSON since session default is json
+			expect(() => JSON.parse(jsonOutput)).not.toThrow();
+		});
+
+		it("handles empty results", async () => {
+			mockAPIResponse(mockVirtualEmpty);
+			const session = createMockSession(
+				"table",
+				"default",
+				true,
+				"virtual",
+				"list",
+			);
+
+			const result = await executeCommand("", session);
+
+			expect(result.error).toBeUndefined();
+		});
+	});
+
+	describe("get command", () => {
+		it("returns JSON output with --output json", async () => {
+			mockAPIResponse(mockVirtualGet);
+			const session = createMockSession(
+				"table",
+				"default",
+				true,
+				"virtual",
+				"get",
+			);
+
+			const result = await executeCommand("http-lb-1 --output json", session);
+
+			expect(result.error).toBeUndefined();
+			const jsonOutput = result.output.join("\n");
+			expect(() => JSON.parse(jsonOutput)).not.toThrow();
+			const parsed = JSON.parse(jsonOutput);
+			expect(parsed.metadata).toBeDefined();
+			expect(parsed.metadata.name).toBe("http-lb-1");
+		});
+
+		it("returns YAML output with --output yaml", async () => {
+			mockAPIResponse(mockVirtualGet);
+			const session = createMockSession(
+				"table",
+				"default",
+				true,
+				"virtual",
+				"get",
+			);
+
+			const result = await executeCommand("http-lb-1 --output yaml", session);
+
+			expect(result.error).toBeUndefined();
+			const yamlOutput = result.output.join("\n");
+			expect(yamlOutput).toContain("metadata:");
+			expect(yamlOutput).toContain("name:");
+		});
+
+		it("returns table output by default", async () => {
+			mockAPIResponse(mockVirtualGet);
+			const session = createMockSession(
+				"table",
+				"default",
+				true,
+				"virtual",
+				"get",
+			);
+
+			const result = await executeCommand("http-lb-1", session);
+
+			expect(result.error).toBeUndefined();
+			expect(result.output.length).toBeGreaterThan(0);
+		});
+
+		it("handles missing resource (404)", async () => {
+			mockAPIErrorResponse(404, "Resource 'http-lb-missing' not found");
+			const session = createMockSession(
+				"table",
+				"default",
+				true,
+				"virtual",
+				"get",
+			);
+
+			const result = await executeCommand("http-lb-missing", session);
+
+			expect(result.error).toBeDefined();
+			const output = result.output.join("\n");
+			expect(output).toContain("not found");
+		});
+
+		it("requires name parameter", async () => {
+			const session = createMockSession(
+				"table",
+				"default",
+				true,
+				"virtual",
+				"get",
+			);
+
+			// Use a flag command to trigger execution without a name
+			const result = await executeCommand("--output json", session);
+
+			expect(result.error).toBeDefined();
+			expect(result.output.join("\n")).toContain("name");
+		});
+	});
+
+	describe("delete command", () => {
+		it("returns success message", async () => {
+			mockAPIResponse(mockVirtualDelete);
+			const session = createMockSession(
+				"table",
+				"default",
+				true,
+				"virtual",
+				"delete",
+			);
+
+			const result = await executeCommand("http-lb-1", session);
+
+			expect(result.error).toBeUndefined();
+		});
+
+		it("handles missing resource (404)", async () => {
+			mockAPIErrorResponse(404, "Resource 'http-lb-missing' not found");
+			const session = createMockSession(
+				"table",
+				"default",
+				true,
+				"virtual",
+				"delete",
+			);
+
+			const result = await executeCommand("http-lb-missing", session);
+
+			expect(result.error).toBeDefined();
+		});
+
+		it("requires name parameter", async () => {
+			const session = createMockSession(
+				"table",
+				"default",
+				true,
+				"virtual",
+				"delete",
+			);
+
+			// Use a flag command to trigger execution without a name
+			const result = await executeCommand("--output json", session);
+
+			expect(result.error).toBeDefined();
+			expect(result.output.join("\n")).toContain("name");
+		});
+	});
+
+	describe("namespace handling", () => {
+		it("uses --namespace flag when provided", async () => {
+			mockAPIResponse(mockVirtualList);
+			const session = createMockSession(
+				"json",
+				"default",
+				true,
+				"virtual",
+				"list",
+			);
+
+			const result = await executeCommand(
+				"--namespace production --output json",
+				session,
+			);
+
+			expect(result.error).toBeUndefined();
+			// Verify output contains expected data
+			const jsonOutput = result.output.join("\n");
+			expect(() => JSON.parse(jsonOutput)).not.toThrow();
+		});
+
+		it("falls back to session namespace", async () => {
+			mockAPIResponse(mockVirtualList);
+			const session = createMockSession(
+				"json",
+				"staging",
+				true,
+				"virtual",
+				"list",
+			);
+
+			const result = await executeCommand("--output json", session);
+
+			expect(result.error).toBeUndefined();
+			// Verify output contains expected data
+			const jsonOutput = result.output.join("\n");
+			expect(() => JSON.parse(jsonOutput)).not.toThrow();
+		});
+
+		it("handles invalid namespace", async () => {
+			mockAPIErrorResponse(404, "Namespace 'nonexistent' not found");
+			const session = createMockSession(
+				"table",
+				"default",
+				true,
+				"virtual",
+				"list",
+			);
+
+			const result = await executeCommand("--namespace nonexistent", session);
+
+			expect(result.error).toBeDefined();
+		});
+	});
+
+	describe("error handling", () => {
+		it("formats 401 unauthorized error", async () => {
+			mockAPIErrorResponse(401, mockAPIErrors.unauthorized.message);
+			const session = createMockSession(
+				"table",
+				"default",
+				true,
+				"virtual",
+				"list",
+			);
+
+			const result = await executeCommand("--namespace default", session);
+
+			expect(result.error).toBeDefined();
+			const output = result.output.join("\n");
+			expect(output).toContain("Unauthorized");
+		});
+
+		it("formats 403 forbidden error", async () => {
+			mockAPIErrorResponse(403, mockAPIErrors.forbidden.message);
+			const session = createMockSession(
+				"table",
+				"default",
+				true,
+				"virtual",
+				"list",
+			);
+
+			const result = await executeCommand("--namespace default", session);
+
+			expect(result.error).toBeDefined();
+			const output = result.output.join("\n");
+			expect(output).toContain("Forbidden");
+		});
+
+		it("formats 404 not found error", async () => {
+			mockAPIErrorResponse(404, mockAPIErrors.notFound.message);
+			const session = createMockSession(
+				"table",
+				"default",
+				true,
+				"virtual",
+				"get",
+			);
+
+			const result = await executeCommand("http-lb-missing", session);
+
+			expect(result.error).toBeDefined();
+			const output = result.output.join("\n");
+			expect(output).toContain("Not Found");
+		});
+
+		it("formats 500 server error", async () => {
+			mockAPIErrorResponse(500, mockAPIErrors.serverError.message);
+			const session = createMockSession(
+				"table",
+				"default",
+				true,
+				"virtual",
+				"list",
+			);
+
+			const result = await executeCommand("--namespace default", session);
+
+			expect(result.error).toBeDefined();
+			const output = result.output.join("\n");
+			expect(output).toContain("Internal Server Error");
+		});
+	});
+
+	describe("authentication handling", () => {
+		it("returns error when not connected", async () => {
+			// Create session with null client but in virtual > list action context
+			const mockContext = createMockContext("virtual", "list");
+			const mockHistory = createMockHistory();
+			const session = {
+				getOutputFormat: () => "table",
+				getNamespace: () => "default",
+				getAPIClient: () => null, // No client = not connected
+				getContextPath: () => mockContext,
+				addToHistory: vi.fn(),
+				getHistory: () => mockHistory,
+			} as unknown as REPLSession;
+
+			const result = await executeCommand("--namespace default", session);
+
+			expect(result.error).toBeDefined();
+			expect(result.output.join("\n")).toContain("Not connected");
+		});
+
+		it("returns error when not authenticated", async () => {
+			// Not authenticated, but in virtual > list action context
+			const session = createMockSession(
+				"table",
+				"default",
+				false,
+				"virtual",
+				"list",
+			);
+
+			const result = await executeCommand("--namespace default", session);
+
+			expect(result.error).toBeDefined();
+			expect(result.output.join("\n")).toContain("Not authenticated");
+		});
+	});
+});

--- a/tests/unit/virtual-fixtures.ts
+++ b/tests/unit/virtual-fixtures.ts
@@ -1,0 +1,189 @@
+/**
+ * Virtual Domain Test Fixtures
+ *
+ * Mock API response data for testing the virtual domain commands.
+ * Based on F5 XC API response format for virtual load balancer resources.
+ */
+
+/**
+ * Mock HTTP Load Balancer list response
+ */
+export const mockVirtualList = {
+	items: [
+		{
+			namespace: "default",
+			name: "http-lb-1",
+			labels: { app: "web", env: "prod" },
+			metadata: {
+				name: "http-lb-1",
+				namespace: "default",
+				uid: "uid-001",
+				creation_timestamp: "2024-01-15T10:00:00Z",
+			},
+		},
+		{
+			namespace: "default",
+			name: "http-lb-2",
+			labels: { app: "api" },
+			metadata: {
+				name: "http-lb-2",
+				namespace: "default",
+				uid: "uid-002",
+				creation_timestamp: "2024-01-16T11:00:00Z",
+			},
+		},
+		{
+			namespace: "default",
+			name: "tcp-lb-1",
+			labels: {},
+			metadata: {
+				name: "tcp-lb-1",
+				namespace: "default",
+				uid: "uid-003",
+				creation_timestamp: "2024-01-17T12:00:00Z",
+			},
+		},
+	],
+};
+
+/**
+ * Mock HTTP Load Balancer get response (single resource)
+ */
+export const mockVirtualGet = {
+	metadata: {
+		name: "http-lb-1",
+		namespace: "default",
+		uid: "uid-001",
+		creation_timestamp: "2024-01-15T10:00:00Z",
+		labels: { app: "web", env: "prod" },
+	},
+	spec: {
+		domains: ["example.com", "www.example.com"],
+		http: {
+			dns_volterra_managed: true,
+		},
+		default_route_pools: [
+			{
+				pool: {
+					name: "origin-pool-1",
+					namespace: "default",
+				},
+				weight: 1,
+			},
+		],
+		advertise_on_public_default_vip: true,
+	},
+	system_metadata: {
+		tenant: "test-tenant",
+		creator_id: "user-123",
+	},
+};
+
+/**
+ * Mock empty list response
+ */
+export const mockVirtualEmpty = {
+	items: [],
+};
+
+/**
+ * Mock delete response
+ */
+export const mockVirtualDelete = {
+	name: "http-lb-1",
+	namespace: "default",
+};
+
+/**
+ * Mock status response
+ */
+export const mockVirtualStatus = {
+	status: {
+		state: "ACTIVE",
+		vip_info: {
+			vip: "203.0.113.10",
+			dns_name: "http-lb-1.example.com",
+		},
+		health_status: "HEALTHY",
+	},
+};
+
+/**
+ * Mock API error responses
+ */
+export const mockAPIErrors = {
+	unauthorized: {
+		code: 401,
+		message: "Unauthorized: Invalid or expired token",
+		details: [],
+	},
+	forbidden: {
+		code: 403,
+		message: "Forbidden: Insufficient permissions to access resource",
+		details: [],
+	},
+	notFound: {
+		code: 404,
+		message: "Not Found: Resource 'http-lb-missing' does not exist",
+		details: [],
+	},
+	conflict: {
+		code: 409,
+		message: "Conflict: Resource 'http-lb-1' already exists",
+		details: [],
+	},
+	serverError: {
+		code: 500,
+		message: "Internal Server Error",
+		details: [],
+	},
+};
+
+/**
+ * Mock namespace list response
+ */
+export const mockNamespaceList = {
+	items: [
+		{ name: "default", uid: "ns-001" },
+		{ name: "production", uid: "ns-002" },
+		{ name: "staging", uid: "ns-003" },
+	],
+};
+
+/**
+ * Create mock API response helper
+ * @param data - Response data
+ * @param status - HTTP status code
+ */
+export function createMockResponse(data: unknown, status = 200) {
+	return {
+		ok: status >= 200 && status < 300,
+		status,
+		statusText: status === 200 ? "OK" : "Error",
+		text: () => Promise.resolve(JSON.stringify(data)),
+		json: () => Promise.resolve(data),
+		headers: new Headers({ "content-type": "application/json" }),
+	};
+}
+
+/**
+ * Create mock error response
+ * @param status - HTTP status code
+ * @param message - Error message
+ */
+export function createMockErrorResponse(status: number, message: string) {
+	const errorData = {
+		code: status,
+		message,
+		details: [],
+	};
+
+	return {
+		ok: false,
+		status,
+		statusText: "Error",
+		text: () => Promise.resolve(JSON.stringify(errorData)),
+		json: () => Promise.resolve(errorData),
+		headers: new Headers({ "content-type": "application/json" }),
+	};
+}


### PR DESCRIPTION
## Summary

Implement unified output formatting for API-generated domains in the executor, aligning them with the same pattern used by custom domains (login, cloudstatus, completion).

## Changes

### Modified Files
- `src/output/index.ts` - Added exports for `formatDomainOutput`, `parseDomainOutputFlags`, and `DomainFormatOptions`
- `src/repl/executor.ts` - Updated `executeAPICommand()` to use `formatDomainOutput()` instead of basic `formatOutput()`

### New Files
- `tests/unit/virtual-fixtures.ts` - Mock API response data for virtual domain testing
- `tests/unit/virtual-domain.test.ts` - Comprehensive test suite (24 tests) for virtual domain output formatting
- `tests/unit/cloudstatus-fixtures.ts` - Mock Atlassian Statuspage API data
- `tests/unit/cloudstatus.test.ts` - Comprehensive test suite (39 tests) for cloudstatus domain

## Technical Details

API-generated domains now use `formatDomainOutput()` which returns `string[]` directly, providing consistent behavior with custom domains.

## Test Coverage
- 24 virtual domain tests (list, get, delete, namespace handling, error handling, authentication)
- 39 cloudstatus domain tests (status, summary, components, incidents, maintenances, output formats)
- All 454+ existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #419