### PR TITLE
fix(chat): build interactive chat as Ink component to fix stdin conflict

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "commander": "^12.1.0",
         "conf": "^13.0.1",
         "ink": "^5.2.1",
+        "ink-spinner": "^5.0.0",
         "ink-text-input": "^6.0.0",
         "react": "^18.3.1",
         "string-width": "^7.2.0",
@@ -5346,6 +5347,34 @@
         "react-devtools-core": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ink-spinner": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ink-spinner/-/ink-spinner-5.0.0.tgz",
+      "integrity": "sha512-EYEasbEjkqLGyPOUc8hBJZNuC5GvXGMLu0w5gdTNskPc7Izc5vO3tdQEYnzvshucyGCBXc86ig0ujXPMWaQCdA==",
+      "license": "MIT",
+      "dependencies": {
+        "cli-spinners": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "peerDependencies": {
+        "ink": ">=4.0.0",
+        "react": ">=18.0.0"
+      }
+    },
+    "node_modules/ink-spinner/node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ink-testing-library": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "commander": "^12.1.0",
     "conf": "^13.0.1",
     "ink": "^5.2.1",
+    "ink-spinner": "^5.0.0",
     "ink-text-input": "^6.0.0",
     "react": "^18.3.1",
     "string-width": "^7.2.0",

--- a/src/domains/ai_services/chat.ts
+++ b/src/domains/ai_services/chat.ts
@@ -1,23 +1,16 @@
 /**
  * GenAI Chat Command
  *
- * Interactive multi-turn conversation with the AI assistant
+ * Interactive multi-turn conversation with the AI assistant.
+ * This command returns a signal to enter chat mode, which is handled
+ * by the Ink-based ChatMode component in the REPL.
  */
 
-import * as readline from "node:readline";
 import type { CommandDefinition, DomainCommandResult } from "../registry.js";
 import { successResult, errorResult } from "../registry.js";
 import type { REPLSession } from "../../repl/session.js";
 import { getCommandSpec, formatSpec } from "../../output/index.js";
 import { parseDomainOutputFlags } from "../../output/domain-formatter.js";
-import { getGenAIClient } from "./client.js";
-import { renderResponse } from "./response-renderer.js";
-import {
-	updateLastQueryState,
-	clearLastQueryState,
-	getLastQueryState,
-} from "./query.js";
-import { FEEDBACK_TYPE_MAP } from "./types.js";
 
 /**
  * Parse chat args for namespace, spec flag, and output format
@@ -63,281 +56,11 @@ function parseChatArgs(
 }
 
 /**
- * Display chat help
- */
-function showChatHelp(): string[] {
-	return [
-		"",
-		"=== AI Chat Commands ===",
-		"",
-		"  /exit, /quit, /q    - Exit chat mode",
-		"  /help, /h           - Show this help",
-		"  /clear, /c          - Clear conversation context",
-		"  /feedback <type>    - Submit feedback for last response",
-		"                        Types: positive, negative",
-		"  1, 2, 3...          - Select a follow-up question by number",
-		"",
-		"Just type your question to query the AI assistant.",
-		"",
-	];
-}
-
-/**
- * Handle feedback submission within chat
- */
-async function handleFeedback(
-	input: string,
-	session: REPLSession,
-): Promise<string[]> {
-	const state = getLastQueryState();
-	if (!state.lastQueryId || !state.lastQuery) {
-		return ["No previous query to provide feedback for."];
-	}
-
-	const parts = input.split(/\s+/);
-	const feedbackType = parts[1]?.toLowerCase();
-
-	if (!feedbackType) {
-		return [
-			"Usage: /feedback <positive|negative>",
-			"  Optional: /feedback negative <type> [comment]",
-			"  Types: other, inaccurate, irrelevant, poor_format, slow",
-		];
-	}
-
-	const apiClient = session.getAPIClient();
-	if (!apiClient) {
-		return ["Not connected to API."];
-	}
-
-	try {
-		const client = getGenAIClient(apiClient);
-
-		if (feedbackType === "positive" || feedbackType === "+") {
-			await client.feedback({
-				query: state.lastQuery,
-				query_id: state.lastQueryId,
-				namespace: state.namespace,
-				positive_feedback: {},
-			});
-			return ["Positive feedback submitted. Thank you!"];
-		}
-
-		if (feedbackType === "negative" || feedbackType === "-") {
-			const negType = parts[2]?.toLowerCase();
-			const mappedType = negType ? FEEDBACK_TYPE_MAP[negType] : undefined;
-			const comment = parts.slice(3).join(" ") || undefined;
-
-			await client.feedback({
-				query: state.lastQuery,
-				query_id: state.lastQueryId,
-				namespace: state.namespace,
-				negative_feedback: {
-					remarks: mappedType ? [mappedType] : ["OTHER"],
-				},
-				comment,
-			});
-			return [
-				"Negative feedback submitted. Thank you for helping improve the AI.",
-			];
-		}
-
-		return [
-			`Unknown feedback type: ${feedbackType}`,
-			"Use 'positive' or 'negative'.",
-		];
-	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
-		return [`Feedback failed: ${message}`];
-	}
-}
-
-/**
- * Run interactive chat loop
- */
-async function runChatLoop(
-	session: REPLSession,
-	namespace: string,
-): Promise<string[]> {
-	const apiClient = session.getAPIClient();
-	if (!apiClient) {
-		return ["Not connected to API. Please configure connection first."];
-	}
-
-	if (!session.isTokenValidated()) {
-		return ["Not authenticated. Please check your API token."];
-	}
-
-	const client = getGenAIClient(apiClient);
-	const output: string[] = [];
-
-	output.push("");
-	output.push("=== F5 XC AI Assistant Chat ===");
-	output.push(`Namespace: ${namespace}`);
-	output.push("Type /help for commands, /exit to quit.");
-	output.push("");
-
-	// Create readline interface
-	const rl = readline.createInterface({
-		input: process.stdin,
-		output: process.stdout,
-		terminal: process.stdin.isTTY ?? false,
-	});
-
-	// Handle Ctrl+C
-	let interrupted = false;
-	rl.on("SIGINT", () => {
-		interrupted = true;
-		console.log("\n(Use /exit to leave chat mode)");
-		rl.prompt();
-	});
-
-	// Promise-based question helper
-	const askQuestion = (prompt: string): Promise<string> => {
-		return new Promise((resolve) => {
-			rl.question(prompt, (answer) => {
-				resolve(answer);
-			});
-		});
-	};
-
-	// Print initial output
-	for (const line of output) {
-		console.log(line);
-	}
-
-	// Main chat loop
-	let running = true;
-	while (running && !interrupted) {
-		const input = await askQuestion("ai> ");
-
-		if (interrupted) {
-			break;
-		}
-
-		const trimmed = input.trim();
-
-		// Empty input
-		if (!trimmed) {
-			continue;
-		}
-
-		// Exit commands
-		if (trimmed === "/exit" || trimmed === "/quit" || trimmed === "/q") {
-			console.log("Exiting chat mode.");
-			running = false;
-			break;
-		}
-
-		// Help command
-		if (trimmed === "/help" || trimmed === "/h") {
-			for (const line of showChatHelp()) {
-				console.log(line);
-			}
-			continue;
-		}
-
-		// Clear command
-		if (trimmed === "/clear" || trimmed === "/c") {
-			clearLastQueryState();
-			console.log("Conversation context cleared.");
-			continue;
-		}
-
-		// Feedback command
-		if (trimmed.startsWith("/feedback")) {
-			const feedbackLines = await handleFeedback(trimmed, session);
-			for (const line of feedbackLines) {
-				console.log(line);
-			}
-			continue;
-		}
-
-		// Follow-up selection by number
-		if (/^\d+$/.test(trimmed)) {
-			const num = parseInt(trimmed, 10);
-			const state = getLastQueryState();
-			if (
-				state.followUpQueries.length > 0 &&
-				num >= 1 &&
-				num <= state.followUpQueries.length
-			) {
-				const followUp = state.followUpQueries[num - 1];
-				if (followUp) {
-					console.log(`\nFollowing up: ${followUp}\n`);
-					try {
-						const response = await client.query(
-							namespace,
-							followUp,
-						);
-
-						updateLastQueryState({
-							namespace,
-							lastQueryId: response.query_id,
-							lastQuery: followUp,
-							followUpQueries: response.follow_up_queries ?? [],
-						});
-
-						const lines = renderResponse(response);
-						for (const line of lines) {
-							console.log(line);
-						}
-						console.log("");
-					} catch (error) {
-						const message =
-							error instanceof Error
-								? error.message
-								: String(error);
-						console.log(`Query failed: ${message}`);
-					}
-					continue;
-				}
-			}
-			console.log(
-				`Invalid selection. Choose 1-${state.followUpQueries.length} from suggested follow-ups.`,
-			);
-			continue;
-		}
-
-		// Unknown command
-		if (trimmed.startsWith("/")) {
-			console.log(
-				`Unknown command: ${trimmed}. Type /help for commands.`,
-			);
-			continue;
-		}
-
-		// Regular query
-		try {
-			const response = await client.query(namespace, trimmed);
-
-			updateLastQueryState({
-				namespace,
-				lastQueryId: response.query_id,
-				lastQuery: trimmed,
-				followUpQueries: response.follow_up_queries ?? [],
-			});
-
-			console.log("");
-			const lines = renderResponse(response);
-			for (const line of lines) {
-				console.log(line);
-			}
-			console.log("");
-		} catch (error) {
-			const message =
-				error instanceof Error ? error.message : String(error);
-			console.log(`Query failed: ${message}`);
-		}
-	}
-
-	rl.close();
-
-	return ["Chat session ended."];
-}
-
-/**
  * Chat command - Interactive conversation with AI assistant
+ *
+ * This command signals the REPL to enter chat mode by returning
+ * enterChatMode: true. The actual chat UI is handled by the
+ * Ink-based ChatMode component in App.tsx.
  */
 export const chatCommand: CommandDefinition = {
 	name: "chat",
@@ -347,7 +70,6 @@ export const chatCommand: CommandDefinition = {
 	descriptionMedium:
 		"Start an interactive multi-turn conversation with the AI assistant. Supports follow-up suggestions and in-chat commands.",
 	usage: "[--namespace <ns>]",
-	aliases: ["interactive", "i"],
 
 	async execute(args, session): Promise<DomainCommandResult> {
 		const { spec, namespace, suppressOutput } = parseChatArgs(
@@ -371,17 +93,34 @@ export const chatCommand: CommandDefinition = {
 		// Check if running in a TTY
 		if (!process.stdin.isTTY) {
 			return errorResult(
-				"Chat mode requires an interactive terminal. Use 'ai query' for non-interactive queries.",
+				"Chat mode requires an interactive terminal. Use 'ai_services query' for non-interactive queries.",
 			);
 		}
 
-		try {
-			const result = await runChatLoop(session, namespace);
-			return successResult(result);
-		} catch (error) {
-			const message =
-				error instanceof Error ? error.message : String(error);
-			return errorResult(`Chat session failed: ${message}`);
+		// Check API connection
+		const apiClient = session.getAPIClient();
+		if (!apiClient) {
+			return errorResult(
+				"Not connected to API. Please configure connection first.",
+			);
 		}
+
+		if (!session.isTokenValidated()) {
+			return errorResult(
+				"Not authenticated. Please check your API token.",
+			);
+		}
+
+		// Signal to enter chat mode - the REPL will switch to ChatMode component
+		return {
+			output: [],
+			shouldExit: false,
+			shouldClear: false,
+			contextChanged: false,
+			enterChatMode: true,
+			chatConfig: {
+				namespace,
+			},
+		};
 	},
 };

--- a/src/domains/registry.ts
+++ b/src/domains/registry.ts
@@ -6,6 +6,14 @@ import type { REPLSession } from "../repl/session.js";
 import { formatCustomDomainHelp, formatSubcommandHelp } from "../repl/help.js";
 
 /**
+ * Configuration for entering chat mode
+ */
+export interface ChatModeConfig {
+	/** Namespace for AI queries */
+	namespace: string;
+}
+
+/**
  * Result from domain command execution
  * Compatible with ExecutionResult from executor
  */
@@ -27,6 +35,15 @@ export interface DomainCommandResult {
 	 * like the image banner.
 	 */
 	rawStdout?: string;
+	/**
+	 * Signal to enter interactive chat mode.
+	 * When set, App.tsx will switch to ChatMode component.
+	 */
+	enterChatMode?: boolean;
+	/**
+	 * Configuration for chat mode (required when enterChatMode is true)
+	 */
+	chatConfig?: ChatModeConfig;
 }
 
 /**

--- a/src/repl/components/ChatMode.tsx
+++ b/src/repl/components/ChatMode.tsx
@@ -1,0 +1,458 @@
+/**
+ * ChatMode component - Interactive AI chat within the Ink REPL
+ * Replaces readline-based chat with Ink-native input handling
+ */
+
+import React, { useState, useCallback, useRef, useEffect } from "react";
+import { Box, Text, useInput } from "ink";
+import TextInput from "ink-text-input";
+import Spinner from "ink-spinner";
+
+import type { REPLSession } from "../session.js";
+import { getGenAIClient } from "../../domains/ai_services/client.js";
+import { renderResponse } from "../../domains/ai_services/response-renderer.js";
+import {
+	updateLastQueryState,
+	clearLastQueryState,
+	getLastQueryState,
+} from "../../domains/ai_services/query.js";
+import { FEEDBACK_TYPE_MAP } from "../../domains/ai_services/types.js";
+
+/**
+ * Props for ChatMode component
+ */
+export interface ChatModeProps {
+	/** REPL session for API access */
+	session: REPLSession;
+	/** Namespace for AI queries */
+	namespace: string;
+	/** Terminal width for layout */
+	width: number;
+	/** Callback when chat mode exits */
+	onExit: (messages: string[]) => void;
+}
+
+/**
+ * Chat message for display
+ */
+interface ChatMessage {
+	id: number;
+	role: "user" | "ai" | "system";
+	content: string;
+}
+
+/**
+ * Horizontal rule in F5 red
+ */
+function HorizontalRule({ width }: { width: number }): React.ReactElement {
+	const rule = "\u2500".repeat(Math.max(width, 1));
+	return <Text color="#CA260A">{rule}</Text>;
+}
+
+/**
+ * ChatMode - Interactive AI chat component
+ */
+export function ChatMode({
+	session,
+	namespace,
+	width,
+	onExit,
+}: ChatModeProps): React.ReactElement {
+	// Input state
+	const [input, setInput] = useState("");
+	const [inputKey, setInputKey] = useState(0);
+
+	// Chat state
+	const [messages, setMessages] = useState<ChatMessage[]>([]);
+	const messageIdRef = useRef(0);
+	const [isLoading, setIsLoading] = useState(false);
+	const [followUps, setFollowUps] = useState<string[]>([]);
+
+	// Add a message to chat history
+	const addMessage = useCallback(
+		(role: ChatMessage["role"], content: string) => {
+			const id = messageIdRef.current++;
+			setMessages((prev) => [...prev, { id, role, content }]);
+		},
+		[],
+	);
+
+	// Initialize with welcome message
+	useEffect(() => {
+		addMessage("system", "=== F5 XC AI Assistant Chat ===");
+		addMessage("system", `Namespace: ${namespace}`);
+		addMessage("system", "Type /help for commands, /exit to quit.");
+		addMessage("system", "");
+	}, [namespace, addMessage]);
+
+	// Show help
+	const showHelp = useCallback(() => {
+		addMessage("system", "");
+		addMessage("system", "=== AI Chat Commands ===");
+		addMessage("system", "");
+		addMessage("system", "  /exit, /quit, /q    - Exit chat mode");
+		addMessage("system", "  /help, /h           - Show this help");
+		addMessage(
+			"system",
+			"  /clear, /c          - Clear conversation context",
+		);
+		addMessage(
+			"system",
+			"  /feedback <type>    - Submit feedback (positive/negative)",
+		);
+		addMessage(
+			"system",
+			"  1, 2, 3...          - Select a follow-up question",
+		);
+		addMessage("system", "");
+		addMessage(
+			"system",
+			"Just type your question to query the AI assistant.",
+		);
+		addMessage("system", "");
+	}, [addMessage]);
+
+	// Handle feedback submission
+	const handleFeedback = useCallback(
+		async (feedbackInput: string) => {
+			const state = getLastQueryState();
+			if (!state.lastQueryId || !state.lastQuery) {
+				addMessage(
+					"system",
+					"No previous query to provide feedback for.",
+				);
+				return;
+			}
+
+			const parts = feedbackInput.split(/\s+/);
+			const feedbackType = parts[1]?.toLowerCase();
+
+			if (!feedbackType) {
+				addMessage("system", "Usage: /feedback <positive|negative>");
+				return;
+			}
+
+			const apiClient = session.getAPIClient();
+			if (!apiClient) {
+				addMessage("system", "Not connected to API.");
+				return;
+			}
+
+			try {
+				const client = getGenAIClient(apiClient);
+
+				if (feedbackType === "positive" || feedbackType === "+") {
+					await client.feedback({
+						query: state.lastQuery,
+						query_id: state.lastQueryId,
+						namespace: state.namespace,
+						positive_feedback: {},
+					});
+					addMessage(
+						"system",
+						"Positive feedback submitted. Thank you!",
+					);
+				} else if (
+					feedbackType === "negative" ||
+					feedbackType === "-"
+				) {
+					const negType = parts[2]?.toLowerCase();
+					const mappedType = negType
+						? FEEDBACK_TYPE_MAP[negType]
+						: undefined;
+					const comment = parts.slice(3).join(" ") || undefined;
+
+					await client.feedback({
+						query: state.lastQuery,
+						query_id: state.lastQueryId,
+						namespace: state.namespace,
+						negative_feedback: {
+							remarks: mappedType ? [mappedType] : ["OTHER"],
+						},
+						comment,
+					});
+					addMessage(
+						"system",
+						"Negative feedback submitted. Thank you for helping improve the AI.",
+					);
+				} else {
+					addMessage(
+						"system",
+						`Unknown feedback type: ${feedbackType}. Use 'positive' or 'negative'.`,
+					);
+				}
+			} catch (error) {
+				const message =
+					error instanceof Error ? error.message : String(error);
+				addMessage("system", `Feedback failed: ${message}`);
+			}
+		},
+		[session, addMessage],
+	);
+
+	// Handle follow-up selection
+	const handleFollowUp = useCallback(
+		async (num: number) => {
+			const state = getLastQueryState();
+			if (num < 1 || num > state.followUpQueries.length) {
+				addMessage(
+					"system",
+					`Invalid selection. Choose 1-${state.followUpQueries.length} from suggested follow-ups.`,
+				);
+				return;
+			}
+
+			const followUp = state.followUpQueries[num - 1];
+			if (!followUp) return;
+
+			addMessage("user", followUp);
+			setFollowUps([]);
+			setIsLoading(true);
+
+			const apiClient = session.getAPIClient();
+			if (!apiClient) {
+				addMessage("system", "Not connected to API.");
+				setIsLoading(false);
+				return;
+			}
+
+			try {
+				const client = getGenAIClient(apiClient);
+				const response = await client.query(namespace, followUp);
+
+				updateLastQueryState({
+					namespace,
+					lastQueryId: response.query_id,
+					lastQuery: followUp,
+					followUpQueries: response.follow_up_queries ?? [],
+				});
+
+				const lines = renderResponse(response);
+				for (const line of lines) {
+					addMessage("ai", line);
+				}
+
+				// Update follow-ups
+				setFollowUps(response.follow_up_queries ?? []);
+			} catch (error) {
+				const message =
+					error instanceof Error ? error.message : String(error);
+				addMessage("system", `Query failed: ${message}`);
+			} finally {
+				setIsLoading(false);
+			}
+		},
+		[session, namespace, addMessage],
+	);
+
+	// Send query to AI
+	const sendQuery = useCallback(
+		async (query: string) => {
+			addMessage("user", query);
+			setFollowUps([]);
+			setIsLoading(true);
+
+			const apiClient = session.getAPIClient();
+			if (!apiClient) {
+				addMessage("system", "Not connected to API.");
+				setIsLoading(false);
+				return;
+			}
+
+			try {
+				const client = getGenAIClient(apiClient);
+				const response = await client.query(namespace, query);
+
+				updateLastQueryState({
+					namespace,
+					lastQueryId: response.query_id,
+					lastQuery: query,
+					followUpQueries: response.follow_up_queries ?? [],
+				});
+
+				addMessage("ai", "");
+				const lines = renderResponse(response);
+				for (const line of lines) {
+					addMessage("ai", line);
+				}
+
+				// Update follow-ups
+				setFollowUps(response.follow_up_queries ?? []);
+			} catch (error) {
+				const message =
+					error instanceof Error ? error.message : String(error);
+				addMessage("system", `Query failed: ${message}`);
+			} finally {
+				setIsLoading(false);
+			}
+		},
+		[session, namespace, addMessage],
+	);
+
+	// Handle input submission
+	const handleSubmit = useCallback(
+		async (value: string) => {
+			const trimmed = value.trim();
+			if (!trimmed) return;
+
+			setInput("");
+			setInputKey((k) => k + 1);
+
+			// Exit commands
+			if (
+				trimmed === "/exit" ||
+				trimmed === "/quit" ||
+				trimmed === "/q"
+			) {
+				addMessage("system", "Exiting chat mode.");
+				// Collect all messages for scrollback
+				const allMessages = messages.map((m) => {
+					if (m.role === "user") return `You: ${m.content}`;
+					if (m.role === "ai") return `AI: ${m.content}`;
+					return m.content;
+				});
+				allMessages.push("Chat session ended.");
+				onExit(allMessages);
+				return;
+			}
+
+			// Help command
+			if (trimmed === "/help" || trimmed === "/h") {
+				showHelp();
+				return;
+			}
+
+			// Clear command
+			if (trimmed === "/clear" || trimmed === "/c") {
+				clearLastQueryState();
+				setFollowUps([]);
+				addMessage("system", "Conversation context cleared.");
+				return;
+			}
+
+			// Feedback command
+			if (trimmed.startsWith("/feedback")) {
+				await handleFeedback(trimmed);
+				return;
+			}
+
+			// Follow-up selection by number
+			if (/^\d+$/.test(trimmed)) {
+				const num = parseInt(trimmed, 10);
+				const state = getLastQueryState();
+				if (state.followUpQueries.length > 0) {
+					await handleFollowUp(num);
+					return;
+				}
+			}
+
+			// Unknown command
+			if (trimmed.startsWith("/")) {
+				addMessage(
+					"system",
+					`Unknown command: ${trimmed}. Type /help for commands.`,
+				);
+				return;
+			}
+
+			// Regular query
+			await sendQuery(trimmed);
+		},
+		[
+			messages,
+			onExit,
+			showHelp,
+			handleFeedback,
+			handleFollowUp,
+			sendQuery,
+			addMessage,
+		],
+	);
+
+	// Handle keyboard shortcuts
+	useInput((char, key) => {
+		// Ctrl+C - exit chat
+		if (key.ctrl && char === "c") {
+			addMessage("system", "Exiting chat mode.");
+			const allMessages = messages.map((m) => {
+				if (m.role === "user") return `You: ${m.content}`;
+				if (m.role === "ai") return `AI: ${m.content}`;
+				return m.content;
+			});
+			allMessages.push("Chat session ended.");
+			onExit(allMessages);
+			return;
+		}
+	});
+
+	return (
+		<Box flexDirection="column" width={width}>
+			{/* Chat messages */}
+			<Box flexDirection="column" marginBottom={1}>
+				{messages.map((msg) => (
+					<Text
+						key={msg.id}
+						color={
+							msg.role === "user"
+								? "#00BFFF"
+								: msg.role === "ai"
+									? "#FFFFFF"
+									: "#888888"
+						}
+					>
+						{msg.role === "user"
+							? `You: ${msg.content}`
+							: msg.content}
+					</Text>
+				))}
+			</Box>
+
+			{/* Follow-up suggestions */}
+			{followUps.length > 0 && (
+				<Box flexDirection="column" marginBottom={1}>
+					<Text color="#888888">Follow-up suggestions:</Text>
+					{followUps.map((fu, i) => (
+						<Text key={i} color="#AAAAAA">
+							{"  "}[{i + 1}] {fu}
+						</Text>
+					))}
+				</Box>
+			)}
+
+			{/* Loading indicator */}
+			{isLoading && (
+				<Box marginBottom={1}>
+					<Text color="#00BFFF">
+						<Spinner type="dots" /> Thinking...
+					</Text>
+				</Box>
+			)}
+
+			{/* Input area */}
+			<HorizontalRule width={width} />
+			<Box>
+				<Text bold color="#00BFFF">
+					ai{">"}{" "}
+				</Text>
+				<TextInput
+					key={inputKey}
+					value={input}
+					onChange={setInput}
+					onSubmit={handleSubmit}
+					focus={!isLoading}
+				/>
+			</Box>
+			<HorizontalRule width={width} />
+
+			{/* Status bar */}
+			<Box paddingX={1} justifyContent="space-between">
+				<Text color="#666666">
+					/exit: quit | /help: commands | /clear: clear chat
+				</Text>
+				<Text color="#666666">Ctrl+C to exit</Text>
+			</Box>
+		</Box>
+	);
+}
+
+export default ChatMode;

--- a/src/repl/components/index.ts
+++ b/src/repl/components/index.ts
@@ -5,3 +5,4 @@
 export { InputBox, useInputState } from "./InputBox.js";
 export { StatusBar, getGitInfo, type GitInfo } from "./StatusBar.js";
 export { Suggestions, useSuggestions, type Suggestion } from "./Suggestions.js";
+export { ChatMode, type ChatModeProps } from "./ChatMode.js";

--- a/src/repl/executor.ts
+++ b/src/repl/executor.ts
@@ -54,6 +54,14 @@ const WRITE_OPERATIONS = new Set([
 ]);
 
 /**
+ * Configuration for entering chat mode
+ */
+export interface ChatModeConfig {
+	/** Namespace for AI queries */
+	namespace: string;
+}
+
+/**
  * Command execution result
  */
 export interface ExecutionResult {
@@ -76,6 +84,15 @@ export interface ExecutionResult {
 	rawStdout?: string;
 	/** Whether to trigger git status refresh */
 	refreshGit?: boolean;
+	/**
+	 * Signal to enter interactive chat mode.
+	 * When set, App.tsx will switch to ChatMode component.
+	 */
+	enterChatMode?: boolean;
+	/**
+	 * Configuration for chat mode (required when enterChatMode is true)
+	 */
+	chatConfig?: ChatModeConfig;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fix chat command immediately exiting due to stdin conflict between React Ink's useInput hook and Node's readline.createInterface()
- Build chat as Ink-native component using TextInput instead of readline
- Add ChatMode.tsx component with full chat functionality (messages, follow-ups, commands)

## Problem
The `/ai_services chat` command was exiting immediately after displaying the chat header. This was caused by stdin competition between Ink's useInput hook (which consumes stdin for the REPL) and the chat command's readline.createInterface() trying to create a second stdin handler.

## Solution
Redesigned chat as an Ink-based React component that integrates with the existing REPL infrastructure:

1. Extended ExecutionResult interfaces with `enterChatMode` and `chatConfig` fields
2. Created ChatMode.tsx component using Ink's TextInput for input handling
3. Modified App.tsx to conditionally render ChatMode when activated
4. Simplified chat.ts to return mode trigger signal instead of running readline loop

## Features Preserved
- Multi-turn conversations with message history
- Follow-up suggestions (select by number 1, 2, 3...)
- Chat commands: `/exit`, `/help`, `/clear`, `/feedback`
- Loading spinner during API calls
- Proper error handling

## Test plan
- [ ] Run `npm run build` - verifies TypeScript compilation
- [ ] Run `xcsh` and execute `ai_services chat`
- [ ] Verify chat mode stays active and accepts input
- [ ] Test follow-up selection by entering numbers
- [ ] Test chat commands (/help, /clear, /exit)
- [ ] Verify /exit returns to xcsh prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)