### PR TITLE
fix: enable automated CI trigger for upstream sync PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ on:
     paths-ignore:
       - "**.md"
       - "docs/**"
+  workflow_dispatch:  # Allows manual/programmatic trigger for automated PRs
 
 permissions:
   contents: read

--- a/.github/workflows/sync-upstream-specs.yml
+++ b/.github/workflows/sync-upstream-specs.yml
@@ -191,6 +191,15 @@ jobs:
             --delete-branch
           echo "✅ Auto-merge enabled - PR will merge automatically when CI passes"
 
+      - name: Trigger CI on PR Branch
+        if: steps.create-pr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "🔄 Triggering CI workflow on branch: sync/upstream-${{ needs.check-upstream.outputs.new_version }}"
+          gh workflow run ci.yml --ref "sync/upstream-${{ needs.check-upstream.outputs.new_version }}"
+          echo "✅ CI workflow triggered - PR will auto-merge when checks pass"
+
   # Step 3: Report if no updates
   no-updates:
     name: Report Status


### PR DESCRIPTION
## Summary
PRs created by `GITHUB_TOKEN` don't trigger CI workflows due to GitHub's anti-recursion protection. This caused automated upstream sync PRs (like #515) to wait indefinitely for CI checks that never ran.

## Changes
- Add `workflow_dispatch` trigger to `ci.yml` for programmatic invocation
- Add "Trigger CI on PR Branch" step to `sync-upstream-specs.yml`

## How It Works
```
sync-upstream-specs.yml creates PR
         ↓
Enables auto-merge (waits for CI)
         ↓
Explicitly triggers CI via workflow_dispatch  ← NEW
         ↓
CI runs and passes → Auto-merge completes
```

## Test Plan
- [x] Pre-commit hooks pass
- [ ] CI passes on this PR
- [ ] After merge: Close PR #515 and trigger fresh sync
- [ ] Verify new sync PR auto-merges without intervention

## Closes
Closes #515 (will need to be re-triggered after this merges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)