### PR TITLE
fix: use REPO_ADMIN_TOKEN in sync-upstream-specs workflow

### DIFF
--- a/.github/workflows/sync-upstream-specs.yml
+++ b/.github/workflows/sync-upstream-specs.yml
@@ -84,7 +84,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.REPO_ADMIN_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -97,7 +97,7 @@ jobs:
 
       - name: Download latest specs
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}
         run: ./scripts/download-specs.sh
 
       - name: Generate domains
@@ -119,7 +119,7 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.REPO_ADMIN_TOKEN }}
           commit-message: |
             chore: sync upstream specs ${{ needs.check-upstream.outputs.new_version }}
 
@@ -199,7 +199,7 @@ jobs:
             fi
           done
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}
 
   # Step 4: Report if no updates
   no-updates:


### PR DESCRIPTION
## Summary

The `sync-upstream-specs.yml` workflow creates PRs using `GITHUB_TOKEN` via `peter-evans/create-pull-request`, which does not trigger other workflows due to GitHub's anti-recursion policy. This means the "Check linked issues" required status check never starts, and the auto-created PRs can never be merged.

**Fix**: Use `REPO_ADMIN_TOKEN` (a PAT) instead of `GITHUB_TOKEN` for:
- Repository checkout (so commits are attributed to a real user)
- Spec downloads (`download-specs.sh`)
- PR creation via `peter-evans/create-pull-request`
- Branch cleanup in the `cleanup-old-branches` job

This ensures that PRs created by the sync workflow trigger all required CI checks and can be merged normally.

Closes #721

## Test plan
- [ ] Manually trigger the `sync-upstream-specs` workflow via `workflow_dispatch`
- [ ] Verify the created PR triggers the "Check linked issues" workflow
- [ ] Verify the PR can be merged once CI passes

---
Generated with [Claude Code](https://claude.com/claude-code)