### PR TITLE
feat: add dynamic documentation generation from enriched API specs

### DIFF
--- a/.github/workflows/sync-upstream-specs.yml
+++ b/.github/workflows/sync-upstream-specs.yml
@@ -12,11 +12,13 @@ on:
   repository_dispatch:
     types: [enriched-specs-updated]
 
-  # Trigger on domain config changes
+  # Trigger on domain config or documentation config changes
   push:
     paths:
       - '.specs/domain_config.yaml'
       - 'scripts/generate-domains.ts'
+      - 'scripts/generate-docs.ts'
+      - 'docs/config/cli-examples.yaml'
 
 jobs:
   # Step 1: Check if upstream has new version
@@ -99,6 +101,9 @@ jobs:
       - name: Generate domains
         run: npx tsx scripts/generate-domains.ts
 
+      - name: Generate documentation
+        run: npx tsx scripts/generate-docs.ts
+
       - name: Format generated code
         run: npx prettier --write "src/**/*.{ts,tsx}"
 
@@ -115,11 +120,13 @@ jobs:
           echo "" >> validation-report.md
           echo "- **Build:** SUCCESS" >> validation-report.md
           echo "- **Tests:** PASSED" >> validation-report.md
-          echo "- **Generated Files:** domains_generated.ts" >> validation-report.md
+          echo "- **Generated Files:** domains_generated.ts, docs/guides/generated/" >> validation-report.md
           echo "" >> validation-report.md
           echo "### Domain Summary" >> validation-report.md
           DOMAIN_COUNT=$(grep -c 'name:' src/types/domains_generated.ts || echo "0")
           echo "- **Total Domains:** $DOMAIN_COUNT" >> validation-report.md
