### PR TITLE
feat: add subscription documentation generator and navigation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -819,6 +819,33 @@ jobs:
           echo "Generated documentation directories:"
           ls -la docs/commands/ | head -20
 
+      - name: Generate subscription documentation
+        id: generate-subscription-docs
+        run: |
+          # Find xcsh binary
+          XCSH_PATH=""
+          for path in /opt/homebrew/bin/xcsh /usr/local/bin/xcsh "$HOME/.local/bin/xcsh"; do
+            if [ -x "$path" ]; then
+              XCSH_PATH="$path"
+              break
+            fi
+          done
+
+          if [ -z "$XCSH_PATH" ] || [ ! -x "$XCSH_PATH" ]; then
+            XCSH_PATH=$(find /opt/homebrew/Caskroom/xcsh /usr/local/Caskroom/xcsh -name xcsh -type f 2>/dev/null | head -1 || true)
+          fi
+
+          if [ -n "$XCSH_PATH" ] && [ -x "$XCSH_PATH" ]; then
+            echo "Generating subscription documentation with: $XCSH_PATH"
+            python scripts/generate-subscription-docs.py \
+              --cli-binary "$XCSH_PATH" \
+              --output docs/commands/subscription \
+              --clean
+            echo "✅ Subscription documentation generated successfully"
+          else
+            echo "::warning::xcsh binary not found - skipping subscription documentation"
+          fi
+
       - name: Validate required documentation files
         id: validate-docs
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -50,8 +50,9 @@ sea-config.json
 sea-prep.blob
 
 # Generated documentation (regenerated in CI)
