### PR TITLE
refactor: remove all domain and command aliases

### DIFF
--- a/src/domains/ai_services/index.ts
+++ b/src/domains/ai_services/index.ts
@@ -94,17 +94,9 @@ export const aiServicesDomain: DomainDefinition = {
 };
 
 /**
- * Domain aliases
+ * Domain aliases (empty - use canonical name 'ai_services')
  */
-export const aiServicesAliases = [
-	"ai",
-	"genai",
-	"assistant",
-	"query",
-	"ask",
-	"q",
-	"chat",
-];
+export const aiServicesAliases: string[] = [];
 
 // Re-export types and utilities for external use
 export type {

--- a/src/domains/cloudstatus/index.ts
+++ b/src/domains/cloudstatus/index.ts
@@ -92,7 +92,6 @@ const statusCommand: CommandDefinition = {
 	descriptionMedium:
 		"Check overall service health status. Use --quiet for exit code suitable for scripts.",
 	usage: "[--quiet]",
-	aliases: ["st"],
 
 	async execute(args, session): Promise<DomainCommandResult> {
 		const { format, noColor, spec, filteredArgs } = parseOutputArgs(
@@ -165,7 +164,6 @@ const summaryCommand: CommandDefinition = {
 	descriptionMedium:
 		"Show combined overview of health, components, incidents, and maintenance windows.",
 	usage: "[--brief]",
-	aliases: ["sum"],
 
 	async execute(args, session): Promise<DomainCommandResult> {
 		const { format, noColor, spec, filteredArgs } = parseOutputArgs(
@@ -224,7 +222,6 @@ const componentsCommand: CommandDefinition = {
 	descriptionMedium:
 		"Display service component health. Use --degraded-only to show only affected components.",
 	usage: "[--degraded-only]",
-	aliases: ["comp"],
 
 	async execute(args, session): Promise<DomainCommandResult> {
 		const { format, noColor, spec, filteredArgs } = parseOutputArgs(
@@ -305,7 +302,6 @@ const incidentsCommand: CommandDefinition = {
 	descriptionMedium:
 		"Display incidents with impact levels and updates. Use --active-only for ongoing issues.",
 	usage: "[--active-only]",
-	aliases: ["inc"],
 
 	async execute(args, session): Promise<DomainCommandResult> {
 		const { format, noColor, spec, filteredArgs } = parseOutputArgs(
@@ -383,7 +379,6 @@ const maintenanceCommand: CommandDefinition = {
 	descriptionMedium:
 		"Show maintenance schedules and timing. Use --upcoming for future windows only.",
 	usage: "[--upcoming]",
-	aliases: ["maint"],
 
 	async execute(args, session): Promise<DomainCommandResult> {
 		const { format, noColor, spec, filteredArgs } = parseOutputArgs(
@@ -602,5 +597,5 @@ export const cloudstatusDomain: DomainDefinition = {
 	subcommands: new Map(),
 };
 
-// Aliases for the domain
-export const cloudstatusAliases = ["cs", "status"];
+// Aliases for the domain (empty - use canonical name 'cloudstatus')
+export const cloudstatusAliases: string[] = [];

--- a/src/domains/login/profile/list.ts
+++ b/src/domains/login/profile/list.ts
@@ -17,7 +17,6 @@ export const listCommand: CommandDefinition = {
 	descriptionShort: "List all saved profiles",
 	descriptionMedium:
 		"Show all profiles with tenant URLs, auth types, and active status indicator.",
-	aliases: ["ls"],
 
 	async execute(args, session) {
 		const { options } = parseDomainOutputFlags(

--- a/src/domains/subscription/index.ts
+++ b/src/domains/subscription/index.ts
@@ -131,7 +131,6 @@ const showCommand: CommandDefinition = {
 	descriptionMedium:
 		"Show subscription tier, active addons, quota usage summary, and current billing status.",
 	usage: "",
-	aliases: ["overview", "info"],
 
 	async execute(args, session): Promise<DomainCommandResult> {
 		const { format, noColor, spec } = parseOutputArgs(args, session);
@@ -430,7 +429,6 @@ const addonListCommand: CommandDefinition = {
 	descriptionMedium:
 		"Display all addon services with status and access information. Use --subscribed for active only.",
 	usage: "[--subscribed]",
-	aliases: ["ls"],
 
 	async execute(args, session): Promise<DomainCommandResult> {
 		const { format, noColor, spec, filteredArgs } = parseOutputArgs(
@@ -1288,7 +1286,6 @@ const reportSummaryCommand: CommandDefinition = {
 	descriptionMedium:
 		"Create comprehensive report with plan, addons, quotas, usage, and billing data.",
 	usage: "",
-	aliases: ["full"],
 
 	async execute(args, session): Promise<DomainCommandResult> {
 		const { format, noColor, spec } = parseOutputArgs(args, session);
@@ -1531,5 +1528,5 @@ export const subscriptionDomain: DomainDefinition = {
 	]),
 };
 
-// Domain aliases
-export const subscriptionAliases = ["sub", "billing", "quota"];
+// Domain aliases (empty - use canonical name 'subscription')
+export const subscriptionAliases: string[] = [];

--- a/tests/unit/completion-full.test.ts
+++ b/tests/unit/completion-full.test.ts
@@ -32,7 +32,7 @@ describe("Completer with trailing spaces", () => {
 	});
 });
 
-describe("Completer with domain alias prefix", () => {
+describe("Completer with domain name prefix", () => {
 	let completer: Completer;
 
 	beforeEach(() => {
@@ -47,9 +47,9 @@ describe("Completer with domain alias prefix", () => {
 		expect(texts).toContain("ai_services");
 	});
 
-	it("should show domain-specific completions for '/ai ' (with trailing space)", async () => {
-		// When typing "/ai " WITH trailing space, should delegate to ai_services domain completions
-		const suggestions = await completer.complete("/ai ");
+	it("should show domain-specific completions for '/ai_services ' (with trailing space)", async () => {
+		// When typing "/ai_services " WITH trailing space, should delegate to ai_services domain completions
+		const suggestions = await completer.complete("/ai_services ");
 		const texts = suggestions.map((s) => s.text);
 		// Should show ai_services commands like query, chat, etc.
 		expect(texts).toContain("query");


### PR DESCRIPTION
## Summary

- Removes all domain aliases (ai, genai, cs, status, sub, billing, etc.)
- Removes all command aliases (st, sum, comp, ls, etc.)
- Simplifies the CLI by requiring canonical names only

## Breaking Changes

Users must now use full domain and command names:

| Before (alias) | After (canonical) |
|----------------|-------------------|
| `ai query` | `ai_services query` |
| `cs status` | `cloudstatus status` |
| `sub show` | `subscription show` |
| `cloudstatus inc` | `cloudstatus incidents` |
| `login profile ls` | `login profile list` |

## Aliases Removed

**Domain aliases:**
- `ai_services`: ai, genai, assistant, query, ask, q, chat
- `cloudstatus`: cs, status  
- `subscription`: sub, billing, quota

**Command aliases:**
- `cloudstatus`: st, sum, comp, inc, maint
- `subscription`: overview, info, ls, full
- `login`: ls

## Test plan

- [x] Build passes
- [x] All unit tests pass
- [x] Updated tests that relied on aliases

🤖 Generated with [Claude Code](https://claude.com/claude-code)