### PR TITLE
fix: add actions:write permission for CI trigger

### DIFF
--- a/.github/workflows/sync-upstream-specs.yml
+++ b/.github/workflows/sync-upstream-specs.yml
@@ -77,6 +77,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      actions: write
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
Adds `actions: write` permission to the sync-upstream-specs workflow to enable `workflow_dispatch` triggering for automated CI on sync PRs.

## Context
The previous fix (PR #520) added CI trigger logic but failed with:
```
HTTP 403: Resource not accessible by integration
```

This PR adds the `actions: write` permission which may resolve the issue.

## Test Plan
- [ ] CI passes on this PR
- [ ] After merge: Close PR #521 and trigger fresh sync
- [ ] Verify CI triggers automatically on new sync PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)