### PR TITLE
fix: enhance Homebrew conflict detection error handling for CI

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -117,11 +117,13 @@ find_existing_installations() {
 check_homebrew_installation() {
   # Check for Homebrew cask installation
   if command_exists brew; then
-    if brew list --cask xcsh >/dev/null 2>&1; then
+    # Check cask installation - suppress all errors
+    if (brew list --cask xcsh 2>&1 | grep -q "xcsh") 2>/dev/null; then
       echo "homebrew-cask"
       return 0
     fi
-    if brew list xcsh >/dev/null 2>&1; then
+    # Check formula installation - suppress all errors
+    if (brew list xcsh 2>&1 | grep -q "xcsh") 2>/dev/null; then
       echo "homebrew-formula"
       return 0
     fi


### PR DESCRIPTION
## Summary

Fixes #595 - Documentation workflow failures caused by Homebrew conflict detection errors in CI environments.

## Changes

Modified `check_homebrew_installation()` in install.sh to use more robust error suppression:

**Before:**
```bash
if brew list --cask xcsh >/dev/null 2>&1; then
```

**After:**
```bash
if (brew list --cask xcsh 2>&1 | grep -q "xcsh") 2>/dev/null; then
```

## Why This Fix Works

1. **Dual-level suppression**: Errors from both `brew` and `grep` commands are suppressed
2. **Positive matching**: grep looks for "xcsh" in output rather than relying on brew exit codes
3. **Subshell isolation**: Parentheses create subshell that prevents error propagation
4. **CI-safe**: Works reliably when Homebrew xcsh is uninstalled or brew commands error

## Testing

- ✅ Local testing confirms install script works
- ⏳ CI testing needed - Documentation workflow should now pass

## Related

- Follows up on PR #594 which fixed version flag syntax
- Addresses persistent failures since commit b4f2d06 added conflict detection
- Failed workflow: https://github.com/robinmordasiewicz/f5xc-xcsh/actions/runs/20960794203