### PR TITLE
fix: add GITHUB_TOKEN to release workflow npm publish build step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -424,6 +424,7 @@ jobs:
       - name: Build
         run: npm run build
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCSH_VERSION: ${{ needs.create-release.outputs.version }}
 
       - name: Set package version


### PR DESCRIPTION
## Summary

The `Publish to npm` job in the release workflow was failing because the Build step was missing `GITHUB_TOKEN`. This caused `download-specs.sh` (called by prebuild) to hit GitHub API rate limits.

### Root Cause
- The npm publish job's Build step only had `XCSH_VERSION` env var
- The build jobs (Linux, macOS, Windows) all correctly had `GITHUB_TOKEN` in their Build TypeScript steps
- The same fix was applied to ci.yml in PR #584

### Fix
Added `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to the Build step's env in publish-npm job.

## Test plan
- [ ] Verify CI passes
- [ ] Merge and verify next release workflow succeeds

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)