### PR TITLE
perf: cache TypeScript build in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,11 +130,25 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/download-specs.sh
 
+      - name: Restore TypeScript build cache
+        id: cache-typescript
+        uses: actions/cache@v4
+        with:
+          path: dist/
+          key: xcsh-dist-${{ runner.os }}-${{ hashFiles('package-lock.json', 'src/**/*.ts') }}
+          restore-keys: |
+            xcsh-dist-${{ runner.os }}-
+
       - name: Build TypeScript
+        if: steps.cache-typescript.outputs.cache-hit != 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCSH_VERSION: ${{ needs.version.outputs.version }}
         run: npm run build
+
+      - name: Restore dist from cache
+        if: steps.cache-typescript.outputs.cache-hit == 'true'
+        run: echo "Using cached TypeScript build"
 
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
@@ -175,11 +189,25 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/download-specs.sh
 
+      - name: Restore TypeScript build cache
+        id: cache-typescript
+        uses: actions/cache@v4
+        with:
+          path: dist/
+          key: xcsh-dist-${{ runner.os }}-${{ hashFiles('package-lock.json', 'src/**/*.ts') }}
+          restore-keys: |
+            xcsh-dist-${{ runner.os }}-
+
       - name: Build TypeScript
+        if: steps.cache-typescript.outputs.cache-hit != 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCSH_VERSION: ${{ needs.version.outputs.version }}
         run: npm run build
+
+      - name: Restore dist from cache
+        if: steps.cache-typescript.outputs.cache-hit == 'true'
+        run: echo "Using cached TypeScript build"
 
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
@@ -221,12 +249,27 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/download-specs.sh
 
+      - name: Restore TypeScript build cache
+        id: cache-typescript
+        uses: actions/cache@v4
+        with:
+          path: dist/
+          key: xcsh-dist-\${{ runner.os }}-\${{ hashFiles('package-lock.json', 'src/**/*.ts') }}
+          restore-keys: |
+            xcsh-dist-\${{ runner.os }}-
+
       - name: Build TypeScript
         shell: bash
+        if: steps.cache-typescript.outputs.cache-hit != 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          XCSH_VERSION: ${{ needs.version.outputs.version }}
+          GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
+          XCSH_VERSION: \${{ needs.version.outputs.version }}
         run: npm run build
+
+      - name: Restore dist from cache
+        shell: bash
+        if: steps.cache-typescript.outputs.cache-hit == 'true'
+        run: echo "Using cached TypeScript build"
 
       - name: Install Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Summary

Add caching for TypeScript compilation output (`dist/`) across all platform builds (Linux, macOS, Windows). If source files haven't changed, skip the expensive TypeScript build step and use cached output instead.

## Problem

Each platform build in `release.yml` runs identical TypeScript compilation:
1. Install dependencies
2. Download specs
3. Build TypeScript (30-60 seconds)
4. Install Bun
5. Build platform-specific binaries

The TypeScript build is the same across all platforms but runs 3 times.

## Solution

Add GitHub Actions cache for `dist/` directory:
- Key: `xcsh-dist-{os}-{hash(package-lock.json, src/**/*.ts)}`
- If cache hits, skip TypeScript build
- Falls back to previous cache if exact match not found

## Expected Time Savings

- Cache hit: ~30-60 seconds per platform (3 platforms = 1.5-3 minutes saved)
- Cache miss: Same as before (no penalty)

## Changes

- `.github/workflows/release.yml`: Added cache restore/skip logic to build-linux, build-macos, build-windows jobs