### PR TITLE
fix(repl): handle --version and -v flags in REPL mode

### DIFF
--- a/src/repl/executor.ts
+++ b/src/repl/executor.ts
@@ -95,6 +95,8 @@ const BUILTIN_COMMANDS = new Set([
 	"ctx",
 	"history",
 	"version",
+	"--version",
+	"-v",
 	"domains",
 	"whoami",
 	"refresh",
@@ -177,11 +179,16 @@ export function parseCommand(input: string): ParsedCommand {
 		BUILTIN_COMMANDS.has(firstWord) ||
 		BUILTIN_COMMANDS.has(normalizedFirst)
 	) {
-		// Map --help and -h to help for execution
-		const effectiveCommand =
-			normalizedFirst === "--help" || normalizedFirst === "-h"
-				? "help"
-				: normalizedFirst;
+		// Map --help/-h to help and --version/-v to version for execution
+		let effectiveCommand = normalizedFirst;
+		if (normalizedFirst === "--help" || normalizedFirst === "-h") {
+			effectiveCommand = "help";
+		} else if (
+			normalizedFirst === "--version" ||
+			normalizedFirst === "-v"
+		) {
+			effectiveCommand = "version";
+		}
 		return {
 			raw: effectiveCommand,
 			isDirectNavigation: false,


### PR DESCRIPTION
## Summary

Fix `--version` and `-v` flags not working in REPL mode.

### Before
```
xcsh> --version
ERROR: list --version failed (HTTP 404)
Hint: Resource not found. Verify the name and namespace are correct.
```

### After
```
xcsh> --version
xcsh version v2.0.7
```

## Root Cause

The `--version` and `-v` flags were not recognized in the REPL's command parser:
1. Missing from `BUILTIN_COMMANDS` set
2. Not mapped to the "version" built-in command in `parseCommand()`

This caused them to be treated as domain command arguments, defaulting to `list --version` → HTTP 404.

## Fix

Added handling in `src/repl/executor.ts`:
- Add `--version` and `-v` to `BUILTIN_COMMANDS` set
- Map these flags to "version" command (mirrors existing `--help`/`-h` → `help` pattern)

## Test Plan
- [x] Build succeeds
- [x] All 539 tests pass
- [x] `--version` in REPL shows version
- [x] `-v` in REPL shows version

🤖 Generated with [Claude Code](https://claude.com/claude-code)