### PR TITLE
fix: remove --output-format json flag from --spec commands for compatibility

### DIFF
--- a/scripts/generate-cloudstatus-docs.py
+++ b/scripts/generate-cloudstatus-docs.py
@@ -24,8 +24,10 @@ from naming import normalize_acronyms, to_human_readable, to_title_case
 def load_spec(cli_binary_path: str) -> dict:
     """Run xcsh --spec and return the full CLI spec."""
     try:
+        # Use --spec without --output-format json for compatibility with older binaries
+        # (--spec already outputs JSON by default)
         result = subprocess.run(
-            [cli_binary_path, "--spec", "--output-format", "json"],
+            [cli_binary_path, "--spec"],
             capture_output=True,
             text=True,
             check=True,
@@ -42,8 +44,9 @@ def load_spec(cli_binary_path: str) -> dict:
 def load_cloudstatus_spec(cli_binary_path: str) -> dict:
     """Run xcsh cloudstatus --spec for extended cloudstatus-specific data."""
     try:
+        # Use --spec without --output-format json for compatibility with older binaries
         result = subprocess.run(
-            [cli_binary_path, "cloudstatus", "--spec", "--output-format", "json"],
+            [cli_binary_path, "cloudstatus", "--spec"],
             capture_output=True,
             text=True,
             check=True,

--- a/scripts/generate-subscription-docs.py
+++ b/scripts/generate-subscription-docs.py
@@ -24,8 +24,10 @@ from naming import normalize_acronyms, to_human_readable, to_title_case
 def load_spec(cli_binary_path: str) -> dict:
     """Run xcsh --spec and return the full CLI spec."""
     try:
+        # Use --spec without --output-format json for compatibility with older binaries
+        # (--spec already outputs JSON by default)
         result = subprocess.run(
-            [cli_binary_path, "--spec", "--output-format", "json"],
+            [cli_binary_path, "--spec"],
             capture_output=True,
             text=True,
             check=True,
@@ -42,8 +44,9 @@ def load_spec(cli_binary_path: str) -> dict:
 def load_subscription_spec(cli_binary_path: str) -> dict:
     """Run xcsh subscription --spec for extended subscription-specific data."""
     try:
+        # Use --spec without --output-format json for compatibility with older binaries
         result = subprocess.run(
-            [cli_binary_path, "subscription", "--spec", "--output-format", "json"],
+            [cli_binary_path, "subscription", "--spec"],
             capture_output=True,
             text=True,
             check=True,


### PR DESCRIPTION
## Summary

Remove the `--output-format json` flag from `--spec` commands in documentation generation scripts to ensure compatibility with older xcsh binaries.

### Root Cause

The Documentation workflow was failing on the "Generate subscription documentation" step because:
1. The runner finds an older xcsh binary at `/usr/local/bin/xcsh`
2. This older binary doesn't support `--output-format json` with `--spec`
3. The `generate-subscription-docs.py` and `generate-cloudstatus-docs.py` scripts used this unsupported flag combination
4. The `generate-docs.py` script worked because it only uses `--spec` (no `--output-format json`)

### Changes

- `scripts/generate-subscription-docs.py`: Remove `--output-format json` from `load_spec()` and `load_subscription_spec()`
- `scripts/generate-cloudstatus-docs.py`: Remove `--output-format json` from `load_spec()` and `load_cloudstatus_spec()`

The `--spec` command already outputs JSON by default, so the flag is unnecessary.

## Test Plan

- [x] Pre-commit hooks pass
- [ ] Documentation workflow succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #474