### PR TITLE
fix(tests): resolve pre-existing test failures

### DIFF
--- a/tests/integration/auth.test.ts
+++ b/tests/integration/auth.test.ts
@@ -150,8 +150,9 @@ describeIf("Authentication Integration Tests", () => {
 				// Timeout or network error is expected
 				expect(error).toBeInstanceOf(APIError);
 				if (error instanceof APIError) {
-					// Should be a timeout-related error
-					expect(["FETCH_ERROR", "TIMEOUT"]).toContain(error.code);
+					// Timeout = statusCode 408, Network error = statusCode 0
+					expect([0, 408]).toContain(error.statusCode);
+					expect(error.message).toMatch(/timed out|network error/i);
 				}
 			}
 		});


### PR DESCRIPTION
## Summary

Fix two pre-existing test failures discovered during esbuild security fix validation:

### Test Failure #1: History Manager
- **File**: `tests/unit/history.test.ts`
- **Test**: `should handle non-existent history file gracefully`
- **Root Cause**: `HistoryManager.load()` migration logic copies from `~/.xcsh_history` when the target path doesn't exist, causing the test to find 64 entries instead of 0
- **Fix**: Temporarily rename the legacy history file during the test to prevent migration

### Test Failure #2: Auth Timeout
- **File**: `tests/integration/auth.test.ts`
- **Test**: `should handle connection timeout`
- **Root Cause**: Test expected `error.code` but `APIError` class uses `statusCode` property (408 for timeout, 0 for network error)
- **Fix**: Check `statusCode` and `message` instead of non-existent `code` property

## Test Plan
- [x] All 539 tests pass
- [x] No changes to production code
- [x] Test isolation properly maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)