### PR TITLE
chore: trigger v2.0.3 release workflow

### DIFF
--- a/src/types/domains_generated.ts
+++ b/src/types/domains_generated.ts
@@ -2,6 +2,7 @@
  * AUTO-GENERATED FILE - DO NOT EDIT
  * Generated from .specs/index.json v2.0.3
  * Run: npx tsx scripts/generate-domains.ts
+ * Synced: 2026-01-05
  */
 
 import type {


### PR DESCRIPTION
## Summary

Trigger v2.0.3 release workflow. The auto-merge squash for PR #507 failed to trigger GitHub Actions workflows.

### Changes
- Added sync date comment to domains_generated.ts

### Reason
The squash merge of the upstream sync PR #507 (v2.0.3) did not trigger the Release workflow on main branch. This PR will trigger the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)