### PR TITLE
fix: require double Ctrl+C to exit interactive mode

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -222,7 +222,7 @@ program
 				// https://github.com/oven-sh/bun/issues/6862
 				process.stdin.resume();
 				const appProps: AppProps = { initialSession: session };
-				render(<App {...appProps} />);
+				render(<App {...appProps} />, { exitOnCtrlC: false });
 				return;
 			}
 


### PR DESCRIPTION
## Summary
Pass `exitOnCtrlC: false` to Ink's `render()` function to disable its built-in SIGINT handler. This allows the existing `useDoubleCtrlC` hook to properly detect two Ctrl+C presses within 500ms before exiting.

## Root Cause
Ink's default `exitOnCtrlC: true` causes immediate exit on SIGINT before the React component's `useInput` hook can intercept it.

## Expected Behavior After Fix
1. First Ctrl+C → Shows "Press Ctrl+C again to exit, or continue typing"
2. Second Ctrl+C within 500ms → Saves history and exits
3. Ctrl+D → Immediate exit (unchanged)

## Files Changed
- `src/index.tsx` - Add `exitOnCtrlC: false` option to Ink render call

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #516