### PR TITLE
fix: improve spec download reliability in Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,10 @@ jobs:
         run: ./scripts/download-specs.sh
 
       - name: Build TypeScript
-        run: XCSH_VERSION=${{ needs.version.outputs.version }} npm run build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          XCSH_VERSION: ${{ needs.version.outputs.version }}
+        run: npm run build
 
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
@@ -171,7 +174,10 @@ jobs:
         run: ./scripts/download-specs.sh
 
       - name: Build TypeScript
-        run: XCSH_VERSION=${{ needs.version.outputs.version }} npm run build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          XCSH_VERSION: ${{ needs.version.outputs.version }}
+        run: npm run build
 
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
@@ -215,9 +221,10 @@ jobs:
 
       - name: Build TypeScript
         shell: bash
-        run: npm run build
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCSH_VERSION: ${{ needs.version.outputs.version }}
+        run: npm run build
 
       - name: Install Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Summary
- Fix macOS Release workflow failure by adding GITHUB_TOKEN to Build TypeScript step
- Improve download-specs.sh error handling, retry logic, and debugging output

## Root Cause
The Build TypeScript step runs `npm run build` which triggers `prebuild` → `reconcile:specs` → `download-specs.sh`. However, GITHUB_TOKEN was only set for the separate "Download enriched API specifications" step, not for the Build TypeScript step. This caused the script to make unauthenticated GitHub API requests during the build, leading to rate limits or timeouts on macOS runners.

## Changes

### release.yml
- Add `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to Build TypeScript step for all platforms (Linux, macOS, Windows)

### download-specs.sh
- Add `is_rate_limit_error()` function for smarter detection of rate limit scenarios
- Use extended backoff (60s) for rate limit errors vs standard exponential backoff
- Increase API call timeout from 30s to 60s
- Increase file download timeout from 120s to 180s  
- Increase connect timeout from 10s to 15s
- Add detailed curl error code descriptions (exit codes 6, 7, 22, 28, 35, 56)
- Add debug logging for authentication status and request/response details
- Reorder script to define log functions before they're used

## Test plan
- [x] Syntax check passed (`bash -n scripts/download-specs.sh`)
- [x] Script tested locally without token (shows warning, continues working)
- [x] Script tested locally with token (shows authentication confirmation)
- [x] TypeScript type check passed
- [x] YAML validation passed
- [x] All pre-commit hooks passed

Closes #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)