### PR TITLE
docs: deploy documentation from gh-pages branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,12 +30,10 @@ on:
       - '.github/workflows/docs.yml'
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
-  group: "pages"
+  group: "docs-deployment"
   cancel-in-progress: true
 
 env:
@@ -922,29 +920,29 @@ jobs:
       - name: Copy install script to site
         run: cp install.sh site/install.sh
 
-      - name: Upload pages artifact
-        uses: actions/upload-pages-artifact@v4
-        with:
-          path: site/
+      - name: Deploy to gh-pages branch
+        if: |
+          (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+          github.event_name == 'release' ||
+          github.event_name == 'workflow_run' ||
+          github.event_name == 'workflow_dispatch'
+        run: |
+          cd site
 
-  deploy:
-    name: Deploy to GitHub Pages
-    runs-on: ubuntu-latest
-    needs: build
-    # Use always() to evaluate condition even when upstream jobs in chain were skipped
-    if: |
-      always() &&
-      needs.build.result == 'success' &&
-      (
-        (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-        github.event_name == 'release' ||
-        github.event_name == 'workflow_run' ||
-        github.event_name == 'workflow_dispatch'
-      )
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          # Configure git
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Initialize new git repo in site directory
+          git init
+          git add -A
+          git commit -m "Deploy documentation to gh-pages
+
+          Generated from commit: ${{ github.sha }}
+          Workflow run: ${{ github.run_id }}
+          Event: ${{ github.event_name }}"
+
+          # Force push to gh-pages branch
+          git push -f https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git HEAD:gh-pages
+
+          echo "✅ Documentation deployed to gh-pages branch"


### PR DESCRIPTION
## Summary
Change the documentation workflow to deploy from a `gh-pages` branch instead of using GitHub Actions deployment artifacts. This enables the "Deploy from a branch" configuration in GitHub Pages settings.

## Changes
- ✅ Created `gh-pages` branch with placeholder index.html
- ✅ Updated `.github/workflows/docs.yml`:
  - Changed permissions from `pages: write` / `id-token: write` to `contents: write`
  - Removed `actions/upload-pages-artifact` and `actions/deploy-pages` steps
  - Added deployment step that commits and force-pushes to `gh-pages` branch
  - Updated concurrency group from `pages` to `docs-deployment`

## How it works
1. Workflow builds the MkDocs site in the `site/` directory
2. Initializes a new git repo in `site/` and commits all files
3. Force pushes to `gh-pages` branch
4. GitHub Pages serves the site from the `gh-pages` branch

## Benefits
- **Transparency**: Documentation source is visible in the `gh-pages` branch
- **Flexibility**: Can manually update or rollback documentation if needed
- **Standard approach**: Uses the traditional GitHub Pages deployment method
- **Cleaner history**: Each deployment is a single commit with metadata

## GitHub Pages Settings Update Required

After merging this PR, you must update the GitHub Pages settings:

1. Go to **Settings** > **Pages**
2. Under **Build and deployment**:
   - Set **Source** to "Deploy from a branch"
   - Select **Branch**: `gh-pages`
   - Select **Folder**: `/ (root)`
3. Click **Save**

The next documentation workflow run will deploy to the `gh-pages` branch and GitHub Pages will automatically serve it.

## Test plan
- [x] Create `gh-pages` branch with placeholder
- [ ] Merge PR and configure GitHub Pages settings
- [ ] Trigger documentation workflow (push to main or create release)
- [ ] Verify documentation site updates at https://robinmordasiewicz.github.io/f5xc-xcsh/

🤖 Generated with [Claude Code](https://claude.com/claude-code)