### PR TITLE
docs: update documentation titles to remove F5 branding

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,8 +1,8 @@
 ---
 title: xcsh
-description: Command-line interface for managing F5 Distributed Cloud
+description: Command-line interface for managing Cloud
 template: doc
 hero:
-  title: F5 Distributed Cloud Shell - xcsh
-  tagline: Command-line interface for managing F5 Distributed Cloud
+  title: Cloud Shell - xcsh
+  tagline: Command-line interface for managing Cloud
 ---


### PR DESCRIPTION
Closes #715