### PR TITLE
fix: output --spec JSON to stdout instead of stderr

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -107,8 +107,10 @@ program
 
 			// Handle root-level spec (xcsh --spec with no domain)
 			// Outputs full CLI specification for documentation generation
+			// NOTE: Must use console.log (stdout) not console.warn (stderr)
+			// because documentation generators capture stdout for JSON parsing
 			if (options.spec && commandArgs.length === 0) {
-				console.warn(formatFullCLISpec());
+				console.log(formatFullCLISpec());
 				process.exit(0);
 			}
 


### PR DESCRIPTION
## Summary
- Fixed `--spec` flag to output JSON to stdout instead of stderr
- This fixes the documentation workflow which captures stdout for JSON parsing

## Problem
The documentation workflow was failing with:
```
Error parsing spec JSON: Expecting value: line 1 column 1 (char 0)
```

This occurred because `console.warn()` writes to stderr, but `scripts/generate-docs.py` captures stdout via `subprocess.run(..., stdout=tmp)`.

## Solution
Changed `console.warn(formatFullCLISpec())` to `console.log(formatFullCLISpec())` so the JSON spec is written to stdout where it can be properly captured.

## Test plan
- [x] Build passes
- [x] `node dist/index.js --spec 2>/dev/null | head` outputs JSON to stdout
- [ ] Documentation workflow should succeed after this fix is released

🤖 Generated with [Claude Code](https://claude.com/claude-code)