### PR TITLE
fix(install): correct backslash escaping in success message

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1043,7 +1043,7 @@ On Alpine:        apk add curl"
   printf "  # Start interactive shell\n"
   printf "  ${CYAN}xcsh${NC}\n"
   printf "  ${CYAN}xcsh --help${NC}\n"
-  printf "  ${CYAN}xcsh login profile create my-tenant \\${NC}\n"
+  printf "  ${CYAN}xcsh login profile create my-tenant${NC} %s\n" '\'
   printf "    ${CYAN}--url https://my-tenant.console.ves.volterra.io${NC}\n"
   printf "\n"
   printf "%s\n" "Documentation: https://github.com/${GITHUB_REPO}"


### PR DESCRIPTION
## Summary
Fix backslash displaying as literal `\n` instead of `\` followed by newline in install success message.

## Problem
The install success message showed:
```
xcsh login profile create my-tenant \n    --url https://my-tenant.console.ves.volterra.io
```

## Solution
Changed from inline escaping to using `%s` format specifier:
```bash
# Before (broken)
printf "  ${CYAN}xcsh login profile create my-tenant \\${NC}\n"

# After (working)
printf "  ${CYAN}xcsh login profile create my-tenant${NC} %s\n" '\'
```

## Expected Output
```
xcsh login profile create my-tenant \
    --url https://my-tenant.console.ves.volterra.io
```

Fixes #568

## Test plan
- [ ] Run `./install.sh` and verify backslash displays correctly
- [ ] Verify the command continuation appears on the next line

🤖 Generated with [Claude Code](https://claude.com/claude-code)