### PR TITLE
fix: dynamic mkdocs nav generation for subscription docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -857,7 +857,8 @@ jobs:
             python scripts/generate-subscription-docs.py \
               --cli-binary "$XCSH_PATH" \
               --output docs/commands/subscription \
-              --clean
+              --clean \
+              --update-nav
             echo "✅ Subscription documentation generated successfully"
           else
             echo "::warning::xcsh binary not found - skipping subscription documentation"


### PR DESCRIPTION
## Summary

Add `--update-nav` flag to subscription and cloudstatus doc generators to dynamically update mkdocs.yml with correct navigation paths.

## Problem

The Documentation workflow was failing because mkdocs.yml nav referenced non-existent paths. The main generator treated subscription commands as groups (expecting `show/index.md`) when the subscription generator created them as leaf files (`show.md`).

## Solution

- Added `update_mkdocs_nav()` function to subscription and cloudstatus generators
- Uses regex-based text replacement to preserve Python tags in mkdocs.yml
- Distinguishes between leaf commands (`.md` files) and group commands (`/index.md`)
- Updated docs.yml workflow to use `--update-nav` flag

## Test Plan

- [x] Pre-commit hooks pass
- [x] All linting checks pass
- [ ] CI workflows pass
- [ ] Documentation workflow generates correct nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #479
Fixes #478