### PR TITLE
fix: add required YAML frontmatter to generated guide files

### DIFF
--- a/docs/guides/generated/admin_console_and_ui.md
+++ b/docs/guides/generated/admin_console_and_ui.md
@@ -1,3 +1,7 @@
+---
+title: "Admin Console And Ui"
+---
+
 # 🖥️ Admin Console And Ui
 
 Namespace-scoped visual elements with versioning. Custom widget deployment and catalog management for portal surfaces.

--- a/docs/guides/generated/ai_services.md
+++ b/docs/guides/generated/ai_services.md
@@ -1,3 +1,7 @@
+---
+title: "Ai Services"
+---
+
 # 🤖 Ai Services
 
 Natural language processing with quality signals and anomaly monitoring. Token authentication for data stream subscriptions.

--- a/docs/guides/generated/api.md
+++ b/docs/guides/generated/api.md
@@ -1,3 +1,7 @@
+---
+title: "Api"
+---
+
 # 🔐 Api
 
 Resource cataloging with automatic classification and security profiling. Organizational hierarchies segment access by function or protection policy.

--- a/docs/guides/generated/authentication.md
+++ b/docs/guides/generated/authentication.md
@@ -1,3 +1,7 @@
+---
+title: "Authentication"
+---
+
 # 🔑 Authentication
 
 Identity management with provider integration, access policies, and credential lifecycle control.

--- a/docs/guides/generated/bigip.md
+++ b/docs/guides/generated/bigip.md
@@ -1,3 +1,7 @@
+---
+title: "Bigip"
+---
+
 # 🏢 Bigip
 
 Legacy device orchestration with iRule scripts and data group synchronization. Virtual server bindings and metrics collection.

--- a/docs/guides/generated/billing_and_usage.md
+++ b/docs/guides/generated/billing_and_usage.md
@@ -1,3 +1,7 @@
+---
+title: "Billing And Usage"
+---
+
 # 💳 Billing And Usage
 
 Plan transitions, invoicing, and resource consumption. Namespace-level quota limits and usage tracking.

--- a/docs/guides/generated/blindfold.md
+++ b/docs/guides/generated/blindfold.md
@@ -1,3 +1,7 @@
+---
+title: "Blindfold"
+---
+
 # 🔏 Blindfold
 
 Encryption key management with policy-based access controls. Audit logging and secure data protection.

--- a/docs/guides/generated/bot_and_threat_defense.md
+++ b/docs/guides/generated/bot_and_threat_defense.md
@@ -1,3 +1,7 @@
+---
+title: "Bot And Threat Defense"
+---
+
 # 🦠 Bot And Threat Defense
 
 Threat classification with behavioral analysis and signature matching. Automated blocking for malicious traffic patterns.

--- a/docs/guides/generated/cdn.md
+++ b/docs/guides/generated/cdn.md
@@ -1,3 +1,7 @@
+---
+title: "Cdn"
+---
+
 # 🚀 Cdn
 
 Global distribution with cache rules and purge operations. Performance monitoring and analytics.

--- a/docs/guides/generated/ce_management.md
+++ b/docs/guides/generated/ce_management.md
@@ -1,3 +1,7 @@
+---
+title: "Ce Management"
+---
+
 # 🔧 Ce Management
 
 Token-based provisioning with image downloads and pre-upgrade validation. Fleet grouping enables bulk operations across distributed locations.

--- a/docs/guides/generated/certificates.md
+++ b/docs/guides/generated/certificates.md
@@ -1,3 +1,7 @@
+---
+title: "Certificates"
+---
+
 # 📜 Certificates
 
 Certificate chains and trusted CA bundles. Revocation list management and manifest configuration for PKI operations.

--- a/docs/guides/generated/cloud_infrastructure.md
+++ b/docs/guides/generated/cloud_infrastructure.md
@@ -1,3 +1,7 @@
+---
+title: "Cloud Infrastructure"
+---
+
 # ☁️ Cloud Infrastructure
 
 Multi-cloud provider connections with gateway peering and network path configuration. Credential vault integration and subnet enumeration.

--- a/docs/guides/generated/container_services.md
+++ b/docs/guides/generated/container_services.md
@@ -1,3 +1,7 @@
+---
+title: "Container Services"
+---
+
 # 📦 Container Services
 
 Pod orchestration without full cluster complexity. Edge site execution, quota enforcement, and standardized compute profiles for distributed apps.

--- a/docs/guides/generated/data_and_privacy_security.md
+++ b/docs/guides/generated/data_and_privacy_security.md
@@ -1,3 +1,7 @@
+---
+title: "Data And Privacy Security"
+---
+
 # 🔐 Data And Privacy Security
 
 Sensitive data policies with custom classification rules. LMA region configuration and geo-based compliance controls.

--- a/docs/guides/generated/data_intelligence.md
+++ b/docs/guides/generated/data_intelligence.md
@@ -1,3 +1,7 @@
+---
+title: "Data Intelligence"
+---
+
 # 🧠 Data Intelligence
 
 Classification rules, resource policies, and insight generation for data analysis workflows.

