### PR TITLE
fix: align xcsh binary search order in subscription docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -822,17 +822,34 @@ jobs:
       - name: Generate subscription documentation
         id: generate-subscription-docs
         run: |
-          # Find xcsh binary
+          # Find xcsh binary (same search order as generate-command-docs)
           XCSH_PATH=""
-          for path in /opt/homebrew/bin/xcsh /usr/local/bin/xcsh "$HOME/.local/bin/xcsh"; do
-            if [ -x "$path" ]; then
-              XCSH_PATH="$path"
-              break
-            fi
-          done
 
+          # 1. Try Homebrew Caskroom (ARM Mac) - primary location
+          if [ -z "$XCSH_PATH" ]; then
+            XCSH_PATH=$(find /opt/homebrew/Caskroom/xcsh -name xcsh -type f 2>/dev/null | head -1 || true)
+          fi
+
+          # 2. Try Homebrew Caskroom (Intel Mac)
           if [ -z "$XCSH_PATH" ] || [ ! -x "$XCSH_PATH" ]; then
-            XCSH_PATH=$(find /opt/homebrew/Caskroom/xcsh /usr/local/Caskroom/xcsh -name xcsh -type f 2>/dev/null | head -1 || true)
+            XCSH_PATH=$(find /usr/local/Caskroom/xcsh -name xcsh -type f 2>/dev/null | head -1 || true)
+          fi
+
+          # 3. Try script install location
+          if [ -z "$XCSH_PATH" ] || [ ! -x "$XCSH_PATH" ]; then
+            if [ -x "$HOME/.local/bin/xcsh" ]; then
+              XCSH_PATH="$HOME/.local/bin/xcsh"
+            fi
+          fi
+
+          # 4. Try Homebrew bin symlinks (last resort)
+          if [ -z "$XCSH_PATH" ] || [ ! -x "$XCSH_PATH" ]; then
+            for path in /opt/homebrew/bin/xcsh /usr/local/bin/xcsh; do
+              if [ -x "$path" ]; then
+                XCSH_PATH="$path"
+                break
+              fi
+            done
           fi
 
           if [ -n "$XCSH_PATH" ] && [ -x "$XCSH_PATH" ]; then


### PR DESCRIPTION
## Summary

The subscription documentation generation step was using a different binary search order than the command documentation step, causing it to find a stale/incompatible xcsh binary at `/usr/local/bin/xcsh` instead of the freshly installed one in Caskroom.

### Root Cause
- **Command docs** (works): Searches `/opt/homebrew/Caskroom/xcsh` first
- **Subscription docs** (fails): Was searching `/opt/homebrew/bin/xcsh` or `/usr/local/bin/xcsh` first

### Solution
Align the search order to:
1. Try Homebrew Caskroom (ARM Mac) first - primary location
2. Try Homebrew Caskroom (Intel Mac)
3. Try script install location (`$HOME/.local/bin`)
4. Try Homebrew bin symlinks (last resort)

### Evidence
Multiple `workflow_run`-triggered Documentation workflows have failed on this step:
- Run 20672616729 - FAILURE
- Run 20672232695 - FAILURE
- Run 20671764521 - FAILURE

## Test Plan
- [x] Pre-commit hooks pass
- [x] YAML workflow syntax validated
- [ ] Documentation workflow runs successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #472