### PR TITLE
chore: add one-time secrets migration workflow

### DIFF
--- a/.github/workflows/migrate-secrets.yml
+++ b/.github/workflows/migrate-secrets.yml
@@ -1,0 +1,38 @@
+name: Migrate Apple Secrets
+
+on:
+  workflow_dispatch:
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Migrate APPLE_CERTIFICATE_BASE64
+        env:
+          GH_TOKEN: ${{ secrets.MIGRATE_TOKEN }}
+          SECRET_VALUE: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
+        run: gh secret set APPLE_CERTIFICATE_BASE64 --repo f5xc-salesdemos/xcsh --body "$SECRET_VALUE"
+
+      - name: Migrate APPLE_CERTIFICATE_PASSWORD
+        env:
+          GH_TOKEN: ${{ secrets.MIGRATE_TOKEN }}
+          SECRET_VALUE: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: gh secret set APPLE_CERTIFICATE_PASSWORD --repo f5xc-salesdemos/xcsh --body "$SECRET_VALUE"
+
+      - name: Migrate APPLE_ID
+        env:
+          GH_TOKEN: ${{ secrets.MIGRATE_TOKEN }}
+          SECRET_VALUE: ${{ secrets.APPLE_ID }}
+        run: gh secret set APPLE_ID --repo f5xc-salesdemos/xcsh --body "$SECRET_VALUE"
+
+      - name: Migrate APPLE_PASSWORD
+        env:
+          GH_TOKEN: ${{ secrets.MIGRATE_TOKEN }}
+          SECRET_VALUE: ${{ secrets.APPLE_PASSWORD }}
+        run: gh secret set APPLE_PASSWORD --repo f5xc-salesdemos/xcsh --body "$SECRET_VALUE"
+
+      - name: Migrate APPLE_TEAM_ID
+        env:
+          GH_TOKEN: ${{ secrets.MIGRATE_TOKEN }}
+          SECRET_VALUE: ${{ secrets.APPLE_TEAM_ID }}
+        run: gh secret set APPLE_TEAM_ID --repo f5xc-salesdemos/xcsh --body "$SECRET_VALUE"


### PR DESCRIPTION
## Summary

- Adds a `workflow_dispatch` workflow that copies Apple code signing secrets from this repo to `f5xc-salesdemos/xcsh`
- Uses `MIGRATE_TOKEN` secret (already set) to authenticate with the target repo
- One-time operation — can be deleted after the secrets are migrated

## Secrets migrated

- `APPLE_CERTIFICATE_BASE64`
- `APPLE_CERTIFICATE_PASSWORD`
- `APPLE_ID`
- `APPLE_PASSWORD`
- `APPLE_TEAM_ID`

## After merge

Trigger via: Actions → Migrate Apple Secrets → Run workflow