### PR TITLE
fix(statusline): show CWD instead of CLI name when not in git repo

### DIFF
--- a/src/repl/components/StatusBar.tsx
+++ b/src/repl/components/StatusBar.tsx
@@ -6,7 +6,7 @@
 import React from "react";
 import { Box, Text, Spacer } from "ink";
 import { execSync } from "child_process";
-import { CLI_NAME } from "../../branding/index.js";
+import { homedir } from "os";
 
 /**
  * Git repository status information
@@ -59,6 +59,22 @@ function getStatusColor(gitInfo: GitInfo): string {
 }
 
 /**
+ * Get formatted current working directory with ~ substitution for home
+ */
+function getFormattedCwd(): string {
+	const cwd = process.cwd();
+	const home = homedir();
+
+	if (cwd === home) {
+		return "~";
+	}
+	if (cwd.startsWith(home + "/")) {
+		return "~" + cwd.slice(home.length);
+	}
+	return cwd;
+}
+
+/**
  * StatusBar component
  * Displays CLI name, git status, and keyboard hints
  */
@@ -67,7 +83,7 @@ export function StatusBar({
 	width = 80,
 	hint = "Ctrl+C: quit",
 }: StatusBarProps): React.ReactElement {
-	// Left side: repo/branch or CLI name
+	// Left side: repo/branch or current working directory
 	const renderLeft = (): React.ReactElement => {
 		if (gitInfo?.inRepo) {
 			const icon = getStatusIcon(gitInfo);
@@ -84,7 +100,8 @@ export function StatusBar({
 			);
 		}
 
-		return <Text color="#ffffff">{CLI_NAME}</Text>;
+		// Show current working directory when not in a git repo
+		return <Text color="#666666">{getFormattedCwd()}</Text>;
 	};
 
 	// Right side: keyboard hints


### PR DESCRIPTION
## Summary
- Show current working directory in statusline when not in a git repository
- Replace CLI name "xcsh" with actual path (using `~` for home directory)

## Problem
When the current working directory is not a git repository, the xcsh statusline showed "xcsh" (the CLI name) instead of the actual current working directory, making it confusing to know where you are.

## Solution
- Added `getFormattedCwd()` helper function that returns CWD with `~` substitution for home
- Updated `renderLeft()` in StatusBar to show CWD when `gitInfo.inRepo` is false

## Changes
- `src/repl/components/StatusBar.tsx`
  - Added `homedir` import from `os`
  - Added `getFormattedCwd()` function
  - Changed fallback display from CLI_NAME to formatted CWD

## Behavior
- **In git repo**: Shows `repoName/branch` with status icon (unchanged)
- **Not in git repo**: Shows current directory path (e.g., `~/Downloads` or `/tmp`)

Fixes #562

## Test plan
- [ ] Run `xcsh` from a git repository - should show repo/branch
- [ ] Run `xcsh` from a non-git directory (e.g., `/tmp`) - should show path
- [ ] Run `xcsh` from home directory - should show `~`
- [ ] Run `xcsh` from subdirectory of home - should show `~/path/to/dir`

🤖 Generated with [Claude Code](https://claude.com/claude-code)