### PR TITLE
refactor: change install.sh default from sudo to user directory

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -584,8 +584,8 @@ jobs:
             rm -rf $HOME/.local/bin/xcsh 2>/dev/null || true
             rm -f install-output.txt 2>/dev/null || true
 
-            # Run the install script and capture output
-            GITHUB_TOKEN=${{ github.token }} VES_NO_SUDO=1 VES_INSTALL_DIR=$HOME/.local/bin sh /tmp/install.sh > install-output.txt 2>&1
+            # Run the install script and capture output (defaults to ~/.local/bin without sudo)
+            GITHUB_TOKEN=${{ github.token }} sh /tmp/install.sh > install-output.txt 2>&1
             INSTALL_EXIT_CODE=$?
 
             echo "Install output:"

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@
 # Environment variables:
 #   F5XC_VERSION      - Specific version to install (default: latest)
 #   F5XC_INSTALL_DIR  - Installation directory (default: /usr/local/bin)
-#   F5XC_NO_SUDO      - Skip sudo if set to any value
+#   F5XC_USE_SUDO     - Use sudo for system install (default: install to ~/.local/bin)
 #   F5XC_NO_VERIFY    - Skip checksum verification if set
 #   GITHUB_TOKEN     - Optional: GitHub token for authenticated API requests (CI/CD use)
 
@@ -309,7 +309,7 @@ determine_install_strategy() {
       echo "custom:"
       return
     fi
-    if [ -z "${F5XC_NO_SUDO:-}" ] && command_exists sudo; then
+    if [ -n "${F5XC_USE_SUDO:-}" ] && command_exists sudo; then
       echo "custom:sudo"
       return
     fi
@@ -323,18 +323,18 @@ Try one of:
     sudo sh install.sh"
   fi
 
-  # Default behavior: try /usr/local/bin with sudo, fall back to ~/.local/bin
+  # Default behavior: install to ~/.local/bin (no sudo), opt-in to /usr/local/bin with sudo
   if [ -w "$DEFAULT_INSTALL_DIR" ] || [ "$(id -u)" -eq 0 ]; then
     echo "system:"
     return
   fi
 
-  if [ -z "${F5XC_NO_SUDO:-}" ] && command_exists sudo; then
+  if [ -n "${F5XC_USE_SUDO:-}" ] && command_exists sudo; then
     echo "system:sudo"
     return
   fi
 
-  # Fall back to user directory (no sudo available)
+  # Default to user directory (no sudo)
   echo "user:"
 }
 
@@ -828,7 +828,7 @@ If installed elsewhere, set F5XC_INSTALL_DIR:
   # Determine if sudo is needed for uninstall
   SUDO_CMD=""
   if [ ! -w "$INSTALL_DIR" ] && [ "$(id -u)" -ne 0 ]; then
-    if [ -z "${F5XC_NO_SUDO:-}" ] && command_exists sudo; then
+    if [ -n "${F5XC_USE_SUDO:-}" ] && command_exists sudo; then
       SUDO_CMD="sudo"
     fi
   fi
@@ -888,8 +888,8 @@ OPTIONS
 
 ENVIRONMENT VARIABLES
     F5XC_VERSION      Specific version to install (default: latest)
-    F5XC_INSTALL_DIR  Installation directory (default: /usr/local/bin)
-    F5XC_NO_SUDO      Skip sudo even if needed (for custom install dirs)
+    F5XC_INSTALL_DIR  Installation directory (default: ~/.local/bin)
+    F5XC_USE_SUDO     Use sudo to install to /usr/local/bin instead
     F5XC_NO_VERIFY    Skip checksum verification
 
 SUPPORTED PLATFORMS

--- a/scripts/templates/commands_index.md.j2
+++ b/scripts/templates/commands_index.md.j2
@@ -78,5 +78,5 @@ xcsh supports multiple output formats:
 
 | Variable | Description |
 |----------|-------------|
-| `VES_API_TOKEN` | API token for authentication (use with `--api-token` flag) |
-| `VES_P12_PASSWORD` | Password for P12 bundle file |
+| `F5XC_API_TOKEN` | API token for authentication (use with `--api-token` flag) |
+| `F5XC_P12_PASSWORD` | Password for P12 bundle file |

--- a/scripts/templates/script.md.j2
+++ b/scripts/templates/script.md.j2
@@ -31,13 +31,13 @@ Install xcsh with automatic platform detection and shell configuration.
 ## Specific Version
 
 ```bash
-curl -fsSL https://robinmordasiewicz.github.io/f5xc-xcsh/install.sh | VES_VERSION={{ version or 'X.Y.Z' }} sh
+curl -fsSL https://robinmordasiewicz.github.io/f5xc-xcsh/install.sh | F5XC_VERSION={{ version or 'X.Y.Z' }} sh
 ```
 
-## Custom Install Directory
+## System Install (with sudo)
 
 ```bash
-curl -fsSL https://robinmordasiewicz.github.io/f5xc-xcsh/install.sh | VES_INSTALL_DIR=$HOME/.local/bin sh
+curl -fsSL https://robinmordasiewicz.github.io/f5xc-xcsh/install.sh | F5XC_USE_SUDO=1 sh
 ```
 
 ## Uninstall
@@ -50,10 +50,10 @@ curl -fsSL https://robinmordasiewicz.github.io/f5xc-xcsh/install.sh | sh -s -- -
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `VES_VERSION` | latest | Specific version to install |
-| `VES_INSTALL_DIR` | `/usr/local/bin` | Installation directory |
-| `VES_NO_SUDO` | unset | Skip sudo usage |
-| `VES_NO_VERIFY` | unset | Skip checksum verification |
+| `F5XC_VERSION` | latest | Specific version to install |
+| `F5XC_INSTALL_DIR` | `~/.local/bin` | Installation directory |
+| `F5XC_USE_SUDO` | unset | Use sudo to install to `/usr/local/bin` |
+| `F5XC_NO_VERIFY` | unset | Skip checksum verification |
 
 ## Features
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -139,7 +139,7 @@ run_integration_tests() {
     echo -e "${YELLOW}Skipping integration tests - environment not configured${NC}"
     echo ""
     echo "To run integration tests, set these environment variables:"
-    echo "  export F5XC_API_URL=\"https://your-tenant.staging.volterra.us\""
+    echo "  export F5XC_API_URL=\"https://tenant.staging.volterra.us\""
     echo "  export F5XC_API_P12_FILE=\"/path/to/cert.p12\""
     echo "  export F5XC_P12_PASSWORD=\"your-password\""
     return 0

--- a/src/domains/login/profile/create.ts
+++ b/src/domains/login/profile/create.ts
@@ -38,7 +38,7 @@ export const createCommand: CommandDefinition = {
 					"  --namespace Default namespace (optional)",
 					"",
 					"Example:",
-					"  login profile create myprofile --url https://myco.console.ves.volterra.io --token abc123",
+					"  login profile create myprofile --url https://tenant.console.ves.volterra.io --token abc123",
 				].join("\n"),
 			);
 		}


### PR DESCRIPTION
## Summary

Changes the install script default behavior and updates environment variable naming.

### Changes
- Default install location changed from `/usr/local/bin` (with sudo) to `~/.local/bin` (no sudo)
- Environment variables renamed from `VES_*` to `F5XC_*` prefix
- `VES_NO_SUDO` replaced with `F5XC_USE_SUDO` (inverted logic - opt-in to sudo)
- Documentation templates updated with new variable names
- GitHub workflow simplified (now uses new defaults)

### Environment Variable Mapping
| Old | New | Notes |
|-----|-----|-------|
| `VES_VERSION` | `F5XC_VERSION` | Same behavior |
| `VES_INSTALL_DIR` | `F5XC_INSTALL_DIR` | Default changed to `~/.local/bin` |
| `VES_NO_SUDO` | `F5XC_USE_SUDO` | Logic inverted: opt-in to sudo |
| `VES_NO_VERIFY` | `F5XC_NO_VERIFY` | Same behavior |
| `VES_API_TOKEN` | `F5XC_API_TOKEN` | Same behavior |
| `VES_P12_PASSWORD` | `F5XC_P12_PASSWORD` | Same behavior |

Closes #554

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)