### PR TITLE
fix: add --tag latest to npm publish for prerelease versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -640,7 +640,7 @@ jobs:
           npm version "$NPM_VERSION" --no-git-tag-version
 
       - name: Publish to npm
-        run: npm publish --access public
+        run: npm publish --access public --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Summary

Fixes the Release workflow npm publish failure.

## Problem

The version format `v{upstream}-{timestamp}` (e.g., `v2.0.46-2601250430`) contains a hyphen which npm interprets as a prerelease identifier. npm requires `--tag` flag when publishing prerelease versions.

## Solution

Add `--tag latest` to the npm publish command to explicitly set the distribution tag.

## Test plan

- [x] Local validation of workflow syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)