### PR TITLE
fix: add workflow_run and workflow_dispatch triggers to docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,6 +12,15 @@ on:
       - "scripts/templates/**"
       - ".github/workflows/docs.yml"
 
+  # Trigger after Release workflow completes to regenerate command docs
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+    branches: [main]
+
+  # Allow manual trigger
+  workflow_dispatch:
+
 permissions:
   contents: write
 


### PR DESCRIPTION
## Summary
- Added `workflow_run` trigger to run Documentation workflow after Release completes
- Added `workflow_dispatch` trigger to allow manual runs from Actions tab

## Problem
The Documentation workflow was failing because it used an old xcsh binary that didn't write `--spec` output to stdout. Even after fixing the spec output issue (PR #684), the Documentation workflow wouldn't automatically run because it only triggers on push events to docs-related files.

## Solution
Added automatic trigger when Release workflow completes on main branch, so command documentation is regenerated with each new release. Also added manual trigger capability for ad-hoc runs.

## Test plan
- [x] Workflow file validates (pre-commit hook passed)
- [ ] CI passes
- [ ] Merging this PR triggers Documentation workflow (since docs.yml is modified)
- [ ] Documentation workflow succeeds with the spec fix from PR #684

🤖 Generated with [Claude Code](https://claude.com/claude-code)