### PR TITLE
fix: handle quoted strings in command parsing and register completion aliases

### DIFF
--- a/src/completion/registry.ts
+++ b/src/completion/registry.ts
@@ -36,6 +36,14 @@ export class CompletionRegistry {
 	}
 
 	/**
+	 * Register an alias for a domain
+	 * Used for domain aliases that aren't part of the domain definition
+	 */
+	registerAlias(alias: string, canonicalName: string): void {
+		this.aliases.set(alias, canonicalName);
+	}
+
+	/**
 	 * Add or merge children into an existing domain
 	 * Used for extensions that augment API domains
 	 */

--- a/src/domains/index.ts
+++ b/src/domains/index.ts
@@ -53,16 +53,19 @@ const domainAliases = new Map<string, string>();
 // Register cloudstatus aliases
 for (const alias of cloudstatusAliases) {
 	domainAliases.set(alias, "cloudstatus");
+	completionRegistry.registerAlias(alias, "cloudstatus");
 }
 
 // Register ai_services aliases
 for (const alias of aiServicesAliases) {
 	domainAliases.set(alias, "ai_services");
+	completionRegistry.registerAlias(alias, "ai_services");
 }
 
 // Register subscription aliases
 for (const alias of subscriptionAliases) {
 	domainAliases.set(alias, "subscription");
+	completionRegistry.registerAlias(alias, "subscription");
 }
 
 // Export registry and types

--- a/src/repl/executor.ts
+++ b/src/repl/executor.ts
@@ -32,6 +32,7 @@ import {
 	formatActionHelp,
 	formatTopicHelp,
 } from "./help.js";
+import { parseInputArgs } from "./completion/completer.js";
 import { getDomainInfo } from "../types/domains.js";
 import {
 	validateNamespaceScope,
@@ -138,7 +139,7 @@ export function parseCommand(input: string): ParsedCommand {
 
 	// Handle "/" prefix for direct domain navigation
 	if (trimmed.startsWith("/") && trimmed.length > 1) {
-		const parts = trimmed.slice(1).split(/\s+/);
+		const parts = parseInputArgs(trimmed.slice(1));
 		const domainPart = parts[0] ?? "";
 
 		// Check if it's a valid domain (custom, extension, or API-generated)
@@ -193,12 +194,12 @@ export function parseCommand(input: string): ParsedCommand {
 			raw: effectiveCommand,
 			isDirectNavigation: false,
 			isBuiltin: true,
-			args: trimmed.split(/\s+/).slice(1),
+			args: parseInputArgs(trimmed).slice(1),
 		};
 	}
 
-	// Regular command - split into parts
-	const parts = trimmed.split(/\s+/);
+	// Regular command - parse with quote handling
+	const parts = parseInputArgs(trimmed);
 	return {
 		raw: trimmed,
 		isDirectNavigation: false,
@@ -345,8 +346,8 @@ function executeBuiltin(
 
 	// Show current user and connection info
 	if (command === "whoami" || command.startsWith("whoami ")) {
-		// Parse flags from command
-		const parts = command.split(/\s+/).slice(1); // Skip "whoami"
+		// Parse flags from command with quote handling
+		const parts = parseInputArgs(command).slice(1); // Skip "whoami"
 		const options: {
 			includeQuotas?: boolean;
 			includeAddons?: boolean;
@@ -1092,8 +1093,8 @@ async function executeAPICommand(
 			args = cmd.args;
 		}
 	} else {
-		// At root, parse domain/action from command
-		const parts = cmd.raw.split(/\s+/);
+		// At root, parse domain/action from command with quote handling
+		const parts = parseInputArgs(cmd.raw);
 		domain = parts[0] ?? "";
 		action = parts[1]?.toLowerCase() ?? "list";
 		args = parts.slice(validActions.has(action) ? 2 : 1);


### PR DESCRIPTION
## Summary
- Fixed quote handling in command parsing so commands like `query 'How do I create an HTTP load balancer?'` work correctly
- Added `registerAlias()` method to CompletionRegistry for explicit alias registration
- Register domain aliases with completionRegistry so tab completion recognizes aliases like `query`, `ask`, `q`, `chat`

## Problem
After PR #573, two issues were reported:
1. Query commands with quoted strings produced empty output (the quoted text was being split on whitespace)
2. Domain aliases weren't recognized by tab completion (only registered for execution, not completion)

## Solution
1. **Quote handling fix**: Replace `split(/\s+/)` with `parseInputArgs()` in executor.ts (5 locations) to properly parse shell-style quoted strings
2. **Completion alias registration**: Add `registerAlias()` method and call it when registering domain aliases so completion system recognizes them

## Test plan
- [x] TypeScript typecheck passes
- [x] ESLint passes
- [x] Build succeeds
- [x] All 515 tests pass
- [ ] Manual: Verify `query 'How do I create an HTTP load balancer?'` executes correctly
- [ ] Manual: Verify tab completion works for `/ai_services` and aliases

🤖 Generated with [Claude Code](https://claude.com/claude-code)