### PR TITLE
fix: resolve flaky test timeout in session.test.ts

### DIFF
--- a/tests/unit/session.test.ts
+++ b/tests/unit/session.test.ts
@@ -8,14 +8,17 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { REPLSession } from "../../src/repl/session.js";
 
+// Create a singleton mock profile manager to avoid timing issues
+const mockProfileManager = {
+	getActive: vi.fn().mockResolvedValue(null),
+	list: vi.fn().mockResolvedValue([]),
+	get: vi.fn().mockResolvedValue(null),
+	setActive: vi.fn().mockResolvedValue({ success: true }),
+};
+
 // Mock the profile manager to avoid file system operations
 vi.mock("../../src/profile/index.js", () => ({
-	getProfileManager: () => ({
-		getActive: vi.fn().mockResolvedValue(null),
-		list: vi.fn().mockResolvedValue([]),
-		get: vi.fn().mockResolvedValue(null),
-		setActive: vi.fn().mockResolvedValue({ success: true }),
-	}),
+	getProfileManager: () => mockProfileManager,
 }));
 
 // Mock the history manager to avoid file system operations
@@ -32,6 +35,12 @@ vi.mock("../../src/repl/history.js", () => ({
 
 describe("REPLSession Token Validation", () => {
 	beforeEach(() => {
+		// Reset mock calls
+		mockProfileManager.getActive.mockClear();
+		mockProfileManager.list.mockClear();
+		mockProfileManager.get.mockClear();
+		mockProfileManager.setActive.mockClear();
+
 		// Set up environment variables for testing
 		vi.stubEnv("F5XC_API_URL", "https://test.volterra.io");
 		vi.stubEnv("F5XC_API_TOKEN", "valid-test-token");
@@ -212,7 +221,9 @@ describe("REPLSession Token Validation", () => {
 	});
 
 	describe("Session State After Initialization", () => {
-		it("should have consistent state after valid token initialization", async () => {
+		it(
+			"should have consistent state after valid token initialization",
+			async () => {
 			const session = new REPLSession();
 
 			const apiClient = session.getAPIClient();
@@ -235,9 +246,13 @@ describe("REPLSession Token Validation", () => {
 			expect(session.isTokenValidated()).toBe(true);
 			expect(session.getValidationError()).toBeNull();
 			expect(session.getServerUrl()).toBe("https://test.volterra.io");
-		});
+		},
+			{ timeout: 10000 },
+		);
 
-		it("should have consistent state after invalid token initialization", async () => {
+		it(
+			"should have consistent state after invalid token initialization",
+			async () => {
 			const session = new REPLSession();
 
 			const apiClient = session.getAPIClient();
@@ -259,7 +274,9 @@ describe("REPLSession Token Validation", () => {
 			expect(session.isAuthenticated()).toBe(true); // Has token, just invalid
 			expect(session.isTokenValidated()).toBe(false);
 			expect(session.getValidationError()).toBe("Token expired");
-		});
+		},
+			{ timeout: 10000 },
+		);
 	});
 
 	describe("HTTP Status Code Handling", () => {


### PR DESCRIPTION
Fixes #678

## Problem
The test "should have consistent state after valid token initialization" in `tests/unit/session.test.ts` was intermittently timing out after 5 seconds in CI environments, causing post-merge workflow failures.

## Root Cause Analysis
1. **Insufficient Timeout**: Default 5-second test timeout was too short for slower CI environments
2. **Mock Inconsistency**: Profile manager mock created new object on each `getProfileManager()` call, causing potential timing issues
3. **State Pollution**: Mock state wasn't being properly reset between tests

## Solution Implemented

### 1. Singleton Mock Profile Manager
```typescript
const mockProfileManager = {
	getActive: vi.fn().mockResolvedValue(null),
	list: vi.fn().mockResolvedValue([]),
	get: vi.fn().mockResolvedValue(null),
	setActive: vi.fn().mockResolvedValue({ success: true }),
};
```
This ensures a consistent instance is returned every time `getProfileManager()` is called.

### 2. Mock State Reset
```typescript
beforeEach(() => {
	mockProfileManager.getActive.mockClear();
	mockProfileManager.list.mockClear();
	mockProfileManager.get.mockClear();
	mockProfileManager.setActive.mockClear();
	// ... rest of setup
});
```
Ensures clean state between test runs.

### 3. Extended Timeout
```typescript
it("should have consistent state after valid token initialization", async () => {
	// ... test body
}, { timeout: 10000 });
```
Increased timeout from 5s (default) to 10s for initialization tests.

## Changes
- Created singleton `mockProfileManager` instance
- Added `mockClear()` calls in `beforeEach` for all mock methods
- Added `{ timeout: 10000 }` to both "Session State After Initialization" tests

## Verification
- ✅ All 14 tests in session.test.ts pass consistently (~77ms execution time)
- ✅ Tests complete well under the new 10-second timeout
- ✅ Pre-commit hooks pass (no lint/type errors)

## Testing
Run locally:
```bash
npm test tests/unit/session.test.ts
```

Expected: All 14 tests pass in ~30-80ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)