### PR TITLE
chore: regenerate completion files to fix CI

### DIFF
--- a/completions/_xcsh
+++ b/completions/_xcsh
@@ -67,7 +67,7 @@ _xcsh() {
             'users:Account tokens, labels, and cloud-init config.'
             'virtual:HTTP, TCP, UDP load balancing with origin pools.'
             'vpm_and_node_management:Node lifecycle, fleet grouping, and orchestration.'
-
+            
             )
             builtins=(
                 'help:Show help information'


### PR DESCRIPTION
## Summary

Fix CI failure in "Verify Generated Code" job.

## Root Cause

After PR #666 merged (removing test-regression.yml), the completion files became out of sync with the current specs. The verify-generated check correctly detected this drift and failed.

## Fix

Regenerated completions:
```bash
npx tsx scripts/generate-completions.ts
```

## Changes

- completions/_xcsh: 1 insertion, 1 deletion