-docs/commands/
+docs/commands/*
 !docs/commands/.gitkeep
+!docs/commands/_nav.yml
 
 # MkDocs build output
 site/

--- a/docs/commands/_nav.yml
+++ b/docs/commands/_nav.yml
@@ -1,0 +1,514 @@
+nav:
+- Commands: commands/index.md
+- Admin Console And Ui:
+  - Admin Console And Ui Overview: commands/admin_console_and_ui/index.md
+  - Add Labels: commands/admin_console_and_ui/add-labels/index.md
+  - Apply: commands/admin_console_and_ui/apply/index.md
+  - Create: commands/admin_console_and_ui/create/index.md
+  - Delete: commands/admin_console_and_ui/delete/index.md
+  - Get: commands/admin_console_and_ui/get/index.md
+  - List: commands/admin_console_and_ui/list/index.md
+  - Patch: commands/admin_console_and_ui/patch/index.md
+  - Remove Labels: commands/admin_console_and_ui/remove-labels/index.md
+  - Replace: commands/admin_console_and_ui/replace/index.md
+  - Status: commands/admin_console_and_ui/status/index.md
+- API:
+  - API Overview: commands/api/index.md
+  - Add Labels: commands/api/add-labels/index.md
+  - Apply: commands/api/apply/index.md
+  - Create: commands/api/create/index.md
+  - Delete: commands/api/delete/index.md
+  - Get: commands/api/get/index.md
+  - List: commands/api/list/index.md
+  - Patch: commands/api/patch/index.md
+  - Remove Labels: commands/api/remove-labels/index.md
+  - Replace: commands/api/replace/index.md
+  - Status: commands/api/status/index.md
+- Authentication:
+  - Authentication Overview: commands/authentication/index.md
+  - Add Labels: commands/authentication/add-labels/index.md
+  - Apply: commands/authentication/apply/index.md
+  - Create: commands/authentication/create/index.md
+  - Delete: commands/authentication/delete/index.md
+  - Get: commands/authentication/get/index.md
+  - List: commands/authentication/list/index.md
+  - Patch: commands/authentication/patch/index.md
+  - Remove Labels: commands/authentication/remove-labels/index.md
+  - Replace: commands/authentication/replace/index.md
+  - Status: commands/authentication/status/index.md
+- BIG-IP:
+  - BIG-IP Overview: commands/bigip/index.md
+  - Add Labels: commands/bigip/add-labels/index.md
+  - Apply: commands/bigip/apply/index.md
+  - Create: commands/bigip/create/index.md
+  - Delete: commands/bigip/delete/index.md
+  - Get: commands/bigip/get/index.md
+  - List: commands/bigip/list/index.md
+  - Patch: commands/bigip/patch/index.md
+  - Remove Labels: commands/bigip/remove-labels/index.md
+  - Replace: commands/bigip/replace/index.md
+  - Status: commands/bigip/status/index.md
+- Billing And Usage:
+  - Billing And Usage Overview: commands/billing_and_usage/index.md
+  - Add Labels: commands/billing_and_usage/add-labels/index.md
+  - Apply: commands/billing_and_usage/apply/index.md
+  - Create: commands/billing_and_usage/create/index.md
+  - Delete: commands/billing_and_usage/delete/index.md
+  - Get: commands/billing_and_usage/get/index.md
+  - List: commands/billing_and_usage/list/index.md
+  - Patch: commands/billing_and_usage/patch/index.md
+  - Remove Labels: commands/billing_and_usage/remove-labels/index.md
+  - Replace: commands/billing_and_usage/replace/index.md
+  - Status: commands/billing_and_usage/status/index.md
+- Blindfold:
+  - Blindfold Overview: commands/blindfold/index.md
+  - Add Labels: commands/blindfold/add-labels/index.md
+  - Apply: commands/blindfold/apply/index.md
+  - Create: commands/blindfold/create/index.md
+  - Delete: commands/blindfold/delete/index.md
+  - Get: commands/blindfold/get/index.md
+  - List: commands/blindfold/list/index.md
+  - Patch: commands/blindfold/patch/index.md
+  - Remove Labels: commands/blindfold/remove-labels/index.md
+  - Replace: commands/blindfold/replace/index.md
+  - Status: commands/blindfold/status/index.md
+- Bot And Threat Defense:
+  - Bot And Threat Defense Overview: commands/bot_and_threat_defense/index.md
+  - Add Labels: commands/bot_and_threat_defense/add-labels/index.md
+  - Apply: commands/bot_and_threat_defense/apply/index.md
+  - Create: commands/bot_and_threat_defense/create/index.md
+  - Delete: commands/bot_and_threat_defense/delete/index.md
+  - Get: commands/bot_and_threat_defense/get/index.md
+  - List: commands/bot_and_threat_defense/list/index.md
+  - Patch: commands/bot_and_threat_defense/patch/index.md
+  - Remove Labels: commands/bot_and_threat_defense/remove-labels/index.md
+  - Replace: commands/bot_and_threat_defense/replace/index.md
+  - Status: commands/bot_and_threat_defense/status/index.md
+- CDN:
+  - CDN Overview: commands/cdn/index.md
+  - Add Labels: commands/cdn/add-labels/index.md
+  - Apply: commands/cdn/apply/index.md
+  - Create: commands/cdn/create/index.md
+  - Delete: commands/cdn/delete/index.md
+  - Get: commands/cdn/get/index.md
+  - List: commands/cdn/list/index.md
+  - Patch: commands/cdn/patch/index.md
+  - Remove Labels: commands/cdn/remove-labels/index.md
+  - Replace: commands/cdn/replace/index.md
+  - Status: commands/cdn/status/index.md
+- CE Management:
+  - CE Management Overview: commands/ce_management/index.md
+  - Add Labels: commands/ce_management/add-labels/index.md
+  - Apply: commands/ce_management/apply/index.md
+  - Create: commands/ce_management/create/index.md
+  - Delete: commands/ce_management/delete/index.md
+  - Get: commands/ce_management/get/index.md
+  - List: commands/ce_management/list/index.md
+  - Patch: commands/ce_management/patch/index.md
+  - Remove Labels: commands/ce_management/remove-labels/index.md
+  - Replace: commands/ce_management/replace/index.md
+  - Status: commands/ce_management/status/index.md
+- Certificates:
+  - Certificates Overview: commands/certificates/index.md
+  - Add Labels: commands/certificates/add-labels/index.md
+  - Apply: commands/certificates/apply/index.md
+  - Create: commands/certificates/create/index.md
+  - Delete: commands/certificates/delete/index.md
+  - Get: commands/certificates/get/index.md
+  - List: commands/certificates/list/index.md
+  - Patch: commands/certificates/patch/index.md
+  - Remove Labels: commands/certificates/remove-labels/index.md
+  - Replace: commands/certificates/replace/index.md
+  - Status: commands/certificates/status/index.md
+- Cloud Infrastructure:
+  - Cloud Infrastructure Overview: commands/cloud_infrastructure/index.md
+  - Add Labels: commands/cloud_infrastructure/add-labels/index.md
+  - Apply: commands/cloud_infrastructure/apply/index.md
+  - Create: commands/cloud_infrastructure/create/index.md
+  - Delete: commands/cloud_infrastructure/delete/index.md
+  - Get: commands/cloud_infrastructure/get/index.md
+  - List: commands/cloud_infrastructure/list/index.md
+  - Patch: commands/cloud_infrastructure/patch/index.md
+  - Remove Labels: commands/cloud_infrastructure/remove-labels/index.md
+  - Replace: commands/cloud_infrastructure/replace/index.md
+  - Status: commands/cloud_infrastructure/status/index.md
+- Cloudstatus:
+  - Cloudstatus Overview: commands/cloudstatus/index.md
+  - Components: commands/cloudstatus/components/index.md
+  - Incidents: commands/cloudstatus/incidents/index.md
+  - Maintenance: commands/cloudstatus/maintenance/index.md
+  - Status: commands/cloudstatus/status/index.md
+  - Summary: commands/cloudstatus/summary/index.md
+- Completion:
+  - Completion Overview: commands/completion/index.md
+  - Bash: commands/completion/bash/index.md
+  - Fish: commands/completion/fish/index.md
+  - Zsh: commands/completion/zsh/index.md
+- Container Services:
+  - Container Services Overview: commands/container_services/index.md
+  - Add Labels: commands/container_services/add-labels/index.md
+  - Apply: commands/container_services/apply/index.md
+  - Create: commands/container_services/create/index.md
+  - Delete: commands/container_services/delete/index.md
+  - Get: commands/container_services/get/index.md
+  - List: commands/container_services/list/index.md
+  - Patch: commands/container_services/patch/index.md
+  - Remove Labels: commands/container_services/remove-labels/index.md
+  - Replace: commands/container_services/replace/index.md
+  - Status: commands/container_services/status/index.md
+- Data And Privacy Security:
+  - Data And Privacy Security Overview: commands/data_and_privacy_security/index.md
+  - Add Labels: commands/data_and_privacy_security/add-labels/index.md
+  - Apply: commands/data_and_privacy_security/apply/index.md
+  - Create: commands/data_and_privacy_security/create/index.md
+  - Delete: commands/data_and_privacy_security/delete/index.md
+  - Get: commands/data_and_privacy_security/get/index.md
+  - List: commands/data_and_privacy_security/list/index.md
+  - Patch: commands/data_and_privacy_security/patch/index.md
+  - Remove Labels: commands/data_and_privacy_security/remove-labels/index.md
+  - Replace: commands/data_and_privacy_security/replace/index.md
+  - Status: commands/data_and_privacy_security/status/index.md
+- Data Intelligence:
+  - Data Intelligence Overview: commands/data_intelligence/index.md
+  - Add Labels: commands/data_intelligence/add-labels/index.md
+  - Apply: commands/data_intelligence/apply/index.md
+  - Create: commands/data_intelligence/create/index.md
+  - Delete: commands/data_intelligence/delete/index.md
+  - Get: commands/data_intelligence/get/index.md
+  - List: commands/data_intelligence/list/index.md
+  - Patch: commands/data_intelligence/patch/index.md
+  - Remove Labels: commands/data_intelligence/remove-labels/index.md
+  - Replace: commands/data_intelligence/replace/index.md
+  - Status: commands/data_intelligence/status/index.md
+- DDOS:
+  - DDOS Overview: commands/ddos/index.md
+  - Add Labels: commands/ddos/add-labels/index.md
+  - Apply: commands/ddos/apply/index.md
+  - Create: commands/ddos/create/index.md
+  - Delete: commands/ddos/delete/index.md
+  - Get: commands/ddos/get/index.md
+  - List: commands/ddos/list/index.md
+  - Patch: commands/ddos/patch/index.md
+  - Remove Labels: commands/ddos/remove-labels/index.md
+  - Replace: commands/ddos/replace/index.md
+  - Status: commands/ddos/status/index.md
+- DNS:
+  - DNS Overview: commands/dns/index.md
+  - Add Labels: commands/dns/add-labels/index.md
+  - Apply: commands/dns/apply/index.md
+  - Create: commands/dns/create/index.md
+  - Delete: commands/dns/delete/index.md
+  - Get: commands/dns/get/index.md
+  - List: commands/dns/list/index.md
+  - Patch: commands/dns/patch/index.md
+  - Remove Labels: commands/dns/remove-labels/index.md
+  - Replace: commands/dns/replace/index.md
+  - Status: commands/dns/status/index.md
+- AI Services:
+  - AI Services Overview: commands/ai_services/index.md
+  - Query: commands/ai_services/query/index.md
+  - Chat: commands/ai_services/chat/index.md
+  - Feedback: commands/ai_services/feedback/index.md
+  - Eval:
+    - Eval Overview: commands/ai_services/eval/index.md
+    - Query: commands/ai_services/eval/query.md
+    - Feedback: commands/ai_services/eval/feedback.md
+- Login:
+  - Login Overview: commands/login/index.md
+  - Banner: commands/login/banner/index.md
+  - Context:
+    - Context Overview: commands/login/context/index.md
+    - List: commands/login/context/list.md
+    - Set: commands/login/context/set.md
+    - Show: commands/login/context/show.md
+  - Profile:
+    - Profile Overview: commands/login/profile/index.md
+    - Create: commands/login/profile/create.md
+    - Delete: commands/login/profile/delete.md
+    - List: commands/login/profile/list.md
+    - Show: commands/login/profile/show.md
+    - Use: commands/login/profile/use.md
+- Subscription:
+  - Subscription Overview: commands/subscription/index.md
+  - Show: commands/subscription/show.md
+  - Plan:
+    - Plan Overview: commands/subscription/plan/index.md
+    - Show: commands/subscription/plan/show.md
+    - List: commands/subscription/plan/list.md
+  - Addon:
+    - Addon Overview: commands/subscription/addon/index.md
+    - List: commands/subscription/addon/list.md
+    - Show: commands/subscription/addon/show.md
+    - Status: commands/subscription/addon/status.md
+  - Quota:
+    - Quota Overview: commands/subscription/quota/index.md
+    - Limits: commands/subscription/quota/limits.md
+    - Usage: commands/subscription/quota/usage.md
+  - Usage:
+    - Usage Overview: commands/subscription/usage/index.md
+    - Current: commands/subscription/usage/current.md
+    - Monthly: commands/subscription/usage/monthly.md
+  - Billing:
+    - Billing Overview: commands/subscription/billing/index.md
+    - Payment:
+      - Payment Overview: commands/subscription/billing/payment/index.md
+      - List: commands/subscription/billing/payment/list.md
+      - Show: commands/subscription/billing/payment/show.md
+    - Invoice:
+      - Invoice Overview: commands/subscription/billing/invoice/index.md
+      - List: commands/subscription/billing/invoice/list.md
+  - Report:
+    - Report Overview: commands/subscription/report/index.md
+    - Summary: commands/subscription/report/summary.md
+- Managed Kubernetes:
+  - Managed Kubernetes Overview: commands/managed_kubernetes/index.md
+  - Add Labels: commands/managed_kubernetes/add-labels/index.md
+  - Apply: commands/managed_kubernetes/apply/index.md
+  - Create: commands/managed_kubernetes/create/index.md
+  - Delete: commands/managed_kubernetes/delete/index.md
+  - Get: commands/managed_kubernetes/get/index.md
+  - List: commands/managed_kubernetes/list/index.md
+  - Patch: commands/managed_kubernetes/patch/index.md
+  - Remove Labels: commands/managed_kubernetes/remove-labels/index.md
+  - Replace: commands/managed_kubernetes/replace/index.md
+  - Status: commands/managed_kubernetes/status/index.md
+- Marketplace:
+  - Marketplace Overview: commands/marketplace/index.md
+  - Add Labels: commands/marketplace/add-labels/index.md
+  - Apply: commands/marketplace/apply/index.md
+  - Create: commands/marketplace/create/index.md
+  - Delete: commands/marketplace/delete/index.md
+  - Get: commands/marketplace/get/index.md
+  - List: commands/marketplace/list/index.md
+  - Patch: commands/marketplace/patch/index.md
+  - Remove Labels: commands/marketplace/remove-labels/index.md
+  - Replace: commands/marketplace/replace/index.md
+  - Status: commands/marketplace/status/index.md
+- Network:
+  - Network Overview: commands/network/index.md
+  - Add Labels: commands/network/add-labels/index.md
+  - Apply: commands/network/apply/index.md
+  - Create: commands/network/create/index.md
+  - Delete: commands/network/delete/index.md
+  - Get: commands/network/get/index.md
+  - List: commands/network/list/index.md
+  - Patch: commands/network/patch/index.md
+  - Remove Labels: commands/network/remove-labels/index.md
+  - Replace: commands/network/replace/index.md
+  - Status: commands/network/status/index.md
+- Network Security:
+  - Network Security Overview: commands/network_security/index.md
+  - Add Labels: commands/network_security/add-labels/index.md
+  - Apply: commands/network_security/apply/index.md
+  - Create: commands/network_security/create/index.md
+  - Delete: commands/network_security/delete/index.md
+  - Get: commands/network_security/get/index.md
+  - List: commands/network_security/list/index.md
+  - Patch: commands/network_security/patch/index.md
+  - Remove Labels: commands/network_security/remove-labels/index.md
+  - Replace: commands/network_security/replace/index.md
+  - Status: commands/network_security/status/index.md
+- Nginx One:
+  - Nginx One Overview: commands/nginx_one/index.md
+  - Add Labels: commands/nginx_one/add-labels/index.md
+  - Apply: commands/nginx_one/apply/index.md
+  - Create: commands/nginx_one/create/index.md
+  - Delete: commands/nginx_one/delete/index.md
+  - Get: commands/nginx_one/get/index.md
+  - List: commands/nginx_one/list/index.md
+  - Patch: commands/nginx_one/patch/index.md
+  - Remove Labels: commands/nginx_one/remove-labels/index.md
+  - Replace: commands/nginx_one/replace/index.md
+  - Status: commands/nginx_one/status/index.md
+- Object Storage:
+  - Object Storage Overview: commands/object_storage/index.md
+  - Add Labels: commands/object_storage/add-labels/index.md
+  - Apply: commands/object_storage/apply/index.md
+  - Create: commands/object_storage/create/index.md
+  - Delete: commands/object_storage/delete/index.md
+  - Get: commands/object_storage/get/index.md
+  - List: commands/object_storage/list/index.md
+  - Patch: commands/object_storage/patch/index.md
+  - Remove Labels: commands/object_storage/remove-labels/index.md
+  - Replace: commands/object_storage/replace/index.md
+  - Status: commands/object_storage/status/index.md
+- Observability:
+  - Observability Overview: commands/observability/index.md
+  - Add Labels: commands/observability/add-labels/index.md
+  - Apply: commands/observability/apply/index.md
+  - Create: commands/observability/create/index.md
+  - Delete: commands/observability/delete/index.md
+  - Get: commands/observability/get/index.md
+  - List: commands/observability/list/index.md
+  - Patch: commands/observability/patch/index.md
+  - Remove Labels: commands/observability/remove-labels/index.md
+  - Replace: commands/observability/replace/index.md
+  - Status: commands/observability/status/index.md
+- Rate Limiting:
+  - Rate Limiting Overview: commands/rate_limiting/index.md
+  - Add Labels: commands/rate_limiting/add-labels/index.md
+  - Apply: commands/rate_limiting/apply/index.md
+  - Create: commands/rate_limiting/create/index.md
+  - Delete: commands/rate_limiting/delete/index.md
+  - Get: commands/rate_limiting/get/index.md
+  - List: commands/rate_limiting/list/index.md
+  - Patch: commands/rate_limiting/patch/index.md
+  - Remove Labels: commands/rate_limiting/remove-labels/index.md
+  - Replace: commands/rate_limiting/replace/index.md
+  - Status: commands/rate_limiting/status/index.md
+- Secops And Incident Response:
+  - Secops And Incident Response Overview: commands/secops_and_incident_response/index.md
+  - Add Labels: commands/secops_and_incident_response/add-labels/index.md
+  - Apply: commands/secops_and_incident_response/apply/index.md
+  - Create: commands/secops_and_incident_response/create/index.md
+  - Delete: commands/secops_and_incident_response/delete/index.md
+  - Get: commands/secops_and_incident_response/get/index.md
+  - List: commands/secops_and_incident_response/list/index.md
+  - Patch: commands/secops_and_incident_response/patch/index.md
+  - Remove Labels: commands/secops_and_incident_response/remove-labels/index.md
+  - Replace: commands/secops_and_incident_response/replace/index.md
+  - Status: commands/secops_and_incident_response/status/index.md
+- Service Mesh:
+  - Service Mesh Overview: commands/service_mesh/index.md
+  - Add Labels: commands/service_mesh/add-labels/index.md
+  - Apply: commands/service_mesh/apply/index.md
+  - Create: commands/service_mesh/create/index.md
+  - Delete: commands/service_mesh/delete/index.md
+  - Get: commands/service_mesh/get/index.md
+  - List: commands/service_mesh/list/index.md
+  - Patch: commands/service_mesh/patch/index.md
+  - Remove Labels: commands/service_mesh/remove-labels/index.md
+  - Replace: commands/service_mesh/replace/index.md
+  - Status: commands/service_mesh/status/index.md
+- Shape:
+  - Shape Overview: commands/shape/index.md
+  - Add Labels: commands/shape/add-labels/index.md
+  - Apply: commands/shape/apply/index.md
+  - Create: commands/shape/create/index.md
+  - Delete: commands/shape/delete/index.md
+  - Get: commands/shape/get/index.md
+  - List: commands/shape/list/index.md
+  - Patch: commands/shape/patch/index.md
+  - Remove Labels: commands/shape/remove-labels/index.md
+  - Replace: commands/shape/replace/index.md
+  - Status: commands/shape/status/index.md
+- Sites:
+  - Sites Overview: commands/sites/index.md
+  - Add Labels: commands/sites/add-labels/index.md
+  - Apply: commands/sites/apply/index.md
+  - Create: commands/sites/create/index.md
+  - Delete: commands/sites/delete/index.md
+  - Get: commands/sites/get/index.md
+  - List: commands/sites/list/index.md
+  - Patch: commands/sites/patch/index.md
+  - Remove Labels: commands/sites/remove-labels/index.md
+  - Replace: commands/sites/replace/index.md
+  - Status: commands/sites/status/index.md
+- Statistics:
+  - Statistics Overview: commands/statistics/index.md
+  - Add Labels: commands/statistics/add-labels/index.md
+  - Apply: commands/statistics/apply/index.md
+  - Create: commands/statistics/create/index.md
+  - Delete: commands/statistics/delete/index.md
+  - Get: commands/statistics/get/index.md
+  - List: commands/statistics/list/index.md
+  - Patch: commands/statistics/patch/index.md
+  - Remove Labels: commands/statistics/remove-labels/index.md
+  - Replace: commands/statistics/replace/index.md
+  - Status: commands/statistics/status/index.md
+- Support:
+  - Support Overview: commands/support/index.md
+  - Add Labels: commands/support/add-labels/index.md
+  - Apply: commands/support/apply/index.md
+  - Create: commands/support/create/index.md
+  - Delete: commands/support/delete/index.md
+  - Get: commands/support/get/index.md
+  - List: commands/support/list/index.md
+  - Patch: commands/support/patch/index.md
+  - Remove Labels: commands/support/remove-labels/index.md
+  - Replace: commands/support/replace/index.md
+  - Status: commands/support/status/index.md
+- Telemetry And Insights:
+  - Telemetry And Insights Overview: commands/telemetry_and_insights/index.md
+  - Add Labels: commands/telemetry_and_insights/add-labels/index.md
+  - Apply: commands/telemetry_and_insights/apply/index.md
+  - Create: commands/telemetry_and_insights/create/index.md
+  - Delete: commands/telemetry_and_insights/delete/index.md
+  - Get: commands/telemetry_and_insights/get/index.md
+  - List: commands/telemetry_and_insights/list/index.md
+  - Patch: commands/telemetry_and_insights/patch/index.md
+  - Remove Labels: commands/telemetry_and_insights/remove-labels/index.md
+  - Replace: commands/telemetry_and_insights/replace/index.md
+  - Status: commands/telemetry_and_insights/status/index.md
+- Tenant And Identity:
+  - Tenant And Identity Overview: commands/tenant_and_identity/index.md
+  - Add Labels: commands/tenant_and_identity/add-labels/index.md
+  - Apply: commands/tenant_and_identity/apply/index.md
+  - Create: commands/tenant_and_identity/create/index.md
+  - Delete: commands/tenant_and_identity/delete/index.md
+  - Get: commands/tenant_and_identity/get/index.md
+  - List: commands/tenant_and_identity/list/index.md
+  - Patch: commands/tenant_and_identity/patch/index.md
+  - Remove Labels: commands/tenant_and_identity/remove-labels/index.md
+  - Replace: commands/tenant_and_identity/replace/index.md
+  - Status: commands/tenant_and_identity/status/index.md
+- Threat Campaign:
+  - Threat Campaign Overview: commands/threat_campaign/index.md
+  - Add Labels: commands/threat_campaign/add-labels/index.md
+  - Apply: commands/threat_campaign/apply/index.md
+  - Create: commands/threat_campaign/create/index.md
+  - Delete: commands/threat_campaign/delete/index.md
+  - Get: commands/threat_campaign/get/index.md
+  - List: commands/threat_campaign/list/index.md
+  - Patch: commands/threat_campaign/patch/index.md
+  - Remove Labels: commands/threat_campaign/remove-labels/index.md
+  - Replace: commands/threat_campaign/replace/index.md
+  - Status: commands/threat_campaign/status/index.md
+- Users:
+  - Users Overview: commands/users/index.md
+  - Add Labels: commands/users/add-labels/index.md
+  - Apply: commands/users/apply/index.md
+  - Create: commands/users/create/index.md
+  - Delete: commands/users/delete/index.md
+  - Get: commands/users/get/index.md
+  - List: commands/users/list/index.md
+  - Patch: commands/users/patch/index.md
+  - Remove Labels: commands/users/remove-labels/index.md
+  - Replace: commands/users/replace/index.md
+  - Status: commands/users/status/index.md
+- Virtual:
+  - Virtual Overview: commands/virtual/index.md
+  - Add Labels: commands/virtual/add-labels/index.md
+  - Apply: commands/virtual/apply/index.md
+  - Create: commands/virtual/create/index.md
+  - Delete: commands/virtual/delete/index.md
+  - Get: commands/virtual/get/index.md
+  - List: commands/virtual/list/index.md
+  - Patch: commands/virtual/patch/index.md
+  - Remove Labels: commands/virtual/remove-labels/index.md
+  - Replace: commands/virtual/replace/index.md
+  - Status: commands/virtual/status/index.md
+- Vpm And Node Management:
+  - Vpm And Node Management Overview: commands/vpm_and_node_management/index.md
+  - Add Labels: commands/vpm_and_node_management/add-labels/index.md
+  - Apply: commands/vpm_and_node_management/apply/index.md
+  - Create: commands/vpm_and_node_management/create/index.md
+  - Delete: commands/vpm_and_node_management/delete/index.md
+  - Get: commands/vpm_and_node_management/get/index.md
+  - List: commands/vpm_and_node_management/list/index.md
+  - Patch: commands/vpm_and_node_management/patch/index.md
+  - Remove Labels: commands/vpm_and_node_management/remove-labels/index.md
+  - Replace: commands/vpm_and_node_management/replace/index.md
+  - Status: commands/vpm_and_node_management/status/index.md
+- WAF:
+  - WAF Overview: commands/waf/index.md
+  - Add Labels: commands/waf/add-labels/index.md
+  - Apply: commands/waf/apply/index.md
+  - Create: commands/waf/create/index.md
+  - Delete: commands/waf/delete/index.md
+  - Get: commands/waf/get/index.md
+  - List: commands/waf/list/index.md
+  - Patch: commands/waf/patch/index.md
+  - Remove Labels: commands/waf/remove-labels/index.md
+  - Replace: commands/waf/replace/index.md
+  - Status: commands/waf/status/index.md

--- a/scripts/generate-subscription-docs.py
+++ b/scripts/generate-subscription-docs.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+"""
+Subscription Documentation Generator
+
+Generates comprehensive documentation for the xcsh subscription command group
+by parsing xcsh --spec JSON output and rendering Jinja2 templates.
+
+Usage:
+    python scripts/generate-subscription-docs.py [--xcsh PATH] [--output DIR] [--clean]
+"""
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+from naming import normalize_acronyms, to_human_readable, to_title_case
+
+
+def load_spec(cli_binary_path: str) -> dict:
+    """Run xcsh --spec and return the full CLI spec."""
+    try:
+        result = subprocess.run(
+            [cli_binary_path, "--spec", "--output-format", "json"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return json.loads(result.stdout)
+    except subprocess.CalledProcessError as e:
+        print(f"Error running xcsh --spec: {e.stderr}", file=sys.stderr)
+        sys.exit(1)
+    except json.JSONDecodeError as e:
+        print(f"Error parsing xcsh --spec output: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def load_subscription_spec(cli_binary_path: str) -> dict:
+    """Run xcsh subscription --spec for extended subscription-specific data."""
+    try:
+        result = subprocess.run(
+            [cli_binary_path, "subscription", "--spec", "--output-format", "json"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return json.loads(result.stdout)
+    except subprocess.CalledProcessError as e:
+        print(f"Note: xcsh subscription --spec not available: {e.stderr}", file=sys.stderr)
+        return {}
+    except json.JSONDecodeError as e:
+        print(f"Error parsing xcsh subscription --spec output: {e}", file=sys.stderr)
+        return {}
+
+
+def find_subscription_command(spec: dict) -> dict | None:
+    """Extract the subscription command from the main spec."""
+    commands = spec.get("commands", [])
+    for cmd in commands:
+        path = cmd.get("path", [])
+        if path == ["subscription"]:
+            return cmd
+    return None
+
+
+def get_command_name(cmd: dict) -> str:
+    """Get the last element of the command path as the name."""
+    path = cmd.get("path", [])
+    return path[-1] if path else ""
+
+
+def get_subcommands(cmd: dict) -> list:
+    """Get direct subcommands of a command."""
+    return cmd.get("subcommands", [])
+
+
+def has_subcommands(cmd: dict) -> bool:
+    """Check if command has subcommands."""
+    return len(get_subcommands(cmd)) > 0
+
+
+def is_leaf_command(cmd: dict) -> bool:
+    """Check if command is a leaf (has no subcommands)."""
+    return not has_subcommands(cmd)
+
+
+def create_front_matter(cmd: dict, command_type: str = "command") -> dict:
+    """Create YAML front matter for a documentation page."""
+    path = cmd.get("path", [])
+    name = get_command_name(cmd)
+    full_command = " ".join(["xcsh"] + path)
+
+    if command_type == "overview":
+        title = "xcsh subscription"
+        description = cmd.get("short", "Subscription and billing management")
+    elif command_type == "group":
+        title = f"xcsh subscription {name}"
+        description = cmd.get("short", f"Manage {to_human_readable(name)}")
+    else:
+        title = f"xcsh subscription {' '.join(path[1:])}"
+        description = cmd.get("short", "")
+
+    keywords = [
+        "xcsh",
+        "F5",
+        "F5 XC",
+        "F5 Distributed Cloud",
+        "subscription",
+        "billing",
+        "quota",
+        name,
+    ]
+
+    aliases = cmd.get("aliases", [])
+    keywords.extend(aliases)
+
+    return {
+        "title": title,
+        "description": normalize_acronyms(description),
+        "keywords": list(set(keywords)),
+        "command": full_command,
+        "command_group": "subscription",
+        "aliases": aliases,
+    }
+
+
+def setup_jinja_env(templates_dir: Path) -> Environment:
+    """Set up Jinja2 environment with custom filters."""
+    env = Environment(
+        loader=FileSystemLoader(templates_dir),
+        autoescape=select_autoescape(),
+        trim_blocks=True,
+        lstrip_blocks=True,
+    )
+
+    env.filters["to_human_readable"] = to_human_readable
+    env.filters["normalize_acronyms"] = normalize_acronyms
+    env.filters["to_title_case"] = to_title_case
+    env.filters["underscore_to_space"] = lambda s: s.replace("_", " ") if s else ""
+
+    return env
+
+
+def generate_overview(
+    env: Environment, subscription_cmd: dict, extended_spec: dict, output_dir: Path
+) -> None:
+    """Generate the main subscription/index.md overview page."""
+    template = env.get_template("subscription.md.j2")
+
+    front_matter = create_front_matter(subscription_cmd, "overview")
+    subcommands = get_subcommands(subscription_cmd)
+
+    leaf_commands = [cmd for cmd in subcommands if is_leaf_command(cmd)]
+    group_commands = [cmd for cmd in subcommands if has_subcommands(cmd)]
+
+    content = template.render(
+        front_matter=front_matter,
+        command=subscription_cmd,
+        subcommands=subcommands,
+        leaf_commands=leaf_commands,
+        group_commands=group_commands,
+        workflows=extended_spec.get("workflows", []),
+        exit_codes=extended_spec.get("exit_codes", []),
+        ai_hints=extended_spec.get("ai_hints", {}),
+    )
+
+    output_file = output_dir / "index.md"
+    output_file.write_text(content)
+    print(f"  Generated: {output_file}")
+
+
+def generate_subcommand_group(env: Environment, cmd: dict, output_dir: Path) -> None:
+    """Generate index.md for a subcommand group."""
+    template = env.get_template("subscription_subcommand.md.j2")
+
+    name = get_command_name(cmd)
+    front_matter = create_front_matter(cmd, "group")
+    subcommands = get_subcommands(cmd)
+
+    content = template.render(
+        front_matter=front_matter,
+        command=cmd,
+        name=name,
+        subcommands=subcommands,
+    )
+
+    subdir = output_dir / name
+    subdir.mkdir(parents=True, exist_ok=True)
+
+    output_file = subdir / "index.md"
+    output_file.write_text(content)
+    print(f"  Generated: {output_file}")
+
+    for subcmd in subcommands:
+        if has_subcommands(subcmd):
+            generate_subcommand_group(env, subcmd, subdir)
+        else:
+            generate_leaf_command(env, subcmd, subdir)
+
+
+def generate_leaf_command(env: Environment, cmd: dict, output_dir: Path) -> None:
+    """Generate documentation for a leaf command."""
+    template = env.get_template("subscription_command.md.j2")
+
+    path = cmd.get("path", [])
+    name = get_command_name(cmd)
+    front_matter = create_front_matter(cmd, "command")
+
+    relative_path = path[1:] if len(path) > 1 else [name]
+
+    content = template.render(
+        front_matter=front_matter,
+        command=cmd,
+        name=name,
+        path=relative_path,
+        flags=cmd.get("flags", []),
+    )
+
+    output_file = output_dir / f"{name}.md"
+    output_file.write_text(content)
+    print(f"  Generated: {output_file}")
+
+
+def generate_standalone_command(env: Environment, cmd: dict, output_dir: Path) -> None:
+    """Generate documentation for a standalone leaf command."""
+    template = env.get_template("subscription_command.md.j2")
+
+    path = cmd.get("path", [])
+    name = get_command_name(cmd)
+    front_matter = create_front_matter(cmd, "command")
+
+    relative_path = path[1:] if len(path) > 1 else [name]
+
+    content = template.render(
+        front_matter=front_matter,
+        command=cmd,
+        name=name,
+        path=relative_path,
+        flags=cmd.get("flags", []),
+    )
+
+    output_file = output_dir / f"{name}.md"
+    output_file.write_text(content)
+    print(f"  Generated: {output_file}")
+
+
+def generate_nav_structure(subscription_cmd: dict) -> list:
+    """Generate the navigation structure for mkdocs.yml."""
+    nav = []
+
+    nav.append({"Subscription Overview": "commands/subscription/index.md"})
+
+    subcommands = get_subcommands(subscription_cmd)
+
+    leaf_commands = sorted(
+        [cmd for cmd in subcommands if is_leaf_command(cmd)], key=lambda c: get_command_name(c)
+    )
+    group_commands = sorted(
+        [cmd for cmd in subcommands if has_subcommands(cmd)], key=lambda c: get_command_name(c)
+    )
+
+    for cmd in leaf_commands:
+        name = get_command_name(cmd)
+        human_name = to_title_case(to_human_readable(name))
+        nav.append({human_name: f"commands/subscription/{name}.md"})
+
+    for cmd in group_commands:
+        name = get_command_name(cmd)
+        human_name = to_title_case(to_human_readable(name))
+        group_nav = [{f"{human_name} Overview": f"commands/subscription/{name}/index.md"}]
+
+        for subcmd in sorted(get_subcommands(cmd), key=lambda c: get_command_name(c)):
+            sub_name = get_command_name(subcmd)
+            sub_human_name = to_title_case(to_human_readable(sub_name))
+
+            if has_subcommands(subcmd):
+                nested_nav = [
+                    {
+                        f"{sub_human_name} Overview": f"commands/subscription/{name}/{sub_name}/index.md"
+                    }
+                ]
+                for nested_cmd in sorted(
+                    get_subcommands(subcmd), key=lambda c: get_command_name(c)
+                ):
+                    nested_name = get_command_name(nested_cmd)
+                    nested_human_name = to_title_case(to_human_readable(nested_name))
+                    nested_nav.append(
+                        {
+                            nested_human_name: f"commands/subscription/{name}/{sub_name}/{nested_name}.md"
+                        }
+                    )
+                group_nav.append({sub_human_name: nested_nav})
+            else:
+                group_nav.append({sub_human_name: f"commands/subscription/{name}/{sub_name}.md"})
+
+        nav.append({human_name: group_nav})
+
+    return nav
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate subscription documentation from CLI --spec"
+    )
+    parser.add_argument(
+        "--cli-binary", default="./xcsh", help="Path to CLI binary (default: ./xcsh)"
+    )
+    parser.add_argument(
+        "--output",
+        default="docs/commands/subscription",
+        help="Output directory (default: docs/commands/subscription)",
+    )
+    parser.add_argument(
+        "--templates",
+        default="scripts/templates",
+        help="Templates directory (default: scripts/templates)",
+    )
+    parser.add_argument(
+        "--clean", action="store_true", help="Clean output directory before generating"
+    )
+    parser.add_argument(
+        "--print-nav", action="store_true", help="Print navigation structure for mkdocs.yml"
+    )
+
+    args = parser.parse_args()
+
+    cli_binary_path = Path(args.cli_binary).resolve()
+    output_dir = Path(args.output)
+    templates_dir = Path(args.templates)
+
+    if not cli_binary_path.exists():
+        print(f"Error: CLI binary not found at {cli_binary_path}", file=sys.stderr)
+        sys.exit(1)
+
+    if not templates_dir.exists():
+        print(f"Error: Templates directory not found at {templates_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Loading spec from {cli_binary_path}...")
+    spec = load_spec(str(cli_binary_path))
+    extended_spec = load_subscription_spec(str(cli_binary_path))
+
+    subscription_cmd = find_subscription_command(spec)
+    if not subscription_cmd:
+        print("Error: subscription command not found in spec", file=sys.stderr)
+        sys.exit(1)
+
+    if args.print_nav:
+        nav = generate_nav_structure(subscription_cmd)
+        import yaml
+
+        print("\n# Navigation structure for mkdocs.yml:")
+        print("- Subscription:")
+        for item in nav:
+            print(f"  {yaml.dump([item], default_flow_style=False).strip()}")
+        return
+
+    if args.clean and output_dir.exists():
+        print(f"Cleaning {output_dir}...")
+        shutil.rmtree(output_dir)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    env = setup_jinja_env(templates_dir)
+
+    print(f"Generating subscription documentation to {output_dir}...")
+
+    generate_overview(env, subscription_cmd, extended_spec, output_dir)
+
+    subcommands = get_subcommands(subscription_cmd)
+
+    for cmd in subcommands:
+        if has_subcommands(cmd):
+            generate_subcommand_group(env, cmd, output_dir)
+        else:
+            generate_standalone_command(env, cmd, output_dir)
+
+    print("\nGenerated documentation for subscription command group")
+    print("\nTo add to mkdocs.yml, run with --print-nav flag")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/templates/subscription.md.j2
+++ b/scripts/templates/subscription.md.j2
@@ -1,0 +1,120 @@
+---
+title: "{{ front_matter.title }}"
+description: "{{ front_matter.description }}"
+keywords:
+{% for kw in front_matter.keywords %}
+  - {{ kw }}
+{% endfor %}
+command: "{{ front_matter.command }}"
+command_group: "{{ front_matter.command_group }}"
+{% if front_matter.aliases %}
+aliases:
+{% for alias in front_matter.aliases %}
+  - "{{ alias }}"
+{% endfor %}
+{% endif %}
+---
+
+# xcsh subscription
+
+> {{ command.short | normalize_acronyms }}
+
+## Synopsis
+
+```bash
+xcsh subscription <command> [flags]
+```
+
+{% if command.long and command.long != command.short %}
+## Overview
+
+{{ command.long | normalize_acronyms }}
+
+{% endif %}
+{% if command.aliases %}
+## Aliases
+
+This command can also be invoked as:
+
+{% for alias in command.aliases %}
+- `xcsh {{ alias }}`
+{% endfor %}
+
+{% endif %}
+## Available Commands
+
+{% if leaf_commands %}
+### Quick Commands
+
+| Command | Description |
+|---------|-------------|
+{% for cmd in leaf_commands %}
+| [{{ cmd.path[-1] }}]({{ cmd.path[-1] }}.md) | {{ cmd.short | normalize_acronyms }} |
+{% endfor %}
+
+{% endif %}
+{% if group_commands %}
+### Management Commands
+
+| Command | Description |
+|---------|-------------|
+{% for cmd in group_commands %}
+| [{{ cmd.path[-1] }}]({{ cmd.path[-1] }}/index.md) | {{ cmd.short | normalize_acronyms }} |
+{% endfor %}
+{% endif %}
+
+{% if command.flags %}
+## Global Flags
+
+| Flag | Short | Type | Default | Description |
+|------|-------|------|---------|-------------|
+{% for flag in command.flags %}
+| `--{{ flag.name }}` | {% if flag.shorthand %}`-{{ flag.shorthand }}`{% endif %} | {{ flag.type }} | {% if flag.default %}{{ flag.default }}{% endif %} | {{ flag.description | normalize_acronyms }} |
+{% endfor %}
+
+{% endif %}
+{% if command.example %}
+## Examples
+
+```bash
+{{ command.example }}
+```
+
+{% endif %}
+{% if workflows %}
+## Common Workflows
+
+{% for workflow in workflows %}
+### {{ workflow.name }}
+
+{{ workflow.description | normalize_acronyms }}
+
+```bash
+{% for step in workflow.steps %}
+# Step {{ step.step }}: {{ step.description }}
+{{ step.command }}
+{% endfor %}
+```
+
+{% endfor %}
+{% endif %}
+{% if exit_codes %}
+## Exit Codes
+
+The subscription commands use standard exit codes for CI/CD integration:
+
+| Code | Name | Description |
+|------|------|-------------|
+{% for code in exit_codes %}
+| {{ code.code }} | {{ code.name }} | {{ code.description | normalize_acronyms }} |
+{% endfor %}
+
+{% endif %}
+## See Also
+
+- [Command Reference](../index.md)
+{% for cmd in subcommands[:5] %}
+{% if cmd.subcommands %}- [xcsh subscription {{ cmd.path[-1] }}]({{ cmd.path[-1] }}/index.md)
+{% else %}- [xcsh subscription {{ cmd.path[-1] }}]({{ cmd.path[-1] }}.md)
+{% endif %}
+{% endfor %}

--- a/scripts/templates/subscription_command.md.j2
+++ b/scripts/templates/subscription_command.md.j2
@@ -1,0 +1,81 @@
+---
+title: "{{ front_matter.title }}"
+description: "{{ front_matter.description }}"
+keywords:
+{% for kw in front_matter.keywords %}
+  - {{ kw }}
+{% endfor %}
+command: "{{ front_matter.command }}"
+command_group: "{{ front_matter.command_group }}"
+{% if front_matter.aliases %}
+aliases:
+{% for alias in front_matter.aliases %}
+  - "{{ alias }}"
+{% endfor %}
+{% endif %}
+---
+
+# xcsh subscription {{ path | join(' ') }}
+
+> {{ command.short | normalize_acronyms }}
+
+## Synopsis
+
+```bash
+xcsh subscription {{ path | join(' ') }} [flags]
+```
+
+{% if command.long and command.long != command.short %}
+## Description
+
+{{ command.long | normalize_acronyms }}
+
+{% endif %}
+{% if command.aliases %}
+## Aliases
+
+This command can also be invoked as:
+
+{% for alias in command.aliases %}
+- `xcsh subscription {{ alias }}`
+{% endfor %}
+
+{% endif %}
+{% if flags %}
+## Flags
+
+| Flag | Short | Type | Default | Description |
+|------|-------|------|---------|-------------|
+{% for flag in flags %}
+| `--{{ flag.name }}` | {% if flag.shorthand %}`-{{ flag.shorthand }}`{% endif %} | {{ flag.type }} | {% if flag.default %}{{ flag.default }}{% endif %} | {{ flag.description | normalize_acronyms }} |
+{% endfor %}
+
+{% endif %}
+{% if command.example %}
+## Examples
+
+```bash
+{{ command.example }}
+```
+
+{% endif %}
+{% if command.valid_values %}
+## Valid Values
+
+{% for field, values in command.valid_values.items() %}
+### {{ field | to_human_readable }}
+
+{% for value in values %}
+- `{{ value }}`
+{% endfor %}
+
+{% endfor %}
+{% endif %}
+## See Also
+
+{% if path | length > 1 %}
+- [{{ path[0] | to_human_readable }} Overview](index.md)
+{% else %}
+- [Subscription Overview](index.md)
+{% endif %}
+- [Command Reference](../../index.md)

--- a/scripts/templates/subscription_subcommand.md.j2
+++ b/scripts/templates/subscription_subcommand.md.j2
@@ -1,0 +1,83 @@
+---
+title: "{{ front_matter.title }}"
+description: "{{ front_matter.description }}"
+keywords:
+{% for kw in front_matter.keywords %}
+  - {{ kw }}
+{% endfor %}
+command: "{{ front_matter.command }}"
+command_group: "{{ front_matter.command_group }}"
+{% if front_matter.aliases %}
+aliases:
+{% for alias in front_matter.aliases %}
+  - "{{ alias }}"
+{% endfor %}
+{% endif %}
+---
+
+# xcsh subscription {{ name }}
+
+> {{ command.short | normalize_acronyms }}
+
+## Synopsis
+
+```bash
+xcsh subscription {{ name }} <command> [flags]
+```
+
+{% if command.long and command.long != command.short %}
+## Description
+
+{{ command.long | normalize_acronyms }}
+
+{% endif %}
+{% if command.aliases %}
+## Aliases
+
+This command can also be invoked as:
+
+{% for alias in command.aliases %}
+- `xcsh subscription {{ alias }}`
+{% endfor %}
+
+{% endif %}
+## Available Commands
+
+| Command | Description |
+|---------|-------------|
+{% for sub in subcommands %}
+{% if sub.subcommands %}
+| [{{ sub.path[-1] }}]({{ sub.path[-1] }}/index.md) | {{ sub.short | normalize_acronyms }} |
+{% else %}
+| [{{ sub.path[-1] }}]({{ sub.path[-1] }}.md) | {{ sub.short | normalize_acronyms }} |
+{% endif %}
+{% endfor %}
+
+{% if command.flags %}
+## Flags
+
+| Flag | Short | Type | Default | Description |
+|------|-------|------|---------|-------------|
+{% for flag in command.flags %}
+| `--{{ flag.name }}` | {% if flag.shorthand %}`-{{ flag.shorthand }}`{% endif %} | {{ flag.type }} | {% if flag.default %}{{ flag.default }}{% endif %} | {{ flag.description | normalize_acronyms }} |
+{% endfor %}
+
+{% endif %}
+{% if command.example %}
+## Examples
+
+```bash
+{{ command.example }}
+```
+
+{% endif %}
+## See Also
+
+- [Subscription Overview](../index.md)
+{% for sub in subcommands[:5] %}
+{% if sub.subcommands %}
+- [xcsh subscription {{ name }} {{ sub.path[-1] }}]({{ sub.path[-1] }}/index.md)
+{% else %}
+- [xcsh subscription {{ name }} {{ sub.path[-1] }}]({{ sub.path[-1] }}.md)
+{% endif %}
+{% endfor %}


### PR DESCRIPTION
## Summary

Add comprehensive documentation generation infrastructure for the subscription command domain, following the pattern established by other domain documentation generators.

## Changes

### New Files
- `scripts/generate-subscription-docs.py` - Python generator that parses `xcsh --spec` output and renders Jinja2 templates
- `scripts/templates/subscription.md.j2` - Main subscription overview template
- `scripts/templates/subscription_subcommand.md.j2` - Template for subcommand groups (plan, addon, quota, etc.)
- `scripts/templates/subscription_command.md.j2` - Template for leaf commands
- `docs/commands/_nav.yml` - Navigation structure including full subscription hierarchy

### Modified Files
- `.github/workflows/docs.yml` - Added subscription documentation generation step
- `.gitignore` - Updated pattern to track `_nav.yml` while ignoring generated docs

## Technical Details

- Uses the `naming.py` utilities for consistent acronym normalization
- Follows the pattern of `generate-cloudstatus-docs.py`
- Generates docs for: show, plan, addon, quota, usage, billing (payment/invoice), and report commands

## Test Plan

- [x] Pre-commit hooks pass
- [x] Python generator script created
- [x] Jinja2 templates created
- [x] Navigation structure added
- [x] Workflow step added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #466