### PR TITLE
fix: update install script to use --version flag

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1172,7 +1172,7 @@ On Alpine:        apk add curl"
 
   # Check for existing installation in target directory
   if [ -f "${INSTALL_DIR}/${BINARY_NAME}" ]; then
-    EXISTING_VERSION=$("${INSTALL_DIR}/${BINARY_NAME}" version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "unknown")
+    EXISTING_VERSION=$("${INSTALL_DIR}/${BINARY_NAME}" --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "unknown")
     if [ "$EXISTING_VERSION" = "$VERSION" ]; then
       success "xcsh v${VERSION} is already installed"
       printf "\n"
@@ -1185,7 +1185,7 @@ On Alpine:        apk add curl"
   download_and_install "$VERSION" "$OS" "$ARCH" "$INSTALL_DIR" "$SUDO_CMD"
 
   # Verify installation
-  if ! "${INSTALL_DIR}/${BINARY_NAME}" version >/dev/null 2>&1; then
+  if ! "${INSTALL_DIR}/${BINARY_NAME}" --version >/dev/null 2>&1; then
     error "Installation verification failed. Please check the binary at ${INSTALL_DIR}/${BINARY_NAME}"
   fi
 


### PR DESCRIPTION
## Summary

Fixes #593

Updates install.sh to use the correct  flag instead of the old  subcommand.

The TypeScript/Commander.js version of xcsh uses standard CLI conventions ( flag) instead of the Go version's  subcommand. This was causing installation verification to fail.

## Changes

- **Line 1175**: Changed existing version check from xcsh version v2.0.21-2601122136 to v2.0.21-2601122136
- **Line 1188**: Changed installation verification from xcsh version v2.0.21-2601122136 to v2.0.21-2601122136

## Testing

✅ Build successful
✅ v2.0.21-2601131427-BETA returns version correctly
✅ Pre-commit hooks pass

## Impact

Fixes failed Documentation workflow that tests the install script:
https://github.com/robinmordasiewicz/f5xc-xcsh/actions/runs/20946695104/job/60191041439

## Checklist

- [x] Code follows project style guidelines
- [x] Pre-commit hooks pass
- [x] Changes are minimal and focused
- [x] Commit message follows conventional commits format

---

🤖 Generated with Claude Code