### PR TITLE
fix(completion): show domain suggestions when typing domain alias prefix

### DIFF
--- a/src/repl/completion/completer.ts
+++ b/src/repl/completion/completer.ts
@@ -184,8 +184,15 @@ export class Completer {
 		}
 
 		// Check if first arg is a custom domain - delegate to domain completion
+		// But only if user has finished typing the domain name (not still typing it)
 		const firstArg = parsed.args[0]?.toLowerCase() ?? "";
-		if (isCustomDomain(firstArg) && parsed.args.length >= 1) {
+		const isStillTypingDomain =
+			parsed.args.length === 1 && parsed.currentWord === firstArg;
+		if (
+			isCustomDomain(firstArg) &&
+			parsed.args.length >= 1 &&
+			!isStillTypingDomain
+		) {
 			return await this.getCustomDomainCompletions(
 				firstArg,
 				parsed.args.slice(1),
@@ -262,8 +269,9 @@ export class Completer {
 		let suggestions: CompletionSuggestion[];
 		if (parsed.isEscapedToRoot) {
 			const firstArg = parsed.args[0];
-			if (parsed.args.length > 0 && firstArg) {
+			if (parsed.args.length > 0 && firstArg && !isStillTypingDomain) {
 				// /domain - navigating to a specific domain, show its children
+				// Only if user has finished typing the domain name (not still typing it)
 				const targetDomain = firstArg.toLowerCase();
 
 				// Check if domain exists in registry
@@ -284,7 +292,7 @@ export class Completer {
 					suggestions = this.getRootContextSuggestions();
 				}
 			} else {
-				// Just "/" - show all domains
+				// Just "/" or still typing domain name - show all domains
 				suggestions = this.getRootContextSuggestions();
 			}
 		} else {

--- a/tests/unit/completion-full.test.ts
+++ b/tests/unit/completion-full.test.ts
@@ -31,3 +31,27 @@ describe("Completer with trailing spaces", () => {
 		expect(texts).toContain("delete");
 	});
 });
+
+describe("Completer with domain alias prefix", () => {
+	let completer: Completer;
+
+	beforeEach(() => {
+		completer = new Completer();
+	});
+
+	it("should show domain suggestions when typing '/ai' (still typing domain)", async () => {
+		// When typing "/ai" without a trailing space, should show domains matching "ai"
+		const suggestions = await completer.complete("/ai");
+		const texts = suggestions.map((s) => s.text);
+		// Should show ai_services as a suggestion (filtered by "ai" prefix)
+		expect(texts).toContain("ai_services");
+	});
+
+	it("should show domain-specific completions for '/ai ' (with trailing space)", async () => {
+		// When typing "/ai " WITH trailing space, should delegate to ai_services domain completions
+		const suggestions = await completer.complete("/ai ");
+		const texts = suggestions.map((s) => s.text);
+		// Should show ai_services commands like query, chat, etc.
+		expect(texts).toContain("query");
+	});
+});


### PR DESCRIPTION
## Summary

- Fixes tab completion not showing suggestions when typing `/ai` (domain alias prefix)
- Now typing `/ai` shows `ai_services` in the completion suggestions
- Typing `/ai ` (with space) correctly delegates to ai_services domain completions

## Problem

When typing "/ai" without a trailing space, the completion system was incorrectly:
1. Recognizing "ai" as a valid custom domain (it's an alias for ai_services)
2. Jumping into domain-specific completions instead of showing domain suggestions

## Solution

1. Added `isStillTypingDomain` check to detect when user is still typing domain name
2. Updated two code paths to show domain suggestions when still typing
3. Updated `getDomainSuggestions()` to include aliases registered via `registerAlias()`

## Test plan

- [x] Unit tests pass
- [x] New tests added for domain alias prefix completion
- [ ] Manual testing: type `/ai` and verify `ai_services` appears in suggestions
- [ ] Manual testing: type `/ai ` (with space) and verify domain commands appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)