+          DOC_COUNT=$(ls -1 docs/guides/generated/*.md 2>/dev/null | wc -l | tr -d ' ')
+          echo "- **Generated Docs:** $DOC_COUNT" >> validation-report.md
           echo "" >> validation-report.md
           echo "### Upstream Version" >> validation-report.md
           echo "- **Previous:** ${{ needs.check-upstream.outputs.current_version }}" >> validation-report.md

--- a/docs/config/cli-examples.yaml
+++ b/docs/config/cli-examples.yaml
@@ -1,0 +1,142 @@
+# xcsh CLI Examples Configuration
+# This file contains implementation-specific examples for xcsh CLI
+# These examples are NOT pushed upstream - they are specific to this project
+#
+# Upstream API specs provide: resource descriptions, best practices, field docs
+# This file provides: CLI command syntax, xcsh-specific workflows, output examples
+
+version: "1.0.0"
+
+# Common CLI patterns
+cli_patterns:
+  list: "xcsh {domain} list {resource}"
+  get: "xcsh {domain} get {resource} {name} -ns {namespace}"
+  create: "xcsh {domain} create {resource} -f {file}"
+  delete: "xcsh {domain} delete {resource} {name} -ns {namespace}"
+  replace: "xcsh {domain} replace {resource} {name} -ns {namespace} -f {file}"
+
+# Domain-specific examples
+# NOTE: Domain keys must match upstream API domain names (e.g., "virtual", not "http_loadbalancer")
+# Resources within a domain are specified in the examples
+domains:
+  virtual:
+    display_name: "Virtual (Load Balancers)"
+    cli_domain: "virtual"
+    examples:
+      list:
+        description: "List all HTTP load balancers"
+        command: "xcsh virtual list http_loadbalancer"
+        output: |
+          NAME           NAMESPACE    DOMAINS              STATUS
+          example-lb     default      example.com          ACTIVE
+          api-lb         production   api.example.com      ACTIVE
+
+      get:
+        description: "Get HTTP load balancer details"
+        command: "xcsh virtual get http_loadbalancer example-lb -ns default -o yaml"
+        output: |
+          metadata:
+            name: example-lb
+            namespace: default
+          spec:
+            domains:
+              - example.com
+            default_route_pools:
+              - pool:
+                  name: my-origin-pool
+                  namespace: default
+
+      create:
+        description: "Create HTTP load balancer from file"
+        command: "xcsh virtual create http_loadbalancer -f lb.yaml"
+
+      delete:
+        description: "Delete HTTP load balancer"
+        command: "xcsh virtual delete http_loadbalancer example-lb -ns default"
+
+    workflows:
+      deploy_basic_lb:
+        title: "Deploy Basic HTTP Load Balancer"
+        description: "Step-by-step guide to deploy a basic HTTP load balancer"
+        steps:
+          - order: 1
+            description: "Create an origin pool pointing to backend servers"
+            command: "xcsh virtual create origin_pool -f origin-pool.yaml"
+          - order: 2
+            description: "Create a health check (optional)"
+            command: "xcsh virtual create healthcheck -f healthcheck.yaml"
+          - order: 3
+            description: "Create the HTTP load balancer"
+            command: "xcsh virtual create http_loadbalancer -f lb.yaml"
+          - order: 4
+            description: "Verify deployment"
+            command: "xcsh virtual get http_loadbalancer example-lb -ns default"
+
+  tenant_and_identity:
+    display_name: "Tenant and Identity"
+    cli_domain: "tenant_and_identity"
+    examples:
+      list_namespaces:
+        description: "List all namespaces"
+        command: "xcsh tenant_and_identity list namespace"
+        output: |
+          NAME           DESCRIPTION
+          default        Default namespace
+          shared         Shared namespace
+          system         System namespace
+
+  sites:
+    display_name: "Sites"
+    cli_domain: "sites"
+    examples:
+      list_aws:
+        description: "List all AWS VPC sites"
+        command: "xcsh sites list aws_vpc_site"
+      get_aws:
+        description: "Get AWS VPC site details"
+        command: "xcsh sites get aws_vpc_site my-aws-site -o yaml"
+      list_azure:
+        description: "List all Azure VNet sites"
+        command: "xcsh sites list azure_vnet_site"
+
+# Quick reference commands (domain-agnostic)
+quick_reference:
+  - category: "Resource Management"
+    commands:
+      - description: "List resources in a domain"
+        command: "xcsh {domain} list {resource}"
+      - description: "Get resource as YAML"
+        command: "xcsh {domain} get {resource} {name} -o yaml"
+      - description: "Create resource from file"
+        command: "xcsh {domain} create {resource} -f {file}.yaml"
+      - description: "Delete resource"
+        command: "xcsh {domain} delete {resource} {name} -ns {namespace}"
+      - description: "Replace/update resource"
+        command: "xcsh {domain} replace {resource} {name} -f {file}.yaml"
+
+  - category: "Output Formats"
+    commands:
+      - description: "Output as YAML"
+        command: "xcsh {domain} get {resource} {name} -o yaml"
+      - description: "Output as JSON"
+        command: "xcsh {domain} get {resource} {name} -o json"
+      - description: "Wide output with more columns"
+        command: "xcsh {domain} list {resource} -o wide"
+
+  - category: "Namespace Operations"
+    commands:
+      - description: "Specify namespace"
+        command: "xcsh {domain} get {resource} {name} -ns {namespace}"
+      - description: "List in all namespaces"
+        command: "xcsh {domain} list {resource} --all-namespaces"
+
+# AI assistant specific examples
+ai_assistant:
+  description: "Using the xcsh AI assistant for natural language queries"
+  examples:
+    - query: "list all load balancers"
+      interpretation: "Lists HTTP load balancers in the current namespace"
+    - query: "create a load balancer for api.example.com"
+      interpretation: "Generates configuration and creates HTTP LB"
+    - query: "show me the origin pools"
+      interpretation: "Lists origin pools with details"

--- a/docs/guides/generated/admin_console_and_ui.md
+++ b/docs/guides/generated/admin_console_and_ui.md
@@ -1,0 +1,30 @@
+# 🖥️ Admin Console And Ui
+
+Namespace-scoped visual elements with versioning. Custom widget deployment and catalog management for portal surfaces.
+
+**Category:** Platform
+
+## Use Cases
+
+- Manage static UI components for admin console
+- Deploy and retrieve UI assets within namespaces
+- Configure console interface elements
+- Manage custom UI component metadata
+
+## Resource Reference
+
+| Resource | Description | Tier | Dependencies |
+|----------|-------------|------|-------------|
+| `ui_component` | UI component | Standard | None |
+| `static_asset` | Static asset | Standard | None |
+
+## Related Domains
+
+| Domain | Description |
+|--------|-------------|
+| [Admin](admin.md) |  |
+| [System](system.md) |  |
+
+---
+
+*Generated from enriched API specs and local xcsh examples.*

--- a/docs/guides/generated/ai_services.md
+++ b/docs/guides/generated/ai_services.md
@@ -1,0 +1,23 @@
+# 🤖 Ai Services
+
+Natural language processing with quality signals and anomaly monitoring. Token authentication for data stream subscriptions.
+
+**Category:** AI
+
+## Use Cases
+
+- Access AI-powered features
+- Configure AI assistant policies
+- Enable flow anomaly detection
+- Manage AI data collection
+
+## Resource Reference
+
+| Resource | Description | Tier | Dependencies |
+|----------|-------------|------|-------------|
+| `ai_policy` | AI policy | Advanced | None |
+| `ai_gateway` | AI gateway | Advanced | None |
+
+---
+
+*Generated from enriched API specs and local xcsh examples.*

--- a/docs/guides/generated/api.md
+++ b/docs/guides/generated/api.md
@@ -1,0 +1,31 @@
+# 🔐 Api
+
+Resource cataloging with automatic classification and security profiling. Organizational hierarchies segment access by function or protection policy.
+
+**Category:** Security
+
+## Use Cases
+
+- Discover and catalog APIs
+- Test API security and behavior
+- Manage API credentials
+- Define API groups and testing policies
+
+## Resource Reference
+
+| Resource | Description | Tier | Dependencies |
+|----------|-------------|------|-------------|
+| `api_definition` | API definition | Advanced | None |
+| `api_endpoint` | API endpoint | Advanced | None |
+| `api_rate_limit` | API rate limit | Advanced | None |
+
+## Related Domains
+
+| Domain | Description |
+|--------|-------------|
+| [Waf](waf.md) | Request inspection, attack signatures, and bot mitigation. |
+| [Network Security](network_security.md) | NAT policies, firewalls, and segment connections. |
+
+---
+
+*Generated from enriched API specs and local xcsh examples.*

--- a/docs/guides/generated/authentication.md
+++ b/docs/guides/generated/authentication.md
@@ -1,0 +1,32 @@
+# 🔑 Authentication
+
+F5 Distributed Cloud Authentication API specifications
+
+**Category:** Platform
+
+## Use Cases
+
+- Configure authentication mechanisms
+- Manage OIDC and OAuth providers
+- Configure SCIM user provisioning
+- Manage API credentials and access
+- Configure account signup policies
+
+## Resource Reference
+
+| Resource | Description | Tier | Dependencies |
+|----------|-------------|------|-------------|
+| `authentication_policy` | Auth policy | Standard | None |
+| `token` | Token | Standard | None |
+| `api_credential` | API credential | Standard | None |
+
+## Related Domains
+
+| Domain | Description |
+|--------|-------------|
+| [System](system.md) |  |
+| [Users](users.md) | Account tokens, labels, and cloud-init config. |
+
+---
+
+*Generated from enriched API specs and local xcsh examples.*

--- a/docs/guides/generated/bigip.md
+++ b/docs/guides/generated/bigip.md
@@ -1,0 +1,29 @@
+# 🏢 Bigip
+
+Legacy device orchestration with iRule scripts and data group synchronization. Virtual server bindings and metrics collection.
+
+**Category:** Platform
+
+## Use Cases
+
+- Manage BigIP F5 appliances
+- Configure iRule scripts
+- Manage data groups
+- Integrate BigIP CNE
+
+## Resource Reference
+
+| Resource | Description | Tier | Dependencies |
+|----------|-------------|------|-------------|
+| `bigip_pool` | BIG-IP pool | Advanced | None |
+| `bigip_device` | BIG-IP device | Advanced | None |
+
+## Related Domains
+
+| Domain | Description |
+|--------|-------------|
+| [Marketplace](marketplace.md) | Add-on services, connectors, and TPM policies. |
+
+---
+
+*Generated from enriched API specs and local xcsh examples.*

--- a/docs/guides/generated/billing_and_usage.md
+++ b/docs/guides/generated/billing_and_usage.md
@@ -1,0 +1,31 @@
+# 💳 Billing And Usage
+
+Plan transitions, invoicing, and resource consumption. Namespace-level quota limits and usage tracking.
+
+**Category:** Platform
+
+## Use Cases
+
+- Manage subscription plans and billing transitions
+- Configure payment methods and invoices
+- Track resource quota usage across namespaces
+- Monitor usage limits and capacity
+
+## Resource Reference
+
+| Resource | Description | Tier | Dependencies |
+|----------|-------------|------|-------------|
+| `subscription` | Subscription | Standard | None |
+| `quota` | Quota | Standard | None |
+| `usage_report` | Usage report | Standard | None |
+
+## Related Domains
+
+| Domain | Description |
+|--------|-------------|
+| [System](system.md) |  |
+| [Users](users.md) | Account tokens, labels, and cloud-init config. |
+
+---
+
+*Generated from enriched API specs and local xcsh examples.*

--- a/docs/guides/generated/blindfold.md
+++ b/docs/guides/generated/blindfold.md
@@ -1,0 +1,30 @@
+# 🔏 Blindfold
+
+Encryption key management with policy-based access controls. Audit logging and secure data protection.
+
+**Category:** Security
+
+## Use Cases
+
+- Configure secret policies for encryption
+- Manage sensitive data encryption
+- Enforce data protection policies
+
+## Resource Reference
+
+| Resource | Description | Tier | Dependencies |
+|----------|-------------|------|-------------|
+| `blindfold_secret` | Blindfold secret | Standard | None |
+| `secret_policy` | Secret policy | Standard | None |
+| `policy_document` | Policy document | Standard | None |
+
+## Related Domains
+
+| Domain | Description |
+|--------|-------------|
+| [Client Side Defense](client_side_defense.md) |  |
+| [Certificates](certificates.md) | SSL/TLS chains, trusted CAs, and revocation lists. |
+
+---
+
+*Generated from enriched API specs and local xcsh examples.*

--- a/docs/guides/generated/bot_and_threat_defense.md
+++ b/docs/guides/generated/bot_and_threat_defense.md
@@ -1,0 +1,31 @@
+# 🦠 Bot And Threat Defense
+
+Threat classification with behavioral analysis and signature matching. Automated blocking for malicious traffic patterns.
+
+**Category:** Security
+
+## Use Cases
+
+- Configure bot defense instances per namespace
+- Manage TPM threat categories for classification
+- Provision API keys for automated defense systems
+- Integrate threat intelligence services
+
+## Resource Reference
+
+| Resource | Description | Tier | Dependencies |
+|----------|-------------|------|-------------|
+| `bot_defense_instance` | Bot defense instance | Advanced | None |
+| `threat_category` | Threat category | Advanced | None |
+
+## Related Domains
+
+| Domain | Description |
+|--------|-------------|
+| [Bot Defense](bot_defense.md) |  |
+| [Shape](shape.md) | Bot defense, fraud prevention, and client integrity. |
+| [Waf](waf.md) | Request inspection, attack signatures, and bot mitigation. |
+
+---
+
+*Generated from enriched API specs and local xcsh examples.*

--- a/docs/guides/generated/cdn.md
+++ b/docs/guides/generated/cdn.md
@@ -1,0 +1,29 @@
+# 🚀 Cdn
+
+Path-based policies with TTL controls and header conditions. Purge operations, access logs, and cache eligibility for multi-region deployments.
+
+**Category:** Networking
+
+## Use Cases
+
+- Configure CDN load balancing
+- Manage content delivery network services
+- Configure caching policies
+- Manage data delivery and distribution
+
+## Resource Reference
+
+| Resource | Description | Tier | Dependencies |
+|----------|-------------|------|-------------|
+| `cdn_loadbalancer` | CDN load balancer | Standard | cdn_origin_pool |
+| `cdn_origin_pool` | CDN origin pool | Standard | None |
+
+## Related Domains
+
+| Domain | Description |
+|--------|-------------|
+| [Virtual](virtual.md) | HTTP, TCP, UDP load balancers and origin pools. |
+
+---
+
+*Generated from enriched API specs and local xcsh examples.*

--- a/docs/guides/generated/ce_management.md
+++ b/docs/guides/generated/ce_management.md
@@ -1,0 +1,31 @@
+# 🔧 Ce Management
+
+Token-based provisioning with image downloads and pre-upgrade validation. Fleet grouping enables bulk operations across distributed locations.
+
+**Category:** Infrastructure
+
+## Use Cases
+
+- Manage Customer Edge site lifecycle
+- Configure network interfaces and fleet settings
+- Handle site registration and token workflows
+- Execute site upgrades with pre-upgrade checks
+
+## Resource Reference
+
+| Resource | Description | Tier | Dependencies |
+|----------|-------------|------|-------------|
+| `site_config` | Site config | Standard | None |
+| `fleet_config` | Fleet config | Standard | None |
+| `registration_token` | Registration token | Standard | None |
+
+## Related Domains
+
+| Domain | Description |
+|--------|-------------|
+| [Customer Edge](customer_edge.md) |  |
+| [Sites](sites.md) | Cloud and edge node deployments. |
+
+---
+
+*Generated from enriched API specs and local xcsh examples.*

--- a/docs/guides/generated/certificates.md
+++ b/docs/guides/generated/certificates.md
@@ -1,0 +1,31 @@
+# 📜 Certificates
+
+Certificate chains and trusted CA bundles. Revocation list management and manifest configuration for PKI operations.
+
+**Category:** Security
+
+## Use Cases
+
+- Manage SSL/TLS certificates
+- Configure trusted CAs
+- Manage certificate revocation lists (CRL)
+- Configure certificate manifests
+
+## Resource Reference
+
+| Resource | Description | Tier | Dependencies |
+|----------|-------------|------|-------------|
+| `certificate` | Certificate | Standard | None |
+| `ca_certificate` | CA certificate | Standard | None |
+| `certificate_chain` | Certificate chain | Standard | None |
+
+## Related Domains
+
+| Domain | Description |
+|--------|-------------|
+| [Blindfold](blindfold.md) | Secret encryption, key policies, and audit trails. |
+| [System](system.md) |  |
+
+---
+
+*Generated from enriched API specs and local xcsh examples.*

--- a/docs/guides/generated/cloud_infrastructure.md
+++ b/docs/guides/generated/cloud_infrastructure.md
@@ -1,0 +1,32 @@
+# ☁️ Cloud Infrastructure
+
+Multi-cloud provider connections with gateway peering and network path configuration. Credential vault integration and subnet enumeration.
+
+**Category:** Infrastructure
+
+## Use Cases
+
+- Connect to cloud providers (AWS, Azure, GCP)
+- Manage cloud credentials and authentication
+- Configure cloud connectivity and elastic provisioning
+- Link and manage cloud regions
+
+## Resource Reference
+
+| Resource | Description | Tier | Dependencies |
+|----------|-------------|------|-------------|
+| `aws_vpc_site` | AWS VPC site | Standard | cloud_credentials |
+| `azure_vnet_site` | Azure VNet site | Standard | cloud_credentials |
+| `gcp_vpc_site` | GCP VPC site | Standard | cloud_credentials |
+| `cloud_credentials` | Cloud credentials | Standard | None |
+
+## Related Domains
+
+| Domain | Description |
+|--------|-------------|
+| [Sites](sites.md) | Cloud and edge node deployments. |
+| [Customer Edge](customer_edge.md) |  |
+
+---
+
+*Generated from enriched API specs and local xcsh examples.*

--- a/docs/guides/generated/container_services.md
+++ b/docs/guides/generated/container_services.md
@@ -1,0 +1,32 @@
+# 📦 Container Services
+
+Pod orchestration without full cluster complexity. Edge site execution, quota enforcement, and standardized compute profiles for distributed apps.
+
+**Category:** Infrastructure
+
+## Use Cases
+
+- Deploy XCCS (Container Services) namespaces for multi-tenant workloads
+- Manage container workloads with simplified orchestration
+- Configure distributed edge container deployments
+- Run containerized applications without full K8s complexity
+
+## Resource Reference
+
+| Resource | Description | Tier | Dependencies |
+|----------|-------------|------|-------------|
+| `virtual_k8s` | Virtual K8s | Advanced | None |
+| `workload` | Workload | Advanced | virtual_k8s |
+| `pod_security_policy` | Pod security policy | Advanced | None |
+
+## Related Domains
+
+| Domain | Description |
+|--------|-------------|
+| [Managed Kubernetes](managed_kubernetes.md) | Cluster RBAC, pod security, and container registries. |
+| [Sites](sites.md) | Cloud and edge node deployments. |
+| [Service Mesh](service_mesh.md) | Microservice routing and sidecar configuration. |
+
+---
+
+*Generated from enriched API specs and local xcsh examples.*

--- a/docs/guides/generated/data_and_privacy_security.md
+++ b/docs/guides/generated/data_and_privacy_security.md
@@ -1,0 +1,30 @@
+# 🔐 Data And Privacy Security
+
+Sensitive data policies with custom classification rules. LMA region configuration and geo-based compliance controls.
+
+**Category:** Security
+
+## Use Cases
+
+- Configure sensitive data detection policies
+- Define custom data types for PII classification
+- Manage LMA region configurations
+- Integrate geo-configurations for compliance
+
+## Resource Reference
+
+| Resource | Description | Tier | Dependencies |
+|----------|-------------|------|-------------|
+| `sensitive_data_policy` | Sensitive data policy | Advanced | None |
+| `data_classification` | Data classification | Advanced | None |
+
+## Related Domains
+
+| Domain | Description |
+|--------|-------------|
+| [Blindfold](blindfold.md) | Secret encryption, key policies, and audit trails. |
+| [Client Side Defense](client_side_defense.md) |  |
+
+---
+
+*Generated from enriched API specs and local xcsh examples.*

--- a/docs/guides/generated/data_intelligence.md
+++ b/docs/guides/generated/data_intelligence.md
@@ -1,0 +1,29 @@
+# 🧠 Data Intelligence
+
+F5 Distributed Cloud Data Intelligence API specifications
+
+**Category:** Operations
+
+## Use Cases
+
+- Analyze security and traffic data
+- Generate intelligent insights from logs
+- Configure data analytics policies
+
+## Resource Reference
+
+| Resource | Description | Tier | Dependencies |
+|----------|-------------|------|-------------|
+| `analytics_query` | Analytics query | Standard | None |
+| `data_export` | Data export | Standard | None |
+
+## Related Domains
+
+| Domain | Description |
+|--------|-------------|
+| [Statistics](statistics.md) | Alerts, logs, flow analytics, and reporting. |
+| [Observability](observability.md) | Synthetic health checks and DNS resolution validation. |
+
+---
+
+*Generated from enriched API specs and local xcsh examples.*

--- a/docs/guides/generated/ddos.md
+++ b/docs/guides/generated/ddos.md
@@ -1,0 +1,29 @@
+# 🛑 Ddos
+
+Deny lists, firewall rule groups, and tunnel-based safeguards. Rate limiting and pattern analysis for network perimeter security.
+
+**Category:** Security
+
+## Use Cases
+
+- Configure DDoS protection policies
+- Monitor and analyze DDoS threats
+- Configure infrastructure protection
+
+## Resource Reference
+
+| Resource | Description | Tier | Dependencies |
+|----------|-------------|------|-------------|
+| `ddos_protection` | DDoS protection | Advanced | None |
+| `ddos_mitigation_rule` | DDoS mitigation rule | Advanced | None |
+
+## Related Domains
+
+| Domain | Description |
+|--------|-------------|
+| [Network Security](network_security.md) | NAT policies, firewalls, and segment connections. |
+| [Virtual](virtual.md) | HTTP, TCP, UDP load balancers and origin pools. |
+
+---
+
+*Generated from enriched API specs and local xcsh examples.*

--- a/docs/guides/generated/dns.md
+++ b/docs/guides/generated/dns.md
@@ -1,0 +1,31 @@
+# 🌐 Dns
+
+Authoritative zone hosting with BIND and AXFR imports. Health checks, failover policies, and request logging.
+
+**Category:** Networking
+
+## Use Cases
+
+- Configure DNS load balancing
+- Manage DNS zones and domains
+- Configure DNS compliance policies
+- Manage resource record sets (RRSets)
+
+## Resource Reference
+
+| Resource | Description | Tier | Dependencies |
+|----------|-------------|------|-------------|
+| `dns_zone` | DNS zone | Standard | None |
+| `dns_domain` | DNS domain | Standard | None |
+| `dns_load_balancer` | DNS load balancer | Standard | dns_zone |
+
+## Related Domains
+
+| Domain | Description |
+|--------|-------------|
+| [Virtual](virtual.md) | HTTP, TCP, UDP load balancers and origin pools. |
+| [Network](network.md) | BGP peering, IPsec tunnels, and segment policies. |
+
+---
+
+*Generated from enriched API specs and local xcsh examples.*

--- a/docs/guides/generated/index.md
+++ b/docs/guides/generated/index.md
@@ -1,0 +1,71 @@
+# Domain Reference
+
+Generated from enriched API specifications v2.0.7.
+
+## AI
+
+| Domain | Description |
+|--------|-------------|
+| [🤖 Ai Services](ai_services.md) | AI assistant queries and feedback collection. |
+
+## Infrastructure
+
+| Domain | Description |
+|--------|-------------|
+| [🔧 Ce Management](ce_management.md) | Network interfaces, fleets, and site registration. |
+| [☁️ Cloud Infrastructure](cloud_infrastructure.md) | AWS, Azure, GCP connectors and VPC attachments. |
+| [📦 Container Services](container_services.md) | Containerized workloads and virtual Kubernetes clusters. |
+| [⚙️ Managed Kubernetes](managed_kubernetes.md) | Cluster RBAC, pod security, and container registries. |
+| [🕸️ Service Mesh](service_mesh.md) | Microservice routing and sidecar configuration. |
+| [🌍 Sites](sites.md) | Cloud and edge node deployments. |
+
+## Networking
+
+| Domain | Description |
+|--------|-------------|
+| [🚀 Cdn](cdn.md) | Edge caching, content delivery, and distribution rules. |
+| [🌐 Dns](dns.md) | Zones, record types, and load balancing. |
+| [🔌 Network](network.md) | BGP peering, IPsec tunnels, and segment policies. |
+| [⏱️ Rate Limiting](rate_limiting.md) | Request throttling, quotas, and policer rules. |
+| [⚖️ Virtual](virtual.md) | HTTP, TCP, UDP load balancers and origin pools. |
+
+## Operations
+
+| Domain | Description |
+|--------|-------------|
+| [🧠 Data Intelligence](data_intelligence.md) | Data Intelligence API |
+| [📊 Observability](observability.md) | Synthetic health checks and DNS resolution validation. |
+| [📈 Statistics](statistics.md) | Alerts, logs, flow analytics, and reporting. |
+| [🎫 Support](support.md) | Tickets, escalations, and network diagnostics. |
+| [📉 Telemetry And Insights](telemetry_and_insights.md) | Telemetry And Insights API |
+
+## Platform
+
+| Domain | Description |
+|--------|-------------|
+| [🖥️ Admin Console And Ui](admin_console_and_ui.md) | Static UI components and console assets. |
+| [🔑 Authentication](authentication.md) | Authentication API |
+| [🏢 Bigip](bigip.md) | iRules, data groups, and APM integration. |
+| [💳 Billing And Usage](billing_and_usage.md) | Subscription plans, payment methods, and quotas. |
+| [🏪 Marketplace](marketplace.md) | Add-on services, connectors, and TPM policies. |
+| [🟢 Nginx One](nginx_one.md) | NGINX Plus instances and dataplane servers. |
+| [🗄️ Object Storage](object_storage.md) | Mobile SDK assets, versioned binaries, and app shield files. |
+| [🪪 Tenant And Identity](tenant_and_identity.md) | User profiles, sessions, and OTP settings. |
+| [👥 Users](users.md) | Account tokens, labels, and cloud-init config. |
+| [🖥️ Vpm And Node Management](vpm_and_node_management.md) | Vpm And Node Management API |
+
+## Security
+
+| Domain | Description |
+|--------|-------------|
+| [🔐 Api](api.md) | Interface definitions, schema validation, and grouping. |
+| [🔏 Blindfold](blindfold.md) | Secret encryption, key policies, and audit trails. |
+| [🦠 Bot And Threat Defense](bot_and_threat_defense.md) | Bot detection, threat categories, and defense instances. |
+| [📜 Certificates](certificates.md) | SSL/TLS chains, trusted CAs, and revocation lists. |
+| [🔐 Data And Privacy Security](data_and_privacy_security.md) | PII detection, data types, and regional compliance. |
+| [🛑 Ddos](ddos.md) | Volumetric attack mitigation and traffic scrubbing. |
+| [🔒 Network Security](network_security.md) | NAT policies, firewalls, and segment connections. |
+| [🚨 Secops And Incident Response](secops_and_incident_response.md) | Threat detection, user risk scoring, and automated blocking. |
+| [🎭 Shape](shape.md) | Bot defense, fraud prevention, and client integrity. |
+| [⚠️ Threat Campaign](threat_campaign.md) | Threat Campaign API |
+| [🛡️ Waf](waf.md) | Request inspection, attack signatures, and bot mitigation. |

--- a/docs/guides/generated/managed_kubernetes.md
+++ b/docs/guides/generated/managed_kubernetes.md
@@ -1,0 +1,32 @@
+# ⚙️ Managed Kubernetes
+
+Kubernetes role bindings and admission policies. Registry integration for EKS, AKS, and GKE workloads.
+
+**Category:** Infrastructure
+
+## Use Cases
+
+- Manage XCKS (Managed Kubernetes) cluster RBAC and security
+- Configure pod security policies and admission controllers
+- Manage container registries for enterprise deployments
+- Integrate with external Kubernetes clusters (EKS, AKS, GKE)
+
+## Resource Reference
+
+| Resource | Description | Tier | Dependencies |
+|----------|-------------|------|-------------|
+| `mk8s_cluster` | MK8s cluster | Advanced | None |
+| `k8s_cluster_role` | K8s cluster role | Advanced | None |
+| `container_registry` | Container registry | Advanced | None |
+
+## Related Domains
+
+| Domain | Description |
+|--------|-------------|
+| [Container Services](container_services.md) | Containerized workloads and virtual Kubernetes clusters. |
+| [Sites](sites.md) | Cloud and edge node deployments. |
+| [Service Mesh](service_mesh.md) | Microservice routing and sidecar configuration. |
+
+---
+
+*Generated from enriched API specs and local xcsh examples.*

--- a/docs/guides/generated/marketplace.md
+++ b/docs/guides/generated/marketplace.md
@@ -1,0 +1,30 @@
+# 🏪 Marketplace
+
+Third-party GRE and IPSec tunnel provisioning with DPD timers. Shared resource allocation across namespaces with tile placement controls.
+
+**Category:** Platform
+
+## Use Cases
+
+- Access third-party integrations and add-ons
+- Manage marketplace extensions
+- Configure Terraform and external integrations
+- Manage TPM policies
+
+## Resource Reference
+
+| Resource | Description | Tier | Dependencies |
+|----------|-------------|------|-------------|
+| `marketplace_item` | Marketplace item | Standard | None |
+| `subscription` | Subscription | Standard | None |
+
+## Related Domains
+
+| Domain | Description |
+|--------|-------------|
+| [Bigip](bigip.md) | iRules, data groups, and APM integration. |
+| [Admin](admin.md) |  |
+
+---
+
+*Generated from enriched API specs and local xcsh examples.*

--- a/docs/guides/generated/network.md
+++ b/docs/guides/generated/network.md
@@ -1,0 +1,34 @@
+# 🔌 Network
+
+Border gateway protocol with ASN management and autonomous system relationships. Site-to-site VPN linking datacenters through encrypted channels.
+
+**Category:** Networking
+
+## Use Cases
+
+- Configure BGP routing and ASN management
+- Manage IPsec tunnels and IKE phases
+- Configure network connectors and routes
+- Manage SRv6 and subnetting
+- Define segment connections and policies
+- Configure IP prefix sets
+
+## Resource Reference
+
+| Resource | Description | Tier | Dependencies |
+|----------|-------------|------|-------------|
+| `virtual_network` | Virtual network | Standard | None |
+| `network_connector` | Network connector | Advanced | virtual_network |
+| `site_mesh_group` | Site mesh group | Advanced | site |
+
+## Related Domains
+
+| Domain | Description |
+|--------|-------------|
+| [Virtual](virtual.md) | HTTP, TCP, UDP load balancers and origin pools. |
+| [Network Security](network_security.md) | NAT policies, firewalls, and segment connections. |
+| [Dns](dns.md) | Zones, record types, and load balancing. |
+
+---
+
+*Generated from enriched API specs and local xcsh examples.*

--- a/docs/guides/generated/network_security.md
+++ b/docs/guides/generated/network_security.md
@@ -1,0 +1,33 @@
+# 🔒 Network Security
+
+Firewall rules with routing decisions based on source, destination, or protocol. Segmentation isolates workloads while outbound proxies govern access.
+
+**Category:** Security
+
+## Use Cases
+
+- Configure network firewall and ACL policies
+- Manage NAT policies and port forwarding
+- Configure policy-based routing
+- Define network segments and policies
+- Configure forward proxy policies
+
+## Resource Reference
+
+| Resource | Description | Tier | Dependencies |
+|----------|-------------|------|-------------|
+| `network_policy` | Network policy | Standard | None |
+| `forward_proxy_policy` | Forward proxy policy | Advanced | None |
+| `network_firewall` | Network firewall | Standard | None |
+
+## Related Domains
+
+| Domain | Description |
+|--------|-------------|
+| [Waf](waf.md) | Request inspection, attack signatures, and bot mitigation. |
+| [Api](api.md) | Interface definitions, schema validation, and grouping. |
+| [Network](network.md) | BGP peering, IPsec tunnels, and segment policies. |
+
+---
+
+*Generated from enriched API specs and local xcsh examples.*

--- a/docs/guides/generated/nginx_one.md
+++ b/docs/guides/generated/nginx_one.md
@@ -1,0 +1,28 @@
+# 🟢 Nginx One
+
+Instance discovery, WAF integration, and service mesh connectivity. Subscription lifecycle and configuration synchronization.
+
+**Category:** Platform
+
+## Use Cases
+
+- Manage NGINX One platform integrations
+- Configure NGINX Plus instances
+- Integrate NGINX configuration management
+
+## Resource Reference
+
+| Resource | Description | Tier | Dependencies |
+|----------|-------------|------|-------------|
+| `nginx_config` | NGINX config | Advanced | None |
+| `nginx_upstream` | NGINX upstream | Advanced | None |
+
+## Related Domains
+
+| Domain | Description |
+|--------|-------------|
+| [Marketplace](marketplace.md) | Add-on services, connectors, and TPM policies. |
+
+---
+
+*Generated from enriched API specs and local xcsh examples.*

--- a/docs/guides/generated/object_storage.md
+++ b/docs/guides/generated/object_storage.md
@@ -1,0 +1,28 @@
+# 🗄️ Object Storage
+
+Versioned library distribution for mobile app integrators. Presigned URLs enable secure downloads with OS-specific builds for iOS and Android.
+
+**Category:** Platform
+
+## Use Cases
+
+- Manage object storage services
+- Configure stored objects and buckets
+- Manage storage policies
+
+## Resource Reference
+
+| Resource | Description | Tier | Dependencies |
+|----------|-------------|------|-------------|
+| `object_store` | Object store | Standard | None |
+| `bucket` | Bucket | Standard | object_store |
+
+## Related Domains
+
+| Domain | Description |
+|--------|-------------|
+| [Marketplace](marketplace.md) | Add-on services, connectors, and TPM policies. |
+
+---
+
+*Generated from enriched API specs and local xcsh examples.*

--- a/docs/guides/generated/observability.md
+++ b/docs/guides/generated/observability.md
@@ -1,0 +1,30 @@
+# 📊 Observability
+
+HTTP availability probes with latency measurement. Certificate expiration alerts and global status dashboards for infrastructure health.
+
+**Category:** Operations
+
+## Use Cases
+
+- Configure synthetic monitoring
+- Define monitoring and testing policies
+- Manage observability dashboards
+
+## Resource Reference
+
+| Resource | Description | Tier | Dependencies |
+|----------|-------------|------|-------------|
+| `log_receiver` | Log receiver | Standard | None |
+| `metrics_receiver` | Metrics receiver | Standard | None |
+| `alert_policy` | Alert policy | Standard | None |
+
+## Related Domains
+
+| Domain | Description |
+|--------|-------------|
+| [Statistics](statistics.md) | Alerts, logs, flow analytics, and reporting. |
+| [Support](support.md) | Tickets, escalations, and network diagnostics. |
+
+---
+
+*Generated from enriched API specs and local xcsh examples.*

--- a/docs/guides/generated/quick-reference.md
+++ b/docs/guides/generated/quick-reference.md
@@ -1,0 +1,42 @@
+# Quick Reference
+
+Common xcsh CLI commands and patterns.
+
+## Resource Management
+
+| Description | Command |
+|-------------|--------|
+| List resources in a domain | `xcsh {domain} list {resource}` |
+| Get resource as YAML | `xcsh {domain} get {resource} {name} -o yaml` |
+| Create resource from file | `xcsh {domain} create {resource} -f {file}.yaml` |
+| Delete resource | `xcsh {domain} delete {resource} {name} -ns {namespace}` |
+| Replace/update resource | `xcsh {domain} replace {resource} {name} -f {file}.yaml` |
+
+## Output Formats
+
+| Description | Command |
+|-------------|--------|
+| Output as YAML | `xcsh {domain} get {resource} {name} -o yaml` |
+| Output as JSON | `xcsh {domain} get {resource} {name} -o json` |
+| Wide output with more columns | `xcsh {domain} list {resource} -o wide` |
+
+## Namespace Operations
+
+| Description | Command |
+|-------------|--------|
+| Specify namespace | `xcsh {domain} get {resource} {name} -ns {namespace}` |
+| List in all namespaces | `xcsh {domain} list {resource} --all-namespaces` |
+
+## AI Assistant
+
+Using the xcsh AI assistant for natural language queries
+
+| Query | Interpretation |
+|-------|---------------|
+| "list all load balancers" | Lists HTTP load balancers in the current namespace |
+| "create a load balancer for api.example.com" | Generates configuration and creates HTTP LB |
+| "show me the origin pools" | Lists origin pools with details |
+
+---
+
+*CLI examples specific to xcsh. See domain guides for API resource details.*

--- a/docs/guides/generated/rate_limiting.md
+++ b/docs/guides/generated/rate_limiting.md
@@ -1,0 +1,30 @@
+# ⏱️ Rate Limiting
+
+Time-based quota enforcement with configurable windows in hours, minutes, or seconds. Protocol-specific controls for traffic shaping.
+
+**Category:** Networking
+
+## Use Cases
+
+- Configure rate limiter policies
+- Manage policer configurations
+- Control traffic flow and queuing
+
+## Resource Reference
+
+| Resource | Description | Tier | Dependencies |
+|----------|-------------|------|-------------|
+| `rate_limiter` | Rate limiter | Standard | None |
+| `rate_limiter_policy` | Rate limiter policy | Standard | None |
+| `rate_limit_threshold` | Rate limit threshold | Standard | None |
+
+## Related Domains
+
+| Domain | Description |
+|--------|-------------|
+| [Virtual](virtual.md) | HTTP, TCP, UDP load balancers and origin pools. |
+| [Network Security](network_security.md) | NAT policies, firewalls, and segment connections. |
+
+---
+
+*Generated from enriched API specs and local xcsh examples.*

--- a/docs/guides/generated/secops_and_incident_response.md
+++ b/docs/guides/generated/secops_and_incident_response.md
@@ -1,0 +1,31 @@
+# 🚨 Secops And Incident Response
+
+Malicious user mitigation with threat level classification. Automated response actions for suspicious behavior patterns.
+
+**Category:** Security
+
+## Use Cases
+
+- Configure automated threat mitigation policies
+- Define rules for malicious user detection
+- Manage incident response workflows
+- Apply blocking or rate limiting to threats
+
+## Resource Reference
+
+| Resource | Description | Tier | Dependencies |
+|----------|-------------|------|-------------|
+| `mitigation_policy` | Mitigation policy | Advanced | None |
+| `malicious_user_rule` | Malicious user rule | Advanced | None |
+
+## Related Domains
+
+| Domain | Description |
+|--------|-------------|
+| [Bot Defense](bot_defense.md) |  |
+| [Waf](waf.md) | Request inspection, attack signatures, and bot mitigation. |
+| [Network Security](network_security.md) | NAT policies, firewalls, and segment connections. |
+
+---
+
+*Generated from enriched API specs and local xcsh examples.*

--- a/docs/guides/generated/service_mesh.md
+++ b/docs/guides/generated/service_mesh.md
@@ -1,0 +1,32 @@
+# 🕸️ Service Mesh
+
+Application type definitions with discovery and learned schema analysis. Traffic pattern inference for intelligent request handling.
+
+**Category:** Infrastructure
+
+## Use Cases
+
+- Configure service mesh connectivity
+- Manage endpoint discovery and routing
+- Configure NFV services
+- Define application settings and types
+
+## Resource Reference
+
+| Resource | Description | Tier | Dependencies |
+|----------|-------------|------|-------------|
+| `endpoint` | Endpoint | Advanced | None |
+| `origin_pool` | Origin pool | Standard | None |
+| `service_discovery` | Service discovery | Advanced | None |
+
+## Related Domains
+
+| Domain | Description |
+|--------|-------------|
+| [Managed Kubernetes](managed_kubernetes.md) | Cluster RBAC, pod security, and container registries. |
+| [Container Services](container_services.md) | Containerized workloads and virtual Kubernetes clusters. |
+| [Virtual](virtual.md) | HTTP, TCP, UDP load balancers and origin pools. |
+
+---
+
+*Generated from enriched API specs and local xcsh examples.*

--- a/docs/guides/generated/shape.md
+++ b/docs/guides/generated/shape.md
@@ -1,0 +1,30 @@
+# 🎭 Shape
+
+Threat recognition with behavioral analysis and device fingerprinting. Mobile SDK integration for application shielding.
+
+**Category:** Security
+
+## Use Cases
+
+- Configure Shape Security policies
+- Manage bot and threat prevention
+- Configure SafeAP policies
+- Enable threat recognition
+
+## Resource Reference
+
+| Resource | Description | Tier | Dependencies |
+|----------|-------------|------|-------------|
+| `shape_app_firewall` | Shape WAF | Advanced | None |
+| `shape_recognizer` | Shape recognizer | Advanced | None |
+
+## Related Domains
+
+| Domain | Description |
+|--------|-------------|
+| [Bot Defense](bot_defense.md) |  |
+| [Waf](waf.md) | Request inspection, attack signatures, and bot mitigation. |
+
+---
+
+*Generated from enriched API specs and local xcsh examples.*

--- a/docs/guides/generated/sites.md
+++ b/docs/guides/generated/sites.md
@@ -1,0 +1,60 @@
+# 🌍 Sites
+
+AWS, Azure, GCP VPC integration with transit gateways. Label-based selection for policy application across regions.
+
+**Category:** Infrastructure
+
+## CLI Examples
+
+### List Aws
+
+List all AWS VPC sites
+
+```bash
+xcsh sites list aws_vpc_site
+```
+
+### Get Aws
+
+Get AWS VPC site details
+
+```bash
+xcsh sites get aws_vpc_site my-aws-site -o yaml
+```
+
+### List Azure
+
+List all Azure VNet sites
+
+```bash
+xcsh sites list azure_vnet_site
+```
+
+## Use Cases
+
+- Deploy F5 XC across cloud providers (AWS, Azure, GCP)
+- Manage XCKS (Managed Kubernetes) site deployments (formerly AppStack)
+- Deploy Secure Mesh sites for networking-focused edge deployments
+- Integrate external Kubernetes clusters as Customer Edge
+- Configure AWS VPC, Azure VNet, and GCP VPC sites
+- Manage virtual sites and site policies
+
+## Resource Reference
+
+| Resource | Description | Tier | Dependencies |
+|----------|-------------|------|-------------|
+| `site` | Site | Standard | None |
+| `virtual_site` | Virtual site | Standard | None |
+| `site_mesh_group` | Site mesh group | Advanced | site |
+
+## Related Domains
+
+| Domain | Description |
+|--------|-------------|
+| [Cloud Infrastructure](cloud_infrastructure.md) | AWS, Azure, GCP connectors and VPC attachments. |
+| [Customer Edge](customer_edge.md) |  |
+| [Managed Kubernetes](managed_kubernetes.md) | Cluster RBAC, pod security, and container registries. |
+
+---
+
+*Generated from enriched API specs and local xcsh examples.*

--- a/docs/guides/generated/statistics.md
+++ b/docs/guides/generated/statistics.md
@@ -1,0 +1,32 @@
+# 📈 Statistics
+
+Alerting policies with receiver integrations. Log aggregation, topology views, and site health tracking.
+
+**Category:** Operations
+
+## Use Cases
+
+- Access flow statistics and analytics
+- Manage alerts and alerting policies
+- View logs and log receivers
+- Generate reports and graphs
+- Track topology and service discovery
+- Monitor status at sites
+
+## Resource Reference
+
+| Resource | Description | Tier | Dependencies |
+|----------|-------------|------|-------------|
+| `dashboard` | Dashboard | Standard | None |
+| `saved_query` | Saved query | Standard | None |
+
+## Related Domains
+
+| Domain | Description |
+|--------|-------------|
+| [Observability](observability.md) | Synthetic health checks and DNS resolution validation. |
+| [Support](support.md) | Tickets, escalations, and network diagnostics. |
+
+---
+
+*Generated from enriched API specs and local xcsh examples.*

--- a/docs/guides/generated/support.md
+++ b/docs/guides/generated/support.md
@@ -1,0 +1,30 @@
+# 🎫 Support
+
+Issue lifecycle with comments, severity changes, and resolution tracking. Packet capture for connection analysis.
+
+**Category:** Operations
+
+## Use Cases
+
+- Submit and manage support tickets
+- Track customer support requests
+- Access operational support documentation
+
+## Resource Reference
+
+| Resource | Description | Tier | Dependencies |
+|----------|-------------|------|-------------|
+| `support_case` | Support case | Standard | None |
+| `alert` | Alert | Standard | None |
+| `audit_log` | Audit log | Standard | None |
+
+## Related Domains
+
+| Domain | Description |
+|--------|-------------|
+| [Statistics](statistics.md) | Alerts, logs, flow analytics, and reporting. |
+| [Observability](observability.md) | Synthetic health checks and DNS resolution validation. |
+
+---
+
+*Generated from enriched API specs and local xcsh examples.*

--- a/docs/guides/generated/telemetry_and_insights.md
+++ b/docs/guides/generated/telemetry_and_insights.md
@@ -1,0 +1,29 @@
+# 📉 Telemetry And Insights
+
+F5 Distributed Cloud Telemetry And Insights API specifications
+
+**Category:** Operations
+
+## Use Cases
+
+- Collect and analyze telemetry data
+- Generate actionable insights from metrics
+- Configure telemetry collection policies
+
+## Resource Reference
+
+| Resource | Description | Tier | Dependencies |
+|----------|-------------|------|-------------|
+| `telemetry_receiver` | Telemetry receiver | Standard | None |
+| `insight_query` | Insight query | Standard | None |
+
+## Related Domains
+
+| Domain | Description |
+|--------|-------------|
+| [Observability](observability.md) | Synthetic health checks and DNS resolution validation. |
+| [Statistics](statistics.md) | Alerts, logs, flow analytics, and reporting. |
+
+---
+
+*Generated from enriched API specs and local xcsh examples.*

--- a/docs/guides/generated/tenant_and_identity.md
+++ b/docs/guides/generated/tenant_and_identity.md
@@ -1,0 +1,51 @@
+# 🪪 Tenant And Identity
+
+Account view configurations and admin alert channels. One-time password resets, provisioning flows, and active connection monitoring.
+
+**Category:** Platform
+
+## CLI Examples
+
+### List Namespaces
+
+List all namespaces
+
+```bash
+xcsh tenant_and_identity list namespace
+```
+
+**Output:**
+
+```text
+NAME           DESCRIPTION
+default        Default namespace
+shared         Shared namespace
+system         System namespace
+```
+
+## Use Cases
+
+- Manage user profiles and notification preferences
+- Configure session controls and OTP settings
+- Handle identity management operations
+- Process initial user access requests
+
+## Resource Reference
+
+| Resource | Description | Tier | Dependencies |
+|----------|-------------|------|-------------|
+| `user_profile` | User profile | Standard | None |
+| `session` | Session | Standard | None |
+| `otp_policy` | OTP policy | Standard | None |
+
+## Related Domains
+
+| Domain | Description |
+|--------|-------------|
+| [Users](users.md) | Account tokens, labels, and cloud-init config. |
+| [Authentication](authentication.md) | Authentication API |
+| [System](system.md) |  |
+
+---
+
+*Generated from enriched API specs and local xcsh examples.*

--- a/docs/guides/generated/threat_campaign.md
+++ b/docs/guides/generated/threat_campaign.md
@@ -1,0 +1,28 @@
+# ⚠️ Threat Campaign
+
+F5 Distributed Cloud Threat Campaign API specifications
+
+**Category:** Security
+
+## Use Cases
+
+- Track and analyze threat campaigns
+- Monitor active threats and attack patterns
+- Configure threat intelligence integration
+
+## Resource Reference
+
+| Resource | Description | Tier | Dependencies |
+|----------|-------------|------|-------------|
+| `threat_campaign_policy` | Threat campaign policy | Advanced | None |
+
+## Related Domains
+
+| Domain | Description |
+|--------|-------------|
+| [Bot Defense](bot_defense.md) |  |
+| [Ddos](ddos.md) | Volumetric attack mitigation and traffic scrubbing. |
+
+---
+
+*Generated from enriched API specs and local xcsh examples.*

--- a/docs/guides/generated/users.md
+++ b/docs/guides/generated/users.md
@@ -1,0 +1,31 @@
+# 👥 Users
+
+Site enrollment credentials with automatic expiration. Taxonomy keys define allowed categorization while auto-derived tags apply dynamically.
+
+**Category:** Platform
+
+## Use Cases
+
+- Manage user accounts and tokens
+- Configure user identification
+- Manage user settings and preferences
+- Configure implicit and known labels
+
+## Resource Reference
+
+| Resource | Description | Tier | Dependencies |
+|----------|-------------|------|-------------|
+| `user` | User | Standard | None |
+| `user_role` | User role | Standard | None |
+| `namespace_role` | Namespace role | Standard | None |
+
+## Related Domains
+
+| Domain | Description |
+|--------|-------------|
+| [System](system.md) |  |
+| [Admin](admin.md) |  |
+
+---
+
+*Generated from enriched API specs and local xcsh examples.*

--- a/docs/guides/generated/virtual.md
+++ b/docs/guides/generated/virtual.md
@@ -1,0 +1,124 @@
+# ⚖️ Virtual
+
+Layer 7 routing rules with health checks and failover. Rate limiting, geo-routing, and service policy enforcement.
+
+**Category:** Networking
+
+## CLI Examples
+
+### List
+
+List all HTTP load balancers
+
+```bash
+xcsh virtual list http_loadbalancer
+```
+
+**Output:**
+
+```text
+NAME           NAMESPACE    DOMAINS              STATUS
+example-lb     default      example.com          ACTIVE
+api-lb         production   api.example.com      ACTIVE
+```
+
+### Get
+
+Get HTTP load balancer details
+
+```bash
+xcsh virtual get http_loadbalancer example-lb -ns default -o yaml
+```
+
+**Output:**
+
+```text
+metadata:
+  name: example-lb
+  namespace: default
+spec:
+  domains:
+    - example.com
+  default_route_pools:
+    - pool:
+        name: my-origin-pool
+        namespace: default
+```
+
+### Create
+
+Create HTTP load balancer from file
+
+```bash
+xcsh virtual create http_loadbalancer -f lb.yaml
+```
+
+### Delete
+
+Delete HTTP load balancer
+
+```bash
+xcsh virtual delete http_loadbalancer example-lb -ns default
+```
+
+## Use Cases
+
+- Configure HTTP/TCP/UDP load balancers
+- Manage origin pools and services
+- Configure virtual hosts and routing
+- Define rate limiter and service policies
+- Manage geo-location-based routing
+- Configure proxy and forwarding policies
+- Manage malware protection and threat campaigns
+- Configure health checks and endpoint monitoring
+
+## Resource Reference
+
+| Resource | Description | Tier | Dependencies |
+|----------|-------------|------|-------------|
+| `http_loadbalancer` | HTTP load balancer | Standard | origin_pool |
+| `tcp_loadbalancer` | TCP load balancer | Standard | origin_pool |
+| `origin_pool` | Origin pool | Standard | None |
+| `healthcheck` | Health check | Standard | None |
+
+## CLI Workflows
+
+### Deploy Basic HTTP Load Balancer
+
+Step-by-step guide to deploy a basic HTTP load balancer
+
+1. Create an origin pool pointing to backend servers
+
+```bash
+xcsh virtual create origin_pool -f origin-pool.yaml
+```
+
+2. Create a health check (optional)
+
+```bash
+xcsh virtual create healthcheck -f healthcheck.yaml
+```
+
+3. Create the HTTP load balancer
+
+```bash
+xcsh virtual create http_loadbalancer -f lb.yaml
+```
+
+4. Verify deployment
+
+```bash
+xcsh virtual get http_loadbalancer example-lb -ns default
+```
+
+## Related Domains
+
+| Domain | Description |
+|--------|-------------|
+| [Dns](dns.md) | Zones, record types, and load balancing. |
+| [Service Policy](service_policy.md) |  |
+| [Network](network.md) | BGP peering, IPsec tunnels, and segment policies. |
+
+---
+
+*Generated from enriched API specs and local xcsh examples.*

--- a/docs/guides/generated/vpm_and_node_management.md
+++ b/docs/guides/generated/vpm_and_node_management.md
@@ -1,0 +1,29 @@
+# 🖥️ Vpm And Node Management
+
+F5 Distributed Cloud Vpm And Node Management API specifications
+
+**Category:** Platform
+
+## Use Cases
+
+- Manage Virtual Private Mesh (VPM) configuration
+- Configure node lifecycle and management
+- Monitor VPM and node status
+
+## Resource Reference
+
+| Resource | Description | Tier | Dependencies |
+|----------|-------------|------|-------------|
+| `node_config` | Node config | Standard | None |
+| `vpm_config` | VPM config | Standard | None |
+
+## Related Domains
+
+| Domain | Description |
+|--------|-------------|
+| [Sites](sites.md) | Cloud and edge node deployments. |
+| [System](system.md) |  |
+
+---
+
+*Generated from enriched API specs and local xcsh examples.*

--- a/docs/guides/generated/waf.md
+++ b/docs/guides/generated/waf.md
@@ -1,0 +1,32 @@
+# 🛡️ Waf
+
+Application firewall rules with signature-based detection. Exclusion policies, blocking pages, and anomaly prevention.
+
+**Category:** Security
+
+## Use Cases
+
+- Configure web application firewall rules
+- Manage application security policies
+- Enable enhanced firewall capabilities
+- Configure protocol inspection
+
+## Resource Reference
+
+| Resource | Description | Tier | Dependencies |
+|----------|-------------|------|-------------|
+| `app_firewall` | WAF policy | Advanced | None |
+| `service_policy` | Service policy | Advanced | None |
+| `malicious_user_detection` | Malicious user detection | Advanced | None |
+
+## Related Domains
+
+| Domain | Description |
+|--------|-------------|
+| [Api](api.md) | Interface definitions, schema validation, and grouping. |
+| [Network Security](network_security.md) | NAT policies, firewalls, and segment connections. |
+| [Virtual](virtual.md) | HTTP, TCP, UDP load balancers and origin pools. |
+
+---
+
+*Generated from enriched API specs and local xcsh examples.*

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "generate:logo": "tsx scripts/generate-logo-asset.ts",
     "generate:descriptions": "tsx scripts/generate-descriptions.ts",
     "generate:description-loader": "tsx scripts/generate-description-loader.ts",
+    "generate:docs": "tsx scripts/generate-docs.ts",
     "generate": "npm run generate:domains && npm run generate:completions && npm run generate:logo && npm run generate:description-loader",
     "reconcile:specs": "./scripts/download-specs.sh",
     "prebuild": "node -e \"const fs=require('fs');if(!fs.existsSync('.specs/index.json')){console.log('Specs missing, run: npm run reconcile:specs');process.exit(1)}\" && npm run generate"

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -1,0 +1,635 @@
+#!/usr/bin/env npx tsx
+/**
+ * Documentation Generator Script
+ * Generates docs/guides/*.md from .specs/index.json and local xcsh examples
+ *
+ * Run: npx tsx scripts/generate-docs.ts
+ *
+ * Data sources:
+ * - UPSTREAM (.specs/index.json): Resource descriptions, best practices, field docs
+ * - LOCAL (docs/config/xcsh-examples.yaml): CLI command syntax, xcsh-specific workflows
+ *
+ * This separation ensures:
+ * - Global API content comes from upstream (shared with other downstream projects)
+ * - CLI-specific content stays local (implementation-specific to xcsh)
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import * as yaml from "yaml";
+
+// Types for spec data
+interface SpecPrimaryResource {
+	name: string;
+	description: string;
+	description_short: string;
+	tier: string;
+	icon?: string;
+	category?: string;
+	dependencies?: {
+		required?: string[];
+		optional?: string[];
+	};
+	relationship_hints?: string[];
+}
+
+interface WorkflowStep {
+	order: number;
+	action: string;
+	resource?: string;
+	description: string;
+	example_ref?: string;
+	command?: string;
+}
+
+interface CliMetadata {
+	common_workflows?: Array<{
+		id: string;
+		title: string;
+		description?: string;
+		steps?: WorkflowStep[];
+	}>;
+	quick_start?: string;
+	troubleshooting?: Array<{
+		issue: string;
+		solution: string;
+	}>;
+}
+
+// Future extensions (feature requests #324, #325, #326)
+interface GuidedWorkflow {
+	id: string;
+	title: string;
+	description?: string;
+	difficulty?: string;
+	estimated_time?: string;
+	prerequisites?: string[];
+	steps: WorkflowStep[];
+	validation?: string[];
+	troubleshooting_ref?: string;
+}
+
+interface Example {
+	description: string;
+	use_case?: string;
+	yaml: string;
+}
+
+interface BestPractices {
+	security?: Array<{
+		id: string;
+		severity?: string;
+		title: string;
+		description: string;
+		remediation?: string;
+	}>;
+	performance?: Array<{
+		id: string;
+		title: string;
+		description: string;
+		impact?: string;
+		configuration?: string;
+	}>;
+	pitfalls?: Array<{
+		id: string;
+		title: string;
+		symptom?: string;
+		cause?: string;
+		solution: string;
+		prevention?: string;
+	}>;
+}
+
+interface SpecIndexEntry {
+	domain: string;
+	title: string;
+	description: string;
+	"x-f5xc-description-short"?: string;
+	"x-f5xc-description-medium"?: string;
+	"x-f5xc-icon"?: string;
+	"x-f5xc-category"?: string;
+	"x-f5xc-use-cases"?: string[];
+	"x-f5xc-related-domains"?: string[];
+	"x-f5xc-cli-metadata"?: CliMetadata;
+	"x-f5xc-primary-resources"?: SpecPrimaryResource[];
+	// Future extensions (when implemented upstream)
+	"x-f5xc-guided-workflows"?: GuidedWorkflow[];
+	"x-f5xc-examples"?: Record<string, Record<string, Example>>;
+	"x-f5xc-best-practices"?: BestPractices;
+}
+
+interface SpecIndex {
+	version: string;
+	timestamp: string;
+	specifications: SpecIndexEntry[];
+}
+
+// Types for LOCAL xcsh-specific examples (docs/config/xcsh-examples.yaml)
+interface XcshExample {
+	description: string;
+	command: string;
+	output?: string;
+}
+
+interface XcshWorkflowStep {
+	order: number;
+	description: string;
+	command: string;
+}
+
+interface XcshWorkflow {
+	title: string;
+	description?: string;
+	steps: XcshWorkflowStep[];
+}
+
+interface XcshDomainConfig {
+	display_name: string;
+	cli_domain: string;
+	examples?: Record<string, XcshExample>;
+	workflows?: Record<string, XcshWorkflow>;
+}
+
+interface QuickRefCommand {
+	description: string;
+	command: string;
+}
+
+interface QuickRefCategory {
+	category: string;
+	commands: QuickRefCommand[];
+}
+
+interface XcshExamplesConfig {
+	version: string;
+	cli_patterns: Record<string, string>;
+	domains: Record<string, XcshDomainConfig>;
+	quick_reference: QuickRefCategory[];
+	ai_assistant?: {
+		description: string;
+		examples: Array<{ query: string; interpretation: string }>;
+	};
+}
+
+/**
+ * Escape markdown special characters
+ */
+function escapeMarkdown(s: string): string {
+	return s.replace(/([_*`])/g, "\\$1");
+}
+
+/**
+ * Convert snake_case to Title Case
+ */
+function titleCase(s: string): string {
+	return s
+		.split("_")
+		.map((part) =>
+			part.length > 0 ? part[0].toUpperCase() + part.slice(1) : "",
+		)
+		.join(" ");
+}
+
+/**
+ * Generate workflow documentation from cli_metadata
+ */
+function generateWorkflowSection(
+	domain: string,
+	cliMetadata: CliMetadata,
+): string {
+	const workflows = cliMetadata.common_workflows || [];
+	if (workflows.length === 0) return "";
+
+	let content = "## Common Workflows\n\n";
+
+	for (const workflow of workflows) {
+		// Skip workflows with missing or invalid title
+		const title = workflow.title;
+		if (!title || typeof title !== "string") continue;
+
+		content += `### ${title}\n\n`;
+		if (workflow.description && typeof workflow.description === "string") {
+			content += `${workflow.description}\n\n`;
+		}
+
+		if (workflow.steps && Array.isArray(workflow.steps) && workflow.steps.length > 0) {
+			for (const step of workflow.steps) {
+				// Skip steps with missing order or description
+				if (typeof step.order !== "number" || !step.description) continue;
+
+				content += `${step.order}. ${step.description}\n\n`;
+				if (step.command && typeof step.command === "string") {
+					content += "```bash\n";
+					content += `${step.command}\n`;
+					content += "```\n\n";
+				}
+			}
+		}
+	}
+
+	// Return empty if no valid workflows were generated
+	if (content === "## Common Workflows\n\n") return "";
+
+	return content;
+}
+
+/**
+ * Generate troubleshooting section from cli_metadata
+ */
+function generateTroubleshootingSection(cliMetadata: CliMetadata): string {
+	const troubleshooting = cliMetadata.troubleshooting || [];
+	if (!Array.isArray(troubleshooting) || troubleshooting.length === 0) return "";
+
+	let content = "## Troubleshooting\n\n";
+	let hasValidItems = false;
+
+	for (const item of troubleshooting) {
+		// Skip items with missing issue or solution
+		if (!item.issue || typeof item.issue !== "string") continue;
+		if (!item.solution || typeof item.solution !== "string") continue;
+
+		content += `### ${item.issue}\n\n`;
+		content += `**Solution:** ${item.solution}\n\n`;
+		hasValidItems = true;
+	}
+
+	return hasValidItems ? content : "";
+}
+
+/**
+ * Generate quick start section from cli_metadata
+ */
+function generateQuickStartSection(cliMetadata: CliMetadata): string {
+	const quickStart = cliMetadata.quick_start;
+	// Skip if missing or not a valid string
+	if (!quickStart || typeof quickStart !== "string") return "";
+
+	return `## Quick Start\n\n${quickStart}\n\n`;
+}
+
+/**
+ * Generate resource reference from primary_resources
+ */
+function generateResourceReference(
+	resources: SpecPrimaryResource[],
+): string {
+	if (resources.length === 0) return "";
+
+	let content = "## Resource Reference\n\n";
+	content +=
+		"| Resource | Description | Tier | Dependencies |\n";
+	content +=
+		"|----------|-------------|------|-------------|\n";
+
+	for (const resource of resources) {
+		const deps = resource.dependencies?.required?.join(", ") || "None";
+		content += `| \`${resource.name}\` | ${resource.description_short || resource.description} | ${resource.tier} | ${deps} |\n`;
+	}
+
+	content += "\n";
+	return content;
+}
+
+/**
+ * Generate use cases section
+ */
+function generateUseCasesSection(useCases: string[]): string {
+	if (useCases.length === 0) return "";
+
+	let content = "## Use Cases\n\n";
+	for (const useCase of useCases) {
+		content += `- ${useCase}\n`;
+	}
+	content += "\n";
+	return content;
+}
+
+/**
+ * Generate related domains section
+ */
+function generateRelatedSection(
+	relatedDomains: string[],
+	allDomains: Map<string, SpecIndexEntry>,
+): string {
+	if (relatedDomains.length === 0) return "";
+
+	let content = "## Related Domains\n\n";
+	content += "| Domain | Description |\n";
+	content += "|--------|-------------|\n";
+
+	for (const related of relatedDomains) {
+		const relatedSpec = allDomains.get(related);
+		const desc = relatedSpec?.["x-f5xc-description-short"] || relatedSpec?.description || "";
+		content += `| [${titleCase(related)}](${related}.md) | ${desc} |\n`;
+	}
+
+	content += "\n";
+	return content;
+}
+
+/**
+ * Generate CLI examples section from LOCAL xcsh config
+ */
+function generateCliExamplesSection(xcshDomain: XcshDomainConfig): string {
+	const examples = xcshDomain.examples;
+	if (!examples || Object.keys(examples).length === 0) return "";
+
+	let content = "## CLI Examples\n\n";
+
+	for (const [operation, example] of Object.entries(examples)) {
+		content += `### ${titleCase(operation)}\n\n`;
+		content += `${example.description}\n\n`;
+		content += "```bash\n";
+		content += `${example.command}\n`;
+		content += "```\n\n";
+
+		if (example.output) {
+			content += "**Output:**\n\n";
+			content += "```text\n";
+			content += `${example.output}`;
+			content += "```\n\n";
+		}
+	}
+
+	return content;
+}
+
+/**
+ * Generate CLI workflows section from LOCAL xcsh config
+ */
+function generateCliWorkflowsSection(xcshDomain: XcshDomainConfig): string {
+	const workflows = xcshDomain.workflows;
+	if (!workflows || Object.keys(workflows).length === 0) return "";
+
+	let content = "## CLI Workflows\n\n";
+
+	for (const [, workflow] of Object.entries(workflows)) {
+		content += `### ${workflow.title}\n\n`;
+		if (workflow.description) {
+			content += `${workflow.description}\n\n`;
+		}
+
+		for (const step of workflow.steps) {
+			content += `${step.order}. ${step.description}\n\n`;
+			content += "```bash\n";
+			content += `${step.command}\n`;
+			content += "```\n\n";
+		}
+	}
+
+	return content;
+}
+
+/**
+ * Generate quick reference guide from LOCAL xcsh config
+ */
+function generateQuickReferenceDoc(xcshConfig: XcshExamplesConfig): string {
+	let content = "# Quick Reference\n\n";
+	content += "Common xcsh CLI commands and patterns.\n\n";
+
+	for (const category of xcshConfig.quick_reference) {
+		content += `## ${category.category}\n\n`;
+		content += "| Description | Command |\n";
+		content += "|-------------|--------|\n";
+
+		for (const cmd of category.commands) {
+			content += `| ${cmd.description} | \`${cmd.command}\` |\n`;
+		}
+		content += "\n";
+	}
+
+	// AI Assistant section
+	if (xcshConfig.ai_assistant) {
+		content += "## AI Assistant\n\n";
+		content += `${xcshConfig.ai_assistant.description}\n\n`;
+		content += "| Query | Interpretation |\n";
+		content += "|-------|---------------|\n";
+		for (const ex of xcshConfig.ai_assistant.examples) {
+			content += `| "${ex.query}" | ${ex.interpretation} |\n`;
+		}
+		content += "\n";
+	}
+
+	content += "---\n\n";
+	content += "*CLI examples specific to xcsh. See domain guides for API resource details.*\n";
+
+	return content;
+}
+
+/**
+ * Generate domain documentation page
+ * Merges UPSTREAM spec data with LOCAL xcsh examples
+ */
+function generateDomainDoc(
+	spec: SpecIndexEntry,
+	allDomains: Map<string, SpecIndexEntry>,
+	xcshConfig?: XcshExamplesConfig,
+): string {
+	const icon = spec["x-f5xc-icon"] || "";
+	const title = `${icon} ${titleCase(spec.domain)}`.trim();
+
+	let content = `# ${title}\n\n`;
+
+	// Description (from UPSTREAM)
+	const description =
+		spec["x-f5xc-description-medium"] || spec.description;
+	content += `${description}\n\n`;
+
+	// Category badge (from UPSTREAM)
+	const category = spec["x-f5xc-category"];
+	if (category) {
+		content += `**Category:** ${category}\n\n`;
+	}
+
+	// Quick start (from UPSTREAM cli_metadata)
+	if (spec["x-f5xc-cli-metadata"]) {
+		content += generateQuickStartSection(spec["x-f5xc-cli-metadata"]);
+	}
+
+	// CLI Examples (from LOCAL xcsh config)
+	const xcshDomain = xcshConfig?.domains[spec.domain];
+	if (xcshDomain) {
+		content += generateCliExamplesSection(xcshDomain);
+	}
+
+	// Use cases (from UPSTREAM)
+	if (spec["x-f5xc-use-cases"]) {
+		content += generateUseCasesSection(spec["x-f5xc-use-cases"]);
+	}
+
+	// Resource reference (from UPSTREAM primary_resources)
+	if (spec["x-f5xc-primary-resources"]) {
+		content += generateResourceReference(spec["x-f5xc-primary-resources"]);
+	}
+
+	// Common workflows (from UPSTREAM cli_metadata)
+	if (spec["x-f5xc-cli-metadata"]) {
+		content += generateWorkflowSection(
+			spec.domain,
+			spec["x-f5xc-cli-metadata"],
+		);
+	}
+
+	// CLI Workflows (from LOCAL xcsh config)
+	if (xcshDomain) {
+		content += generateCliWorkflowsSection(xcshDomain);
+	}
+
+	// Troubleshooting (from UPSTREAM cli_metadata)
+	if (spec["x-f5xc-cli-metadata"]) {
+		content += generateTroubleshootingSection(spec["x-f5xc-cli-metadata"]);
+	}
+
+	// Related domains (from UPSTREAM)
+	if (spec["x-f5xc-related-domains"]) {
+		content += generateRelatedSection(
+			spec["x-f5xc-related-domains"],
+			allDomains,
+		);
+	}
+
+	// Footer
+	content += "---\n\n";
+	content += `*Generated from enriched API specs and local xcsh examples.*\n`;
+
+	return content;
+}
+
+/**
+ * Generate index page for all domains
+ */
+function generateIndexDoc(
+	specs: SpecIndexEntry[],
+	version: string,
+): string {
+	let content = "# Domain Reference\n\n";
+	content += `Generated from enriched API specifications v${version}.\n\n`;
+
+	// Group by category
+	const byCategory = new Map<string, SpecIndexEntry[]>();
+	for (const spec of specs) {
+		const category = spec["x-f5xc-category"] || "Other";
+		if (!byCategory.has(category)) {
+			byCategory.set(category, []);
+		}
+		byCategory.get(category)!.push(spec);
+	}
+
+	// Sort categories
+	const sortedCategories = Array.from(byCategory.keys()).sort();
+
+	for (const category of sortedCategories) {
+		const categorySpecs = byCategory.get(category)!;
+		content += `## ${category}\n\n`;
+		content += "| Domain | Description |\n";
+		content += "|--------|-------------|\n";
+
+		for (const spec of categorySpecs.sort((a, b) =>
+			a.domain.localeCompare(b.domain),
+		)) {
+			const icon = spec["x-f5xc-icon"] || "";
+			const title = `${icon} ${titleCase(spec.domain)}`.trim();
+			const desc = spec["x-f5xc-description-short"] || "";
+			content += `| [${title}](${spec.domain}.md) | ${desc} |\n`;
+		}
+		content += "\n";
+	}
+
+	return content;
+}
+
+/**
+ * Main generator function
+ */
+async function main(): Promise<void> {
+	console.log("📚 Generating documentation from enriched specs...");
+
+	const specsDir = ".specs";
+	const indexPath = path.join(specsDir, "index.json");
+	const xcshConfigPath = "docs/config/cli-examples.yaml";
+	const outputDir = "docs/guides/generated";
+
+	// Read UPSTREAM spec index
+	if (!fs.existsSync(indexPath)) {
+		console.error(`❌ Spec index not found: ${indexPath}`);
+		console.error(
+			"   Run 'npm run reconcile:specs' first to download API specifications.",
+		);
+		process.exit(1);
+	}
+
+	const indexData = fs.readFileSync(indexPath, "utf-8");
+	const specIndex: SpecIndex = JSON.parse(indexData);
+	console.log(
+		`✓ Loaded UPSTREAM spec index v${specIndex.version} with ${specIndex.specifications.length} domains`,
+	);
+
+	// Read LOCAL xcsh examples config
+	let xcshConfig: XcshExamplesConfig | undefined;
+	if (fs.existsSync(xcshConfigPath)) {
+		const xcshConfigData = fs.readFileSync(xcshConfigPath, "utf-8");
+		xcshConfig = yaml.parse(xcshConfigData) as XcshExamplesConfig;
+		console.log(
+			`✓ Loaded LOCAL xcsh examples v${xcshConfig.version} with ${Object.keys(xcshConfig.domains).length} domains`,
+		);
+	} else {
+		console.log(`⚠️  Local xcsh examples not found: ${xcshConfigPath}`);
+	}
+
+	// Filter to non-empty domains (have upstream metadata OR local examples)
+	const activeSpecs = specIndex.specifications.filter(
+		(spec) =>
+			spec["x-f5xc-cli-metadata"] ||
+			spec["x-f5xc-primary-resources"]?.length ||
+			xcshConfig?.domains[spec.domain],
+	);
+
+	console.log(
+		`✓ Found ${activeSpecs.length} domains with documentation content`,
+	);
+
+	// Build domain lookup
+	const allDomains = new Map<string, SpecIndexEntry>();
+	for (const spec of specIndex.specifications) {
+		allDomains.set(spec.domain, spec);
+	}
+
+	// Ensure output directory exists
+	if (!fs.existsSync(outputDir)) {
+		fs.mkdirSync(outputDir, { recursive: true });
+	}
+
+	// Generate domain docs (merging UPSTREAM + LOCAL)
+	let generatedCount = 0;
+	for (const spec of activeSpecs) {
+		const content = generateDomainDoc(spec, allDomains, xcshConfig);
+		const outputPath = path.join(outputDir, `${spec.domain}.md`);
+		fs.writeFileSync(outputPath, content, "utf-8");
+		generatedCount++;
+	}
+
+	console.log(`✓ Generated ${generatedCount} domain documentation files`);
+
+	// Generate index
+	const indexContent = generateIndexDoc(activeSpecs, specIndex.version);
+	const indexOutputPath = path.join(outputDir, "index.md");
+	fs.writeFileSync(indexOutputPath, indexContent, "utf-8");
+	console.log(`✓ Generated: ${indexOutputPath}`);
+
+	// Generate quick reference from LOCAL config
+	if (xcshConfig) {
+		const quickRefContent = generateQuickReferenceDoc(xcshConfig);
+		const quickRefPath = path.join(outputDir, "quick-reference.md");
+		fs.writeFileSync(quickRefPath, quickRefContent, "utf-8");
+		console.log(`✓ Generated: ${quickRefPath}`);
+	}
+
+	console.log(`✅ Documentation generation complete!`);
+	console.log(`   - UPSTREAM: Resource descriptions, best practices`);
+	console.log(`   - LOCAL: CLI command syntax, xcsh-specific workflows`);
+}
+
+main().catch((err) => {
+	console.error("❌ Generation failed:", err);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary

Implement dynamic documentation generation that merges **upstream API specifications** with **local xcsh-specific CLI examples**, enabling automatic documentation regeneration when upstream specs are updated.

### Key Changes
- **`scripts/generate-docs.ts`** - Documentation generator script
- **`docs/config/cli-examples.yaml`** - Local CLI examples configuration  
- **`docs/guides/generated/*.md`** - 40+ generated domain documentation files
- **Updated sync workflow** - Auto-regenerates docs on upstream spec sync

### Design Decisions

| Data Source | Content | Location |
|-------------|---------|----------|
| **UPSTREAM** | Resource descriptions, best practices, field docs | `.specs/index.json` |
| **LOCAL** | xcsh CLI syntax, command examples, workflows | `docs/config/cli-examples.yaml` |

This separation ensures:
- xcsh-specific content stays in this repository (not upstream)
- Upstream API changes automatically flow through
- Local CLI examples can be maintained independently

### Related Upstream Issues
- robinmordasiewicz/f5xc-api-enriched#324 (x-f5xc-guided-workflows)
- robinmordasiewicz/f5xc-api-enriched#325 (x-f5xc-examples)
- robinmordasiewicz/f5xc-api-enriched#326 (x-f5xc-best-practices)

## Test Plan
- [x] Build succeeds with `npm run build`
- [x] Documentation generates without errors (`npm run generate:docs`)
- [x] Generated docs display correct CLI examples
- [x] Malformed upstream data handled gracefully
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)