### PR TITLE
fix: use bash explicitly for download-specs.sh on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "generate:description-loader": "tsx scripts/generate-description-loader.ts",
     "generate:docs": "tsx scripts/generate-docs.ts",
     "generate": "npm run generate:domains && npm run generate:completions && npm run generate:logo && npm run generate:description-loader",
-    "reconcile:specs": "./scripts/download-specs.sh",
+    "reconcile:specs": "bash ./scripts/download-specs.sh",
     "prebuild": "npm run reconcile:specs && npm run generate"
   },
   "keywords": [


### PR DESCRIPTION
Fix Windows release build by explicitly calling bash to run download-specs.sh script.