--- a/docs/guides/generated/ddos.md
+++ b/docs/guides/generated/ddos.md
@@ -1,3 +1,7 @@
+---
+title: "Ddos"
+---
+
 # 🛑 Ddos
 
 Deny lists, firewall rule groups, and tunnel-based safeguards. Rate limiting and pattern analysis for network perimeter security.

--- a/docs/guides/generated/dns.md
+++ b/docs/guides/generated/dns.md
@@ -1,3 +1,7 @@
+---
+title: "Dns"
+---
+
 # 🌐 Dns
 
 Name resolution with zone transfers and health checks. Record types and delegation support.

--- a/docs/guides/generated/index.md
+++ b/docs/guides/generated/index.md
@@ -1,3 +1,7 @@
+---
+title: "Domain Reference"
+---
+
 # Domain Reference
 
 Generated from enriched API specifications v2.1.13.

--- a/docs/guides/generated/managed_kubernetes.md
+++ b/docs/guides/generated/managed_kubernetes.md
@@ -1,3 +1,7 @@
+---
+title: "Managed Kubernetes"
+---
+
 # ⚙️ Managed Kubernetes
 
 Kubernetes role bindings and admission policies. Registry integration for EKS, AKS, and GKE workloads.

--- a/docs/guides/generated/marketplace.md
+++ b/docs/guides/generated/marketplace.md
@@ -1,3 +1,7 @@
+---
+title: "Marketplace"
+---
+
 # 🏪 Marketplace
 
 Third-party GRE and IPSec tunnel provisioning with DPD timers. Shared resource allocation across namespaces with tile placement controls.

--- a/docs/guides/generated/network.md
+++ b/docs/guides/generated/network.md
@@ -1,3 +1,7 @@
+---
+title: "Network"
+---
+
 # 🔌 Network
 
 Border gateway protocol with ASN management and autonomous system relationships. Site-to-site VPN linking datacenters through encrypted channels.

--- a/docs/guides/generated/network_security.md
+++ b/docs/guides/generated/network_security.md
@@ -1,3 +1,7 @@
+---
+title: "Network Security"
+---
+
 # 🔒 Network Security
 
 Firewall rules with routing decisions based on source, destination, or protocol. Segmentation isolates workloads while outbound proxies govern access.

--- a/docs/guides/generated/nginx_one.md
+++ b/docs/guides/generated/nginx_one.md
@@ -1,3 +1,7 @@
+---
+title: "Nginx One"
+---
+
 # 🟢 Nginx One
 
 Instance discovery, WAF integration, and service mesh connectivity. Subscription lifecycle and configuration synchronization.

--- a/docs/guides/generated/object_storage.md
+++ b/docs/guides/generated/object_storage.md
@@ -1,3 +1,7 @@
+---
+title: "Object Storage"
+---
+
 # 🗄️ Object Storage
 
 Versioned library distribution for mobile app integrators. Presigned URLs enable secure downloads with OS-specific builds for iOS and Android.

--- a/docs/guides/generated/observability.md
+++ b/docs/guides/generated/observability.md
@@ -1,3 +1,7 @@
+---
+title: "Observability"
+---
+
 # 📊 Observability
 
 HTTP availability probes with latency measurement. Certificate expiration alerts and global status dashboards for infrastructure health.

--- a/docs/guides/generated/rate_limiting.md
+++ b/docs/guides/generated/rate_limiting.md
@@ -1,3 +1,7 @@
+---
+title: "Rate Limiting"
+---
+
 # ⏱️ Rate Limiting
 
 Time-based quota enforcement with configurable windows in hours, minutes, or seconds. Protocol-specific controls for traffic shaping.

--- a/docs/guides/generated/secops_and_incident_response.md
+++ b/docs/guides/generated/secops_and_incident_response.md
@@ -1,3 +1,7 @@
+---
+title: "Secops And Incident Response"
+---
+
 # 🚨 Secops And Incident Response
 
 Malicious user mitigation with threat level classification. Automated response actions for suspicious behavior patterns.

--- a/docs/guides/generated/service_mesh.md
+++ b/docs/guides/generated/service_mesh.md
@@ -1,3 +1,7 @@
+---
+title: "Service Mesh"
+---
+
 # 🕸️ Service Mesh
 
 Application type definitions with discovery and learned schema analysis. Traffic pattern inference for intelligent request handling.

--- a/docs/guides/generated/shape.md
+++ b/docs/guides/generated/shape.md
@@ -1,3 +1,7 @@
+---
+title: "Shape"
+---
+
 # 🎭 Shape
 
 Threat recognition with behavioral analysis and device fingerprinting. Mobile SDK integration for application shielding.

--- a/docs/guides/generated/sites.md
+++ b/docs/guides/generated/sites.md
@@ -1,3 +1,7 @@
+---
+title: "Sites"
+---
+
 # 🌍 Sites
 
 AWS, Azure, GCP VPC integration with transit gateways. Label-based selection for policy application across regions.

--- a/docs/guides/generated/statistics.md
+++ b/docs/guides/generated/statistics.md
@@ -1,3 +1,7 @@
+---
+title: "Statistics"
+---
+
 # 📈 Statistics
 
 Alerting policies with receiver integrations. Log aggregation, topology views, and site health tracking.

