### PR TITLE
fix: use temp file for docs generation to avoid 64KB buffer limit

### DIFF
--- a/scripts/generate-subscription-docs.py
+++ b/scripts/generate-subscription-docs.py
@@ -14,6 +14,7 @@ import json
 import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
@@ -24,15 +25,19 @@ from naming import normalize_acronyms, to_human_readable, to_title_case
 def load_spec(cli_binary_path: str) -> dict:
     """Run xcsh --spec and return the full CLI spec."""
     try:
-        # Use --spec without --output-format json for compatibility with older binaries
-        # (--spec already outputs JSON by default)
-        result = subprocess.run(
-            [cli_binary_path, "--spec"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        return json.loads(result.stdout)
+        # Use a temporary file to handle large JSON output
+        # (subprocess.PIPE has 64KB buffer limitation)
+        with tempfile.NamedTemporaryFile(mode="w+", suffix=".json", delete=True) as tmp:
+            subprocess.run(
+                [cli_binary_path, "--spec"],
+                stdout=tmp,
+                stderr=subprocess.PIPE,
+                text=True,
+                check=True,
+            )
+            tmp.flush()
+            tmp.seek(0)
+            return json.load(tmp)
     except subprocess.CalledProcessError as e:
         print(f"Error running xcsh --spec: {e.stderr}", file=sys.stderr)
         sys.exit(1)
@@ -44,14 +49,18 @@ def load_spec(cli_binary_path: str) -> dict:
 def load_subscription_spec(cli_binary_path: str) -> dict:
     """Run xcsh subscription --spec for extended subscription-specific data."""
     try:
-        # Use --spec without --output-format json for compatibility with older binaries
-        result = subprocess.run(
-            [cli_binary_path, "subscription", "--spec"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        return json.loads(result.stdout)
+        # Use a temporary file to handle large JSON output
+        with tempfile.NamedTemporaryFile(mode="w+", suffix=".json", delete=True) as tmp:
+            subprocess.run(
+                [cli_binary_path, "subscription", "--spec"],
+                stdout=tmp,
+                stderr=subprocess.PIPE,
+                text=True,
+                check=True,
+            )
+            tmp.flush()
+            tmp.seek(0)
+            return json.load(tmp)
     except subprocess.CalledProcessError as e:
         print(f"Note: xcsh subscription --spec not available: {e.stderr}", file=sys.stderr)
         return {}


### PR DESCRIPTION
## Summary

Fix the documentation generation workflow failure caused by subprocess 64KB PIPE buffer limitation.

## Changes

- **`scripts/generate-subscription-docs.py`**: Use `tempfile.NamedTemporaryFile` for `load_spec()` and `load_subscription_spec()`
- **`scripts/generate-cloudstatus-docs.py`**: Use `tempfile.NamedTemporaryFile` for `load_spec()` and `load_cloudstatus_spec()`

## Root Cause

The `xcsh --spec` output exceeds 64KB, causing truncation when using `capture_output=True`. This resulted in:
```
Error parsing xcsh --spec output: Expecting value: line 2058 column 1 (char 65536)
```

## Solution

Match the temp file approach already used in `generate-docs.py` to handle large subprocess output.

## Test Plan

- [x] Pre-commit hooks pass
- [ ] CI checks pass
- [ ] Documentation workflow succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #476