### PR TITLE
fix: force install script to use ~/.local/bin to avoid Homebrew conflict

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -574,8 +574,9 @@ jobs:
             rm -rf $HOME/.local/bin/xcsh 2>/dev/null || true
             rm -f install-output.txt 2>/dev/null || true
 
-            # Run the install script and capture output (defaults to ~/.local/bin without sudo)
-            GITHUB_TOKEN=${{ github.token }} sh /tmp/install.sh > install-output.txt 2>&1
+            # Run the install script and capture output
+            # Force install to ~/.local/bin to avoid conflict with Homebrew version at /usr/local/bin
+            GITHUB_TOKEN=${{ github.token }} F5XC_INSTALL_DIR=$HOME/.local/bin sh /tmp/install.sh > install-output.txt 2>&1
             INSTALL_EXIT_CODE=$?
 
             echo "Install output:"
@@ -759,6 +760,14 @@ jobs:
       - name: Generate command documentation
         id: generate-command-docs
         run: |
+          # Debug: Show available xcsh binaries
+          echo "=== Debug: Available xcsh binaries ==="
+          echo "Script install location ($HOME/.local/bin/xcsh):"
+          ls -la "$HOME/.local/bin/xcsh" 2>/dev/null || echo "  Not found"
+          echo "Homebrew bin locations:"
+          ls -la /opt/homebrew/bin/xcsh /usr/local/bin/xcsh 2>/dev/null || echo "  Not found"
+          echo "========================================"
+
           # Find xcsh binary - prioritize script-installed version (guaranteed latest from release)
           XCSH_PATH=""
 
@@ -810,6 +819,12 @@ jobs:
       - name: Generate subscription documentation
         id: generate-subscription-docs
         run: |
+          # Debug: Show available xcsh binaries (same as command docs step)
+          echo "=== Debug: Available xcsh binaries ==="
+          echo "Script install location ($HOME/.local/bin/xcsh):"
+          ls -la "$HOME/.local/bin/xcsh" 2>/dev/null || echo "  Not found"
+          echo "========================================"
+
           # Find xcsh binary - prioritize script-installed version (guaranteed latest from release)
           XCSH_PATH=""
 


### PR DESCRIPTION
## Summary

- Force install script to install to `~/.local/bin` by setting `F5XC_INSTALL_DIR`
- Add debug output showing available xcsh binaries during documentation generation

## Problem

The Documentation workflow was failing with:
```
Error parsing spec JSON: Expecting value: line 1 column 1 (char 0)
```

Root cause analysis:
1. The `install.sh` script defaults to `/usr/local/bin` when that directory is writable
2. On GitHub Actions macOS runners, `/usr/local/bin` IS writable
3. So the script-installed xcsh goes to `/usr/local/bin/xcsh`, overwriting/conflicting with the Homebrew-installed version
4. The "search order fix" in PR #686 looked for `~/.local/bin/xcsh` first, but that file never existed
5. It fell back to `/usr/local/bin/xcsh` which was the OLD Homebrew version without the `--spec` stdout fix

## Solution

Explicitly set `F5XC_INSTALL_DIR=$HOME/.local/bin` when running the install script, ensuring:
1. Script-installed xcsh goes to `~/.local/bin/xcsh`
2. The search logic finds it at the prioritized location
3. The latest release binary (with PR #684's `--spec` stdout fix) is used

## Test plan

- [ ] Documentation workflow runs successfully
- [ ] Debug output shows `~/.local/bin/xcsh` exists
- [ ] `--spec` JSON parsing succeeds
- [ ] Command documentation is generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)