### PR TITLE
feat: add CLI reserved words and dangerous name detection

### DIFF
--- a/src/domains/login/profile/create.ts
+++ b/src/domains/login/profile/create.ts
@@ -10,6 +10,7 @@ import {
 	formatConnectionTable,
 	buildConnectionInfo,
 } from "./connection-table.js";
+import { validateResourceName } from "../../../validation/index.js";
 
 export const createCommand: CommandDefinition = {
 	name: "create",
@@ -40,6 +41,19 @@ export const createCommand: CommandDefinition = {
 					"  login profile create myprofile --url https://myco.console.ves.volterra.io --token abc123",
 				].join("\n"),
 			);
+		}
+
+		// Validate profile name for CLI safety
+		const nameValidation = validateResourceName(name, {
+			maxLength: 128, // Profiles can have longer names than API resources
+			resourceType: "profile",
+		});
+		if (!nameValidation.valid) {
+			const lines = [`Invalid profile name: ${nameValidation.message}`];
+			if (nameValidation.suggestion) {
+				lines.push("", `Suggested: ${nameValidation.suggestion}`);
+			}
+			return errorResult(lines.join("\n"));
 		}
 
 		// Check if profile already exists

--- a/src/validation/index.ts
+++ b/src/validation/index.ts
@@ -25,3 +25,24 @@ export {
 	type SideEffects,
 	type SafetyCheckResult,
 } from "./safety.js";
+
+export {
+	validateResourceName,
+	sanitizeName,
+	isReservedAction,
+	containsShellMetacharacters,
+	isDangerousCommand,
+	type NameValidationResult,
+	type NameValidationOptions,
+	type NameValidationCategory,
+} from "./resource-name.js";
+
+export {
+	RESERVED_ACTIONS,
+	SHELL_METACHARACTERS,
+	DANGEROUS_PATTERNS,
+	DANGEROUS_COMMANDS,
+	CONTROL_CHARS,
+	RFC1035_PATTERN,
+	RFC1123_PATTERN,
+} from "./reserved-words.js";

