### PR TITLE
fix: documentation workflow asset name mismatch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -167,7 +167,7 @@ jobs:
 
           Write-Host "Latest release: $latestTag"
           $version = $latestTag.TrimStart('v')
-          $expectedAsset = "xcsh_${version}_windows_amd64.zip"
+          $expectedAsset = "xcsh_v${version}_windows_amd64.zip"
 
           Write-Host "Waiting for asset: $expectedAsset"
 
@@ -199,7 +199,7 @@ jobs:
         shell: pwsh
         run: |
           $version = "${{ steps.wait-assets.outputs.version }}"
-          $url = "https://github.com/${{ github.repository }}/releases/download/v$version/xcsh_${version}_windows_amd64.zip"
+          $url = "https://github.com/${{ github.repository }}/releases/download/v$version/xcsh_v${version}_windows_amd64.zip"
 
           Write-Host "Downloading xcsh $version from $url"
 
@@ -489,7 +489,7 @@ jobs:
 
           # Expected asset name for darwin arm64 (what the macOS runner will download)
           VERSION="${LATEST_TAG#v}"
-          EXPECTED_ASSET="xcsh_${VERSION}_darwin_arm64.tar.gz"
+          EXPECTED_ASSET="xcsh_v${VERSION}_darwin_arm64.tar.gz"
 
           echo "Waiting for asset: $EXPECTED_ASSET"
 


### PR DESCRIPTION
## Summary

Fix Documentation workflow failing because it looks for release assets without the `v` prefix in filenames.

### Root Cause
- Expected: `xcsh_1.0.91-..._windows_amd64.zip`
- Actual: `xcsh_v1.0.91-..._windows_amd64.zip`

The release workflow creates assets with `v` prefix but the docs workflow was looking for assets without it.

### Changes
- `.github/workflows/docs.yml`: Fix asset name patterns in 3 locations

## Test Plan
- [x] Pre-commit hooks pass
- [ ] Documentation workflow succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #458