### PR TITLE
docs: add F5XC_API_URL to environment variables documentation

### DIFF
--- a/scripts/templates/commands_index.md.j2
+++ b/scripts/templates/commands_index.md.j2
@@ -78,5 +78,6 @@ xcsh supports multiple output formats:
 
 | Variable | Description |
 |----------|-------------|
+| `F5XC_API_URL` | API URL for F5 Distributed Cloud tenant |
 | `F5XC_API_TOKEN` | API token for authentication (use with `--api-token` flag) |
 | `F5XC_P12_PASSWORD` | Password for P12 bundle file |


### PR DESCRIPTION
## Summary
- Add missing `F5XC_API_URL` environment variable to the commands index template

This ensures the `F5XC_API_URL` environment variable is documented alongside `F5XC_API_TOKEN` and `F5XC_P12_PASSWORD` in the generated command reference documentation.

## Test plan
- [ ] Verify documentation generates correctly with `F5XC_API_URL` in the environment variables table

🤖 Generated with [Claude Code](https://claude.com/claude-code)