--- a/src/validation/reserved-words.ts
+++ b/src/validation/reserved-words.ts
@@ -1,0 +1,237 @@
+/**
+ * Reserved Words and Dangerous Patterns for CLI Resource Names
+ *
+ * Based on industry-standard CLI conventions from:
+ * - kubectl (Kubernetes)
+ * - az (Azure CLI)
+ * - aws (AWS CLI)
+ * - gcloud (Google Cloud)
+ * - terraform
+ * - docker
+ *
+ * These patterns prevent:
+ * - Command injection attacks via shell metacharacters
+ * - Name conflicts with reserved CLI action verbs
+ * - Path traversal and flag confusion vulnerabilities
+ * - Dangerous system command execution
+ */
+
+/**
+ * CLI action verbs that cannot be used as resource names.
+ * These words are reserved across all major cloud CLI tools.
+ */
+export const RESERVED_ACTIONS = new Set([
+	// CRUD operations
+	"create",
+	"delete",
+	"list",
+	"get",
+	"update",
+	"apply",
+	"patch",
+	// Info operations
+	"describe",
+	"show",
+	"status",
+	"logs",
+	"events",
+	// Modification
+	"edit",
+	"replace",
+	"set",
+	"unset",
+	// Lifecycle
+	"start",
+	"stop",
+	"restart",
+	"rollout",
+	"scale",
+	// Connection
+	"attach",
+	"detach",
+	"connect",
+	"disconnect",
+	// Registration
+	"register",
+	"deregister",
+	"associate",
+	"disassociate",
+	// AWS-specific
+	"put",
+	"modify",
+	// Built-in xcsh commands
+	"help",
+	"quit",
+	"exit",
+	"clear",
+	"history",
+	"refresh",
+	"context",
+	"banner",
+	"profile",
+	"completion",
+	// Common CLI patterns
+	"run",
+	"exec",
+	"wait",
+	"open",
+	"close",
+	"inspect",
+	"validate",
+	"diff",
+	"plan",
+	"import",
+	"export",
+]);
+
+/**
+ * Shell metacharacters that enable command injection attacks.
+ * These must never appear in resource names.
+ *
+ * Security risks:
+ * - ; & | - Command chaining/piping
+ * - ` $() - Command substitution
+ * - < > - I/O redirection
+ * - # - Comment (truncates remaining input)
+ * - ! - History expansion
+ * - {} [] - Brace/bracket expansion
+ * - * ? ~ - Glob patterns
+ */
+export const SHELL_METACHARACTERS = /[;&|`$()<>\\#!{}[\]*?~\n\r]/;
+
+/**
+ * Dangerous patterns that indicate potential security issues or CLI conflicts.
+ */
+export const DANGEROUS_PATTERNS: Array<{
+	pattern: RegExp;
+	message: string;
+}> = [
+	{
+		pattern: /^-/,
+		message:
+			"Name cannot start with a hyphen (would be interpreted as a flag)",
+	},
+	{
+		pattern: /^--/,
+		message:
+			"Name cannot start with double-hyphen (would be interpreted as a long flag)",
+	},
+	{
+		pattern: /\.\./,
+		message: "Name cannot contain '..' (path traversal risk)",
+	},
+	{
+		pattern: /^\./,
+		message: "Name cannot start with '.' (hidden file pattern)",
+	},
+	{
+		pattern: /\//,
+		message: "Name cannot contain '/' (path separator)",
+	},
+	{
+		pattern: /\\$/,
+		message: "Name cannot end with backslash (escape sequence risk)",
+	},
+	{
+		pattern: /\s/,
+		message: "Name cannot contain whitespace",
+	},
+	{
+		pattern: /^_/,
+		message:
+			"Name cannot start with underscore (reserved for internal use)",
+	},
+];
+
+/**
+ * Dangerous system command names that should never be resource names.
+ * Attackers may try to name resources after destructive commands.
+ */
+export const DANGEROUS_COMMANDS = new Set([
+	// File destruction
+	"rm",
+	"rm-rf",
+	"rmdir",
+	"del",
+	"unlink",
+	"shred",
+	// Privilege escalation
+	"sudo",
+	"su",
+	"chmod",
+	"chown",
+	"chattr",
+	"setfacl",
+	// Network tools (payload download)
+	"wget",
+	"curl",
+	"nc",
+	"netcat",
+	"socat",
+	"telnet",
+	"ssh",
+	"scp",
+	"rsync",
+	// Shell execution
+	"bash",
+	"sh",
+	"zsh",
+	"csh",
+	"ksh",
+	"fish",
+	"pwsh",
+	"powershell",
+	// Process execution
+	"exec",
+	"eval",
+	"source",
+	"nohup",
+	"xargs",
+	// Process termination
+	"kill",
+	"pkill",
+	"killall",
+	"killall5",
+	// Disk operations
+	"dd",
+	"mkfs",
+	"fdisk",
+	"parted",
+	"format",
+	// System control
+	"reboot",
+	"shutdown",
+	"halt",
+	"poweroff",
+	"init",
+	"systemctl",
+	// Container escape
+	"docker",
+	"kubectl",
+	"nsenter",
+	"chroot",
+]);
+
+/**
+ * Control characters (0x00-0x1F, 0x7F) that can cause parser confusion.
+ * These are never valid in resource names.
+ */
+// eslint-disable-next-line no-control-regex -- Intentional: detecting control chars for security validation
+export const CONTROL_CHARS = /[\x00-\x1f\x7f]/;
+
+/**
+ * RFC 1035 DNS label format for Kubernetes/cloud resource names.
+ * - 1-63 characters
+ * - Lowercase alphanumeric and hyphens
+ * - Must start with a letter
+ * - Must end with alphanumeric
+ */
+// eslint-disable-next-line security/detect-unsafe-regex -- False positive: bounded to 63 chars max
+export const RFC1035_PATTERN = /^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$/;
+
+/**
+ * RFC 1123 DNS label format (slightly more permissive than RFC 1035).
+ * - Can start with a digit
+ */
+// eslint-disable-next-line security/detect-unsafe-regex -- False positive: bounded to 63 chars max
+export const RFC1123_PATTERN = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/;

--- a/src/validation/resource-name.ts
+++ b/src/validation/resource-name.ts
@@ -1,0 +1,245 @@
+/**
+ * Resource Name Validation Module
+ *
+ * Validates resource names for CLI safety and platform compliance.
+ * Prevents command injection, reserved word conflicts, and naming violations.
+ */
+
+import {
+	RESERVED_ACTIONS,
+	SHELL_METACHARACTERS,
+	DANGEROUS_PATTERNS,
+	DANGEROUS_COMMANDS,
+	CONTROL_CHARS,
+	RFC1035_PATTERN,
+} from "./reserved-words.js";
+
+/**
+ * Validation result categories indicating the type of failure
+ */
+export type NameValidationCategory =
+	| "reserved"
+	| "dangerous"
+	| "invalid"
+	| "security";
+
+/**
+ * Result of resource name validation
+ */
+export interface NameValidationResult {
+	/** Whether the name is valid */
+	valid: boolean;
+	/** Category of validation failure (if invalid) */
+	category?: NameValidationCategory;
+	/** Human-readable error message */
+	message?: string;
+	/** Suggested alternative name */
+	suggestion?: string;
+}
+
+/**
+ * Options for resource name validation
+ */
+export interface NameValidationOptions {
+	/** Maximum allowed length (default: 63 for RFC 1035) */
+	maxLength?: number;
+	/** Allow uppercase letters (default: false) */
+	allowUppercase?: boolean;
+	/** Resource type for context-specific rules */
+	resourceType?: string;
+	/** Skip RFC 1035 format validation (default: false) */
+	skipFormatValidation?: boolean;
+}
+
+const DEFAULT_OPTIONS: Required<Omit<NameValidationOptions, "resourceType">> = {
+	maxLength: 63,
+	allowUppercase: false,
+	skipFormatValidation: false,
+};
+
+/**
+ * Validate a resource name for CLI safety and platform compliance.
+ *
+ * Checks for:
+ * - Empty or whitespace-only names
+ * - Length violations
+ * - Control characters
+ * - Shell metacharacters (security)
+ * - Reserved CLI action words
+ * - Dangerous command names
+ * - Dangerous patterns (leading hyphen, path traversal, etc.)
+ * - RFC 1035 DNS label compliance
+ *
+ * @param name - The resource name to validate
+ * @param options - Validation options
+ * @returns Validation result with error details if invalid
+ */
+export function validateResourceName(
+	name: string,
+	options: NameValidationOptions = {},
+): NameValidationResult {
+	const opts = { ...DEFAULT_OPTIONS, ...options };
+	const nameLower = name.toLowerCase();
+
+	// Empty name check
+	if (!name || name.trim().length === 0) {
+		return {
+			valid: false,
+			category: "invalid",
+			message: "Resource name cannot be empty",
+		};
+	}
+
+	// Length check
+	if (name.length > opts.maxLength) {
+		return {
+			valid: false,
+			category: "invalid",
+			message: `Name exceeds maximum length of ${opts.maxLength} characters (got ${name.length})`,
+			suggestion: sanitizeName(name.slice(0, opts.maxLength)),
+		};
+	}
+
+	// Control characters (security critical)
+	if (CONTROL_CHARS.test(name)) {
+		return {
+			valid: false,
+			category: "security",
+			message: "Name contains control characters which are not allowed",
+		};
+	}
+
+	// Shell metacharacters (security critical)
+	if (SHELL_METACHARACTERS.test(name)) {
+		const match = name.match(SHELL_METACHARACTERS);
+		const char = match?.[0] ?? "unknown";
+		const charDesc = getCharacterDescription(char);
+		return {
+			valid: false,
+			category: "security",
+			message: `Name contains shell metacharacter '${charDesc}' which could enable command injection`,
+		};
+	}
+
+	// Reserved action words
+	if (RESERVED_ACTIONS.has(nameLower)) {
+		return {
+			valid: false,
+			category: "reserved",
+			message: `'${name}' is a reserved CLI action word and cannot be used as a resource name`,
+			suggestion: `my-${name}`,
+		};
+	}
+
+	// Dangerous command names
+	if (DANGEROUS_COMMANDS.has(nameLower)) {
+		return {
+			valid: false,
+			category: "dangerous",
+			message: `'${name}' matches a dangerous system command and cannot be used as a resource name`,
+		};
+	}
+
+	// Dangerous patterns
+	for (const { pattern, message } of DANGEROUS_PATTERNS) {
+		if (pattern.test(name)) {
+			return {
+				valid: false,
+				category: "dangerous",
+				message,
+			};
+		}
+	}
+
+	// RFC 1035 format validation (unless skipped)
+	if (!opts.skipFormatValidation) {
+		const nameToCheck = opts.allowUppercase ? nameLower : name;
+		if (!RFC1035_PATTERN.test(nameToCheck.toLowerCase())) {
+			return {
+				valid: false,
+				category: "invalid",
+				message:
+					"Name must start with a letter, end with alphanumeric, and contain only lowercase letters, numbers, and hyphens",
+				suggestion: sanitizeName(name),
+			};
+		}
+	}
+
+	return { valid: true };
+}
+
+/**
+ * Get a human-readable description for a shell metacharacter
+ */
+function getCharacterDescription(char: string): string {
+	const descriptions: Record<string, string> = {
+		";": "; (command separator)",
+		"&": "& (background execution)",
+		"|": "| (pipe)",
+		"`": "` (command substitution)",
+		$: "$ (variable/command expansion)",
+		"(": "( (subshell)",
+		")": ") (subshell)",
+		"<": "< (input redirection)",
+		">": "> (output redirection)",
+		"\\": "\\ (escape)",
+		"#": "# (comment)",
+		"!": "! (history expansion)",
+		"{": "{ (brace expansion)",
+		"}": "} (brace expansion)",
+		"[": "[ (bracket expansion)",
+		"]": "] (bracket expansion)",
+		"*": "* (glob pattern)",
+		"?": "? (glob pattern)",
+		"~": "~ (home directory)",
+		"\n": "newline",
+		"\r": "carriage return",
+	};
+	return descriptions[char] ?? char;
+}
+
+/**
+ * Sanitize a name to make it valid.
+ * Converts to lowercase, replaces invalid characters with hyphens,
+ * and ensures proper start/end characters.
+ *
+ * @param name - The name to sanitize
+ * @returns A sanitized version of the name
+ */
+export function sanitizeName(name: string): string {
+	return (
+		name
+			.toLowerCase()
+			// Replace invalid characters with hyphens
+			.replace(/[^a-z0-9-]/g, "-")
+			// Remove leading hyphens/numbers
+			.replace(/^[^a-z]+/, "")
+			// Remove trailing hyphens
+			.replace(/-+$/, "")
+			// Collapse multiple hyphens
+			.replace(/-{2,}/g, "-")
+			// Ensure max length
+			.slice(0, 63) || "resource"
+	);
+}
+
+/**
+ * Check if a name is a reserved action word
+ */
+export function isReservedAction(name: string): boolean {
+	return RESERVED_ACTIONS.has(name.toLowerCase());
+}
+
+/**
+ * Check if a name contains shell metacharacters
+ */
+export function containsShellMetacharacters(name: string): boolean {
+	return SHELL_METACHARACTERS.test(name);
+}
+
+/**
+ * Check if a name matches a dangerous command
+ */
+export function isDangerousCommand(name: string): boolean {
+	return DANGEROUS_COMMANDS.has(name.toLowerCase());
+}


### PR DESCRIPTION
## Summary

Implement comprehensive resource name validation for CLI safety and security.

### New Validation Features
- **Reserved action words** - Blocks CLI verbs (delete, create, list, etc.) as resource names
- **Shell metacharacters** - Rejects injection vectors (; & | ` $ ( ) < > etc.)
- **Dangerous patterns** - Detects path traversal (..), flag confusion (--), hidden files (.)
- **Dangerous commands** - Blocks system command names (rm, sudo, wget, curl, etc.)
- **RFC 1035/1123** - Enforces DNS label format (max 63 chars, lowercase alphanumeric + hyphens)

### Security Protections
- Command injection prevention via metacharacter detection
- Path traversal attack prevention
- Control character rejection (0x00-0x1F, 0x7F)
- Dangerous system command name blocking

### Validation Scope
- **Namespace validation**: Applied to all operations
- **Resource name validation**: Applied only to write operations (create, replace, apply, patch)
- **Read operations**: Skip validation to support legacy resources

### Files Changed
- **New**: `src/validation/reserved-words.ts` - Dictionary of reserved words
- **New**: `src/validation/resource-name.ts` - Core validator
- **Modified**: `src/validation/index.ts` - Export new validators
- **Modified**: `src/repl/executor.ts` - Integrate validation
- **Modified**: `src/domains/login/profile/create.ts` - Profile name validation

## Test Plan
- [x] Build succeeds with `npm run build`
- [x] All pre-commit hooks pass
- [x] Unit tests pass (425/426 - 1 pre-existing failure)
- [x] TypeScript type checking passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #485