### PR TITLE
fix: handle API response 'summary' field in AI services renderer

### DIFF
--- a/src/domains/ai_services/types.ts
+++ b/src/domains/ai_services/types.ts
@@ -32,14 +32,17 @@ export interface GenAIQueryRequest {
 
 /**
  * Generic text response
+ * Note: API returns 'summary' field with HTML content, 'text' is for backwards compatibility
  */
 export interface GenericResponse {
 	text?: string;
+	summary?: string;
+	is_error?: boolean;
 	links?: Array<{
 		title: string;
 		url: string;
 	}>;
-	error?: string;
+	error?: string | null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fixed AI services query command producing empty output
- API returns `summary` field with HTML content, but renderer expected `text` field
- Added HTML-to-text conversion for readable CLI output

## Problem
When running `query 'How do I create an HTTP load balancer?'`, the command would produce empty output because:
1. The GenAI API returns responses with a `summary` field containing HTML
2. The `GenericResponse` type only defined a `text` field
3. The renderer looked for `text` but found nothing

## Solution
1. **Updated GenericResponse type** to include `summary` and `is_error` fields
2. **Added stripHtml() function** to convert HTML to readable plain text, preserving:
   - Bold/emphasis as `**bold**` and `*italic*`
   - Code blocks as `` `code` ``
   - Links as `text (url)`
   - List items as bullets
   - Headings and paragraphs with proper spacing
3. **Updated renderGenericResponse()** to use `summary ?? text`
4. **Updated renderResponseCompact() and extractResponseText()** for consistency

## Test plan
- [x] Build succeeds
- [x] All 515 tests pass
- [x] `ai_services query test` produces formatted output
- [x] `/ai_services query 'How do I create an HTTP load balancer?'` works
- [x] `query 'How do I create an HTTP load balancer?'` (alias) works
- [x] HTML content is properly converted to readable text

🤖 Generated with [Claude Code](https://claude.com/claude-code)