--- a/docs/guides/generated/support.md
+++ b/docs/guides/generated/support.md
@@ -1,3 +1,7 @@
+---
+title: "Support"
+---
+
 # 🎫 Support
 
 Issue lifecycle with comments, severity changes, and resolution tracking. Packet capture for connection analysis.

--- a/docs/guides/generated/telemetry_and_insights.md
+++ b/docs/guides/generated/telemetry_and_insights.md
@@ -1,3 +1,7 @@
+---
+title: "Telemetry And Insights"
+---
+
 # 📉 Telemetry And Insights
 
 Collection endpoints, metrics storage, and insight generation for observability workflows.

--- a/docs/guides/generated/tenant_and_identity.md
+++ b/docs/guides/generated/tenant_and_identity.md
@@ -1,3 +1,7 @@
+---
+title: "Tenant And Identity"
+---
+
 # 🪪 Tenant And Identity
 
 Account view configurations and admin alert channels. One-time password resets, provisioning flows, and active connection monitoring.

--- a/docs/guides/generated/threat_campaign.md
+++ b/docs/guides/generated/threat_campaign.md
@@ -1,3 +1,7 @@
+---
+title: "Threat Campaign"
+---
+
 # ⚠️ Threat Campaign
 
 Detection policies, attack tracking, and automated mitigation rule generation for security operations.

--- a/docs/guides/generated/users.md
+++ b/docs/guides/generated/users.md
@@ -1,3 +1,7 @@
+---
+title: "Users"
+---
+
 # 👥 Users
 
 Site enrollment credentials with automatic expiration. Taxonomy keys define allowed categorization while auto-derived tags apply dynamically.

--- a/docs/guides/generated/virtual.md
+++ b/docs/guides/generated/virtual.md
@@ -1,3 +1,7 @@
+---
+title: "Virtual"
+---
+
 # ⚖️ Virtual
 
 Traffic distribution across regions with routing rules. Health checks and failover policies.

--- a/docs/guides/generated/vpm_and_node_management.md
+++ b/docs/guides/generated/vpm_and_node_management.md
@@ -1,3 +1,7 @@
+---
+title: "Vpm And Node Management"
+---
+
 # 🖥️ Vpm And Node Management
 
 Lifecycle control, fleet configuration, and deployment policies for distributed node management.

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -394,7 +394,8 @@ function generateCliWorkflowsSection(xcshDomain: XcshDomainConfig): string {
  * Generate quick reference guide from LOCAL xcsh config
  */
 function generateQuickReferenceDoc(xcshConfig: XcshExamplesConfig): string {
-  let content = "# Quick Reference\n\n";
+  let content = `---\ntitle: "Quick Reference"\n---\n\n`;
+  content += "# Quick Reference\n\n";
   content += "Common xcsh CLI commands and patterns.\n\n";
 
   for (const category of xcshConfig.quick_reference) {
@@ -437,9 +438,11 @@ function generateDomainDoc(
   xcshConfig?: XcshExamplesConfig,
 ): string {
   const icon = spec["x-f5xc-icon"] || "";
-  const title = `${icon} ${titleCase(spec.domain)}`.trim();
+  const displayTitle = `${icon} ${titleCase(spec.domain)}`.trim();
+  // Frontmatter title without emoji for Astro/Starlight compatibility
+  const frontmatterTitle = titleCase(spec.domain);
 
-  let content = `# ${title}\n\n`;
+  let content = `---\ntitle: "${frontmatterTitle}"\n---\n\n# ${displayTitle}\n\n`;
 
   // Description (from UPSTREAM)
   const description = spec["x-f5xc-description-medium"] || spec.description;
@@ -509,7 +512,8 @@ function generateDomainDoc(
  * Generate index page for all domains
  */
 function generateIndexDoc(specs: SpecIndexEntry[], version: string): string {
-  let content = "# Domain Reference\n\n";
+  let content = `---\ntitle: "Domain Reference"\n---\n\n`;
+  content += "# Domain Reference\n\n";
   content += `Generated from enriched API specifications v${version}.\n\n`;
 
   // Group by category


### PR DESCRIPTION
## Summary

- Fixed `scripts/generate-docs.ts` to emit YAML frontmatter with a `title` field on all generated markdown files in `docs/guides/generated/`
- Astro/Starlight requires frontmatter with at least a `title` field; all 38 generated files were missing it, causing build failures
- The frontmatter title uses a clean version (no emoji) while the markdown heading retains the emoji icon

## Changes

- **`scripts/generate-docs.ts`**: Updated `generateDomainDoc()`, `generateIndexDoc()`, and `generateQuickReferenceDoc()` to prepend YAML frontmatter
- **`docs/guides/generated/*.md`**: Regenerated all 38 files with proper frontmatter

## Test plan

- [ ] Verify Astro/Starlight build passes without content collection errors
- [ ] Confirm all 38 generated guide files render correctly with titles
- [ ] Re-run `npm run generate:docs` and verify output matches committed files

Closes #735

Generated with [Claude Code](https://claude.com/claude-code)