### PR TITLE
chore: simplify documentation homepage

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,34 +1,8 @@
 ---
 title: xcsh
 description: Command-line interface for managing F5 Distributed Cloud
-template: splash
+template: doc
 hero:
-  title: xcsh Documentation
+  title: F5 Distributed Cloud Shell - xcsh
   tagline: Command-line interface for managing F5 Distributed Cloud
-  actions:
-    - text: Install
-      link: install/
-      icon: right-arrow
-    - text: Commands
-      link: commands/
-      icon: right-arrow
-      variant: minimal
-    - text: Guides
-      link: guides/
-      icon: right-arrow
-      variant: minimal
 ---
-
-import { Card, CardGrid } from '@astrojs/starlight/components';
-
-<CardGrid>
-  <Card title="Install" icon="rocket">
-    Install xcsh and configure authentication
-  </Card>
-  <Card title="Commands" icon="open-book">
-    CLI documentation on arguments, global flags, environment variables, and supported resource types.
-  </Card>
-  <Card title="Guides" icon="document">
-    HTTP load balancers, cloud sites, and common deployment patterns.
-  </Card>
-</CardGrid>


### PR DESCRIPTION
## Summary

Simplifies the documentation homepage template from splash layout to doc layout for cleaner integration with the documentation structure.

## Changes

- Change homepage template from splash to doc layout
- Update hero section title to 'F5 Distributed Cloud Shell - xcsh'
- Remove action buttons (Install, Commands, Guides)
- Remove redundant Card Grid component

This improves the documentation landing page by reducing cognitive load while keeping all content accessible through the main documentation navigation.

Closes #709