### PR TITLE
fix: prioritize script-installed xcsh for documentation generation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -759,27 +759,25 @@ jobs:
       - name: Generate command documentation
         id: generate-command-docs
         run: |
-          # Find xcsh binary (check multiple locations)
+          # Find xcsh binary - prioritize script-installed version (guaranteed latest from release)
           XCSH_PATH=""
 
-          # 1. Try Homebrew Caskroom (ARM Mac)
-          if [ -z "$XCSH_PATH" ]; then
+          # 1. Try script install location FIRST (guaranteed latest from release)
+          if [ -x "$HOME/.local/bin/xcsh" ]; then
+            XCSH_PATH="$HOME/.local/bin/xcsh"
+          fi
+
+          # 2. Try Homebrew Caskroom (ARM Mac)
+          if [ -z "$XCSH_PATH" ] || [ ! -x "$XCSH_PATH" ]; then
             XCSH_PATH=$(find /opt/homebrew/Caskroom/xcsh -name xcsh -type f 2>/dev/null | head -1 || true)
           fi
 
-          # 2. Try Homebrew Caskroom (Intel Mac)
+          # 3. Try Homebrew Caskroom (Intel Mac)
           if [ -z "$XCSH_PATH" ] || [ ! -x "$XCSH_PATH" ]; then
             XCSH_PATH=$(find /usr/local/Caskroom/xcsh -name xcsh -type f 2>/dev/null | head -1 || true)
           fi
 
-          # 3. Try script install location
-          if [ -z "$XCSH_PATH" ] || [ ! -x "$XCSH_PATH" ]; then
-            if [ -x "$HOME/.local/bin/xcsh" ]; then
-              XCSH_PATH="$HOME/.local/bin/xcsh"
-            fi
-          fi
-
-          # 4. Try Homebrew bin symlinks
+          # 4. Try Homebrew bin symlinks (last resort)
           if [ -z "$XCSH_PATH" ] || [ ! -x "$XCSH_PATH" ]; then
             for path in /opt/homebrew/bin/xcsh /usr/local/bin/xcsh; do
               if [ -x "$path" ]; then
@@ -812,24 +810,22 @@ jobs:
       - name: Generate subscription documentation
         id: generate-subscription-docs
         run: |
-          # Find xcsh binary (same search order as generate-command-docs)
+          # Find xcsh binary - prioritize script-installed version (guaranteed latest from release)
           XCSH_PATH=""
 
-          # 1. Try Homebrew Caskroom (ARM Mac) - primary location
-          if [ -z "$XCSH_PATH" ]; then
+          # 1. Try script install location FIRST (guaranteed latest from release)
+          if [ -x "$HOME/.local/bin/xcsh" ]; then
+            XCSH_PATH="$HOME/.local/bin/xcsh"
+          fi
+
+          # 2. Try Homebrew Caskroom (ARM Mac)
+          if [ -z "$XCSH_PATH" ] || [ ! -x "$XCSH_PATH" ]; then
             XCSH_PATH=$(find /opt/homebrew/Caskroom/xcsh -name xcsh -type f 2>/dev/null | head -1 || true)
           fi
 
-          # 2. Try Homebrew Caskroom (Intel Mac)
+          # 3. Try Homebrew Caskroom (Intel Mac)
           if [ -z "$XCSH_PATH" ] || [ ! -x "$XCSH_PATH" ]; then
             XCSH_PATH=$(find /usr/local/Caskroom/xcsh -name xcsh -type f 2>/dev/null | head -1 || true)
-          fi
-
-          # 3. Try script install location
-          if [ -z "$XCSH_PATH" ] || [ ! -x "$XCSH_PATH" ]; then
-            if [ -x "$HOME/.local/bin/xcsh" ]; then
-              XCSH_PATH="$HOME/.local/bin/xcsh"
-            fi
           fi
 
           # 4. Try Homebrew bin symlinks (last resort)


### PR DESCRIPTION
## Summary
- Reordered xcsh binary search to prioritize script-installed version

## Problem
The Documentation workflow was finding an old xcsh binary at `/usr/local/bin/xcsh` instead of the freshly installed one from the latest release. This caused the spec JSON parsing to fail because the old binary writes `--spec` output to stderr instead of stdout.

## Solution
Changed the search order to check `$HOME/.local/bin/xcsh` first, since this is the location used by the install script which downloads directly from GitHub releases and is guaranteed to be the latest version.

### Previous order:
1. Homebrew Caskroom (ARM Mac)
2. Homebrew Caskroom (Intel Mac)  
3. Script install location
4. Homebrew bin symlinks

### New order:
1. Script install location (guaranteed latest)
2. Homebrew Caskroom (ARM Mac)
3. Homebrew Caskroom (Intel Mac)
4. Homebrew bin symlinks (last resort)

## Test plan
- [x] Workflow file validates (pre-commit hook passed)
- [ ] CI passes
- [ ] Documentation workflow succeeds with correct xcsh binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)