### PR TITLE
fix(chat): increase GenAI query timeout from 15s to 60s

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -255,7 +255,8 @@ export class APIClient {
 		body: string | null,
 	): Promise<APIResponse<T>> {
 		const controller = new AbortController();
-		const timeoutId = setTimeout(() => controller.abort(), this.timeout);
+		const requestTimeout = options.timeout ?? this.timeout;
+		const timeoutId = setTimeout(() => controller.abort(), requestTimeout);
 
 		try {
 			const response = await fetch(url, {
@@ -319,7 +320,7 @@ export class APIClient {
 			// Handle abort/timeout
 			if (error instanceof Error && error.name === "AbortError") {
 				throw new APIError(
-					`Request timed out after ${this.timeout}ms`,
+					`Request timed out after ${requestTimeout}ms`,
 					408,
 					undefined,
 					`${options.method} ${options.path}`,
@@ -448,6 +449,7 @@ export class APIClient {
 	async post<T = unknown>(
 		path: string,
 		body?: Record<string, unknown>,
+		timeout?: number,
 	): Promise<APIResponse<T>> {
 		const options: APIRequestOptions = {
 			method: "POST",
@@ -455,6 +457,9 @@ export class APIClient {
 		};
 		if (body) {
 			options.body = body;
+		}
+		if (timeout !== undefined) {
+			options.timeout = timeout;
 		}
 		return this.request<T>(options);
 	}

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -54,6 +54,8 @@ export interface APIRequestOptions {
 	headers?: Record<string, string>;
 	/** Query parameters */
 	query?: Record<string, string>;
+	/** Request timeout in milliseconds (overrides client default) */
+	timeout?: number;
 }
 
 /**

--- a/src/domains/ai_services/client.ts
+++ b/src/domains/ai_services/client.ts
@@ -12,6 +12,12 @@ import type {
 } from "./types.js";
 
 /**
+ * GenAI query timeout (60 seconds)
+ * AI queries can take longer to process than typical API calls
+ */
+const GENAI_QUERY_TIMEOUT = 60000;
+
+/**
  * GenAI API Client
  *
  * Provides methods for querying the AI assistant and submitting feedback
@@ -35,6 +41,7 @@ export class GenAIClient {
 		const response = await this.apiClient.post<GenAIQueryResponse>(
 			`/api/gen-ai/namespaces/${namespace}/query`,
 			request,
+			GENAI_QUERY_TIMEOUT,
 		);
 
 		if (!response.ok) {
@@ -83,6 +90,7 @@ export class GenAIClient {
 		const response = await this.apiClient.post<GenAIQueryResponse>(
 			`/api/gen-ai/namespaces/${namespace}/eval_query`,
 			request,
+			GENAI_QUERY_TIMEOUT,
 		);
 
 		if (!response.ok) {


### PR DESCRIPTION
## Summary

Fixes the chat mode timeout issue where GenAI queries were failing with "Request timed out after 15000ms" error.

## Problem

The interactive chat mode was timing out after 15 seconds when making GenAI queries. AI queries often take longer to process than typical API calls because they need to:
- Process and understand the natural language query
- Search through namespace data
- Generate a comprehensive response

## Solution

Added support for per-request timeout overrides and increased the timeout for GenAI queries to 60 seconds.

## Changes

### API Client Infrastructure
- Added `timeout?: number` parameter to `APIRequestOptions` interface
- Updated `APIClient.executeRequest()` to use request-specific timeout if provided
- Updated `APIClient.post()` to accept optional timeout parameter
- Updated error message to show the actual timeout that was used

### GenAI Client
- Added `GENAI_QUERY_TIMEOUT` constant set to 60000ms (60 seconds)
- Updated `query()` method to pass the extended timeout
- Updated `evalQuery()` method to pass the extended timeout

## Benefits

- GenAI queries now have sufficient time to process and respond
- Other API operations maintain the default 15-second timeout
- Architecture is flexible for future timeout customization needs
- No breaking changes to existing code

## Testing

Build and type checks pass. Ready for manual testing in chat mode.

🤖 Generated with Claude Code