### PR TITLE
fix: add error reporting to subscription show command

### DIFF
--- a/src/domains/subscription/index.ts
+++ b/src/domains/subscription/index.ts
@@ -110,6 +110,15 @@ function progressBar(percentage: number, width = 10): string {
 	return "\u2588".repeat(filled) + "\u2591".repeat(empty);
 }
 
+/**
+ * Helper: truncate string in the middle with ellipsis
+ */
+function truncateMiddle(str: string, maxLen: number): string {
+	if (str.length <= maxLen) return str;
+	const half = Math.floor((maxLen - 3) / 2);
+	return str.slice(0, half) + "..." + str.slice(-(maxLen - half - 3));
+}
+
 // ============================================================================
 // DEFAULT SHOW COMMAND
 // ============================================================================
@@ -212,6 +221,28 @@ const showCommand: CommandDefinition = {
 				lines.push(
 					`\u2502 Payment Status: ${padEnd(pmStatus, 38)} \u2502`,
 				);
+			}
+
+			// API Errors (if any)
+			if (overview.errors && overview.errors.length > 0) {
+				lines.push(
+					"\u251C\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524",
+				);
+				lines.push(
+					`\u2502 \u26A0\uFE0F  API Errors (${overview.errors.length}):${padEnd("", 36)} \u2502`,
+				);
+				for (const error of overview.errors) {
+					const statusInfo = error.statusCode
+						? ` [${error.statusCode}]`
+						: "";
+					const errorMsg = truncateMiddle(
+						`${error.endpoint}${statusInfo}`,
+						52,
+					);
+					lines.push(
+						`\u2502   \u2022 ${padEnd(errorMsg, 50)} \u2502`,
+					);
+				}
 			}
 
 			lines.push(

--- a/src/domains/subscription/types.ts
+++ b/src/domains/subscription/types.ts
@@ -336,6 +336,15 @@ export interface AddonUnsubscribeRequest {
 }
 
 /**
+ * API Error Information
+ */
+export interface APIError {
+	endpoint: string;
+	message: string;
+	statusCode?: number;
+}
+
+/**
  * Subscription Overview - Combined summary for default command
  */
 export interface SubscriptionOverview {
@@ -356,6 +365,8 @@ export interface SubscriptionOverview {
 		outstanding_balance?: number;
 		payment_method_status?: string;
 	};
+	/** API errors encountered during data retrieval */
+	errors?: APIError[];
 }
 
 /**


### PR DESCRIPTION
## Summary

Add error tracking and display to the subscription show command so users can see WHY API calls are failing instead of just seeing placeholder values.

## Changes

- Add `APIError` type to track endpoint, message, and status code
- Update `getOverview()` to capture rejected promises with error details  
- Display errors section in show command output when API calls fail

## Before/After

**Before:** Shows "Unknown", "N/A", "0 active" with no explanation

**After:** Shows error section with endpoint names and HTTP status codes:
```
├─────────────────────────────────────────────┤
│ ⚠️  API Errors (5):                          │
│   • usage_plans/current [404]               │
│   • addon_services [403]                    │
╰─────────────────────────────────────────────╯
```

## Test Plan

- [x] TypeScript type check passes
- [x] All pre-commit hooks pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #468