### PR TITLE
fix(ci): exclude E2E tests from release and sync-specs workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,9 +45,9 @@ jobs:
         if: steps.changes.outputs.code == 'true'
         run: npm ci
 
-      - name: Run tests
+      - name: Run tests (excluding E2E)
         if: steps.changes.outputs.code == 'true'
-        run: npm test
+        run: npm test -- --exclude='**/e2e/**'
 
       - name: Run type check
         if: steps.changes.outputs.code == 'true'

--- a/.github/workflows/sync-upstream-specs.yml
+++ b/.github/workflows/sync-upstream-specs.yml
@@ -112,8 +112,8 @@ jobs:
       - name: Validate generated code
         run: npm run build
 
-      - name: Run tests
-        run: npm test
+      - name: Run tests (excluding E2E)
+        run: npm test -- --exclude='**/e2e/**'
 
       - name: Create Pull Request
         id: create-pr


### PR DESCRIPTION
## Summary

Excludes E2E tests from workflows that don't have access to the `F5XC_API_TOKEN` secret.

## Problem

The Release and Sync Upstream Specs workflows were running all tests including E2E tests, which require authentication to the F5 XC API. Without the token, these tests fail.

## Solution

Added `--exclude='**/e2e/**'` to npm test commands in:
- `release.yml` - Test job
- `sync-upstream-specs.yml` - Test step

E2E tests will only run in the dedicated `e2e-tests` job in `ci.yml` when `F5XC_API_TOKEN` is configured.

## Test Plan

- [x] Workflow YAML validates successfully
- [ ] Release workflow passes without E2E tests
- [ ] Sync specs workflow passes without E2E tests

🤖 Generated with [Claude Code](https://claude.ai/code)