### PR TITLE
fix(ci): correct environment variable prefix to F5XC_API_TOKEN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
       - name: Check if F5 XC credentials are available
         id: check
         run: |
-          if [ -n "${{ secrets.F5_XC_API_TOKEN }}" ]; then
+          if [ -n "${{ secrets.F5XC_API_TOKEN }}" ]; then
             echo "has-credentials=true" >> $GITHUB_OUTPUT
             echo "✅ F5 XC credentials available - E2E tests will run"
           else
@@ -170,7 +170,7 @@ jobs:
       - name: Configure F5 XC credentials
         run: |
           mkdir -p ~/.xcsh
-          echo "${{ secrets.F5_XC_API_TOKEN }}" > ~/.xcsh/token
+          echo "${{ secrets.F5XC_API_TOKEN }}" > ~/.xcsh/token
 
       - name: Run E2E tests
         run: npm test -- tests/e2e/ --run


### PR DESCRIPTION
## Summary

Corrects the secret reference from `F5_XC_API_TOKEN` to `F5XC_API_TOKEN` to match the project naming convention where all environment variables use the `F5XC_` prefix.

## Changes

- `secrets.F5_XC_API_TOKEN` → `secrets.F5XC_API_TOKEN` (2 occurrences)

## Test Plan

- [x] CI workflow YAML validates successfully
- [ ] E2E tests run when `F5XC_API_TOKEN` secret is configured

🤖 Generated with [Claude Code](https://claude.ai/code)