### PR TITLE
fix(ci): add GITHUB_TOKEN to download-specs.sh invocations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,8 @@ jobs:
         run: npm ci
 
       - name: Download enriched API specifications
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/download-specs.sh
 
       - name: Regenerate domains
@@ -169,6 +171,8 @@ jobs:
         run: npm ci
 
       - name: Download enriched API specifications
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/download-specs.sh
 
       - name: Build package

--- a/.github/workflows/sync-upstream-specs.yml
+++ b/.github/workflows/sync-upstream-specs.yml
@@ -96,6 +96,8 @@ jobs:
         run: npm ci
 
       - name: Download latest specs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/download-specs.sh
 
       - name: Generate domains


### PR DESCRIPTION
## Summary
- Add GITHUB_TOKEN to all `download-specs.sh` invocations in CI workflows
- Prevents GitHub API rate limiting during CI runs

## Problem
CI workflow failed because `download-specs.sh` was making unauthenticated GitHub API requests:
```
⚠ GITHUB_TOKEN not set - API requests may be rate limited
ℹ Fetching latest enriched spec release...
##[error]Process completed with exit code 1.
```

**Failed run**: https://github.com/robinmordasiewicz/f5xc-xcsh/actions/runs/20841275142/job/59876053503

## Solution
Add `env: GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to all download-specs.sh invocations, matching the pattern already used in release.yml.

## Changes
- `.github/workflows/ci.yml`
  - verify-generated job: Download enriched API specifications step
  - build job: Download enriched API specifications step
- `.github/workflows/sync-upstream-specs.yml`
  - Download latest specs step

## Note
The `download-specs.sh` script already has:
- Authentication support (checks for GITHUB_TOKEN)
- Exponential backoff retry logic
- Rate limit detection with extended backoff
- Detailed error logging

It just wasn't receiving the token from the CI environment.

Fixes #566

## Test plan
- [ ] CI workflow completes successfully with authenticated API requests
- [ ] Verify "Using authenticated GitHub API requests" appears in logs instead of rate